### PR TITLE
Minor Rust tweaks

### DIFF
--- a/src/bundler/run.rs
+++ b/src/bundler/run.rs
@@ -1,6 +1,7 @@
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 
+#[derive(Debug)]
 pub struct Args {
     pub port: u16,
     pub host: String,
@@ -10,6 +11,6 @@ pub async fn run(
     _args: Args,
     _shutdown_rx: broadcast::Receiver<()>,
     _shutdown_scope: mpsc::Sender<()>,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<()> {
     Ok(())
 }

--- a/src/op_pool/run.rs
+++ b/src/op_pool/run.rs
@@ -15,7 +15,7 @@ pub async fn run(
     args: Args,
     mut shutdown_rx: broadcast::Receiver<()>,
     _shutdown_scope: mpsc::Sender<()>,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<()> {
     let addr = format!("{}:{}", args.host, args.port).parse()?;
     let op_pool_server = OpPoolServer::new(OpPoolImpl);
     let reflection_service = tonic_reflection::server::Builder::configure()

--- a/src/rpc/run.rs
+++ b/src/rpc/run.rs
@@ -10,6 +10,6 @@ pub async fn run(
     _args: Args,
     _shutdown_rx: broadcast::Receiver<()>,
     _shutdown_scope: mpsc::Sender<()>,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<()> {
     Ok(())
 }


### PR DESCRIPTION
Small changes that IMO are idiomatic:

* Avoids `clone` on `String`s when converting args, and uses the `From` trait.
* Uses `anyhow::Result<T>` instead of `Result<T, anyhow::Error>`.