### PR TITLE
feat(op_pool): simple mempool implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-util",
+ "parking_lot 0.12.1",
  "prost",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tracing-appender = "0.2.2"
 metrics = "0.20.1"
 metrics-exporter-prometheus = "0.11.0"
 metrics-util = "0.14.0"
+parking_lot = "0.12.1"
 
 [build-dependencies]
 ethers = "1.0.2"

--- a/proto/op_pool.proto
+++ b/proto/op_pool.proto
@@ -37,7 +37,9 @@ message AddOpRequest {
   UserOperation op = 1;
   bytes entry_point = 2;
 }
-message AddOpResponse {}
+message AddOpResponse {
+  bytes hash = 1;
+}
 
 message GetOpsRequest {
   uint64 max_ops = 1;

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -17,7 +17,7 @@ impl UserOperation {
     ///
     /// The hash is used to uniquely identify a user operation in the entry point
     /// it does not include the signature field.
-    pub fn op_hash(&self, entry_point: &Address, chain_id: &U256) -> H256 {
+    pub fn op_hash(&self, entry_point: Address, chain_id: U256) -> H256 {
         keccak256(
             [
                 keccak256(self.pack()).to_vec(),
@@ -103,7 +103,7 @@ mod tests {
             .parse()
             .unwrap();
         let chain_id: U256 = 1337.into();
-        let hash = operation.op_hash(&entry_point, &chain_id);
+        let hash = operation.op_hash(entry_point, chain_id);
         assert_eq!(
             hash,
             "0x184db936a8bddc422ee3dd1545d41758f20dab071c44668d1b3379ea61c4da92"
@@ -163,7 +163,7 @@ mod tests {
             .parse()
             .unwrap();
         let chain_id: U256 = 1337.into();
-        let hash = operation.op_hash(&entry_point, &chain_id);
+        let hash = operation.op_hash(entry_point, chain_id);
         assert_eq!(
             hash,
             "0xf1f17c5eb34cf7f0584569a9d9831f17af470f8942a6ccdbca9b1597bef2e370"

--- a/src/op_pool/mempool/mod.rs
+++ b/src/op_pool/mempool/mod.rs
@@ -1,0 +1,65 @@
+mod pool;
+pub mod uo_pool;
+
+use ethers::types::{Address, H256};
+use std::sync::Arc;
+
+use crate::common::types::UserOperation;
+
+/// In-memory operation pool
+pub trait Mempool {
+    /// Returns the entry point address this pool targets.
+    fn entry_point(&self) -> Address;
+
+    /// Event listener for when a new block is mined.
+    ///
+    /// Pool is updated according to the new blocks events.
+    /// User operations that were included in the block are removed.
+    fn on_new_block(&self, event: OnNewBlockEvent);
+
+    /// Adds a validated user operation to the pool.
+    ///
+    /// Adds a user operation to the pool that was submitted via a local
+    /// RPC call and was validated before submission.
+    fn add_operation(
+        &self,
+        origin: OperationOrigin,
+        operation: UserOperation,
+    ) -> anyhow::Result<H256>;
+
+    /// Adds multiple validated user operations to the pool.
+    ///
+    /// Adds multiple user operations to the pool that were discovered
+    /// via the P2P gossip protocol.
+    fn add_operations(
+        &self,
+        origin: OperationOrigin,
+        operations: impl IntoIterator<Item = UserOperation>,
+    ) -> Vec<anyhow::Result<H256>>;
+
+    /// Returns the best operations from the pool.
+    ///
+    /// Returns the best operations from the pool based on their gas bids up to
+    /// the specified maximum number of operations.
+    fn best_operations(&self, max: usize) -> Vec<Arc<UserOperation>>;
+
+    /// Clears the mempool
+    fn clear(&self);
+}
+
+/// Event when a new block is mined.
+#[derive(Debug)]
+pub struct OnNewBlockEvent {
+    /// List of operations that were included in the block by their hashes.
+    pub mined_operations: Vec<H256>,
+}
+
+/// Origin of an operation.
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)] // TODO(danc): remove once implemented
+pub enum OperationOrigin {
+    /// The operation was submitted via a local RPC call.
+    Local,
+    /// The operation was discovered via the P2P gossip protocol.
+    External,
+}

--- a/src/op_pool/mempool/pool.rs
+++ b/src/op_pool/mempool/pool.rs
@@ -1,0 +1,298 @@
+use crate::common::types::{UserOperation, UserOperationId};
+use ethers::{
+    abi::Address,
+    types::{H256, U256},
+};
+use std::{
+    cmp::Ordering,
+    collections::{hash_map::Entry, BTreeSet, HashMap, HashSet},
+    ops::Deref,
+    sync::Arc,
+};
+
+const MAX_MEMPOOL_USEROPS_PER_SENDER: usize = 1;
+
+/// Pool of user operations
+#[derive(Debug)]
+pub struct PoolInner {
+    // Address of the entry point this pool targets
+    entry_point: Address,
+    // Chain ID this pool targets
+    chain_id: U256,
+    // Operations by hash
+    by_hash: HashMap<H256, PoolOperation>,
+    // Operations by operation ID
+    by_id: HashMap<UserOperationId, PoolOperation>,
+    // Best operations, sorted by gas price
+    best: BTreeSet<PoolOperation>,
+    // Count of operations by sender
+    count_by_sender: HashMap<Address, usize>,
+    // Submission ID counter
+    submission_id: u64,
+}
+
+impl PoolInner {
+    pub fn new(entry_point: Address, chain_id: U256) -> Self {
+        Self {
+            by_hash: HashMap::new(),
+            by_id: HashMap::new(),
+            best: BTreeSet::new(),
+            count_by_sender: HashMap::new(),
+            entry_point,
+            chain_id,
+            submission_id: 0,
+        }
+    }
+
+    pub fn add_operation(&mut self, operation: UserOperation) -> anyhow::Result<H256> {
+        // Check for replacement by ID
+        if let Some(old_op) = self.by_id.get(&operation.id()) {
+            // replace only if higher gas
+            if old_op.max_priority_fee_per_gas <= operation.max_priority_fee_per_gas
+                && old_op.max_fee_per_gas <= operation.max_fee_per_gas
+            {
+                self.best.remove(old_op);
+                self.by_hash
+                    .remove(&old_op.op_hash(self.entry_point, self.chain_id));
+            } else {
+                anyhow::bail!("Operation with higher gas already in mempool");
+            }
+        }
+
+        // Check sender count and reject if too many, else increment
+        let sender_count = self.count_by_sender.entry(operation.sender).or_insert(0);
+        if *sender_count >= MAX_MEMPOOL_USEROPS_PER_SENDER {
+            anyhow::bail!(
+                "Sender already has {MAX_MEMPOOL_USEROPS_PER_SENDER} operations in mempool, cannot add more"
+            );
+        }
+        *sender_count += 1;
+
+        let pool_op = PoolOperation {
+            op: Arc::new(operation),
+            submission_id: self.next_submission_id(),
+        };
+        let hash = pool_op.op_hash(self.entry_point, self.chain_id);
+        self.by_hash.insert(hash, pool_op.clone());
+        self.by_id.insert(pool_op.id(), pool_op.clone());
+        self.best.insert(pool_op);
+
+        Ok(hash)
+    }
+
+    pub fn add_operations(
+        &mut self,
+        operations: impl IntoIterator<Item = UserOperation>,
+    ) -> Vec<anyhow::Result<H256>> {
+        operations
+            .into_iter()
+            .map(|op| self.add_operation(op))
+            .collect()
+    }
+
+    pub fn best_operations(&self, max: usize) -> Vec<Arc<UserOperation>> {
+        if max == 0 {
+            return vec![];
+        }
+
+        // Only add one op per sender
+        let mut senders = HashSet::new();
+
+        let mut best = Vec::new();
+        for operation in self.best.iter() {
+            if senders.contains(&operation.sender) {
+                continue;
+            }
+            best.push(operation.clone().into());
+            senders.insert(operation.sender);
+
+            if best.len() == max {
+                break;
+            }
+        }
+
+        best
+    }
+
+    pub fn remove_operation_by_hash(&mut self, hash: H256) {
+        if let Entry::Occupied(e) = self.by_hash.entry(hash) {
+            self.by_id.remove(&e.get().id());
+            self.best.remove(e.get());
+
+            if let Entry::Occupied(mut count_entry) = self.count_by_sender.entry(e.get().sender) {
+                *count_entry.get_mut() -= 1;
+                if *count_entry.get() == 0 {
+                    count_entry.remove_entry();
+                }
+            }
+
+            e.remove_entry();
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.by_hash.clear();
+        self.by_id.clear();
+        self.best.clear();
+        self.count_by_sender.clear();
+    }
+
+    fn next_submission_id(&mut self) -> u64 {
+        let id = self.submission_id;
+        self.submission_id += 1;
+        id
+    }
+}
+
+// Wrapper type to implement a custom Ord of UserOperations for PoolInner
+#[derive(Debug, Clone)]
+struct PoolOperation {
+    op: Arc<UserOperation>,
+    submission_id: u64,
+}
+
+impl Deref for PoolOperation {
+    type Target = Arc<UserOperation>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.op
+    }
+}
+
+impl Eq for PoolOperation {}
+
+impl Ord for PoolOperation {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Sort by gas price descending
+        // then by id ascending
+        other
+            .max_fee_per_gas
+            .cmp(&self.max_fee_per_gas)
+            .then_with(|| self.submission_id.cmp(&other.submission_id))
+    }
+}
+
+impl PartialOrd for PoolOperation {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for PoolOperation {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl From<PoolOperation> for Arc<UserOperation> {
+    fn from(po: PoolOperation) -> Self {
+        po.op
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_single_op() {
+        let mut pool = PoolInner::new(Address::zero(), 1.into());
+        let op = UserOperation::default();
+        let hash = pool.add_operation(op.clone()).unwrap();
+
+        check_map_entry(pool.by_hash.get(&hash), Some(&op));
+        check_map_entry(pool.by_id.get(&op.id()), Some(&op));
+        check_map_entry(pool.best.iter().next(), Some(&op));
+    }
+
+    #[test]
+    fn test_add_multiple_ops() {
+        let mut pool = PoolInner::new(Address::zero(), 1.into());
+        let ops = vec![
+            create_op(Address::random(), 0, 1),
+            create_op(Address::random(), 0, 2),
+            create_op(Address::random(), 0, 3),
+        ];
+
+        let mut hashes = vec![];
+        for op in ops.iter() {
+            hashes.push(pool.add_operation(op.clone()).unwrap());
+        }
+
+        for (hash, op) in hashes.iter().zip(&ops) {
+            check_map_entry(pool.by_hash.get(hash), Some(op));
+            check_map_entry(pool.by_id.get(&op.id()), Some(op));
+        }
+
+        // best should be sorted by gas
+        assert_eq!(pool.best.len(), 3);
+        check_map_entry(pool.best.iter().next(), Some(&ops[2]));
+        check_map_entry(pool.best.iter().nth(1), Some(&ops[1]));
+        check_map_entry(pool.best.iter().nth(2), Some(&ops[0]));
+    }
+
+    #[test]
+    fn test_best_ties() {
+        let mut pool = PoolInner::new(Address::zero(), 1.into());
+        let ops = vec![
+            create_op(Address::random(), 0, 1),
+            create_op(Address::random(), 0, 1),
+            create_op(Address::random(), 0, 1),
+        ];
+
+        let mut hashes = vec![];
+        for op in ops.iter() {
+            hashes.push(pool.add_operation(op.clone()).unwrap());
+        }
+
+        // best should be sorted by gas, then by submission id
+        assert_eq!(pool.best.len(), 3);
+        check_map_entry(pool.best.iter().next(), Some(&ops[0]));
+        check_map_entry(pool.best.iter().nth(1), Some(&ops[1]));
+        check_map_entry(pool.best.iter().nth(2), Some(&ops[2]));
+    }
+
+    #[test]
+    fn test_remove_op() {
+        let mut pool = PoolInner::new(Address::zero(), 1.into());
+        let ops = vec![
+            create_op(Address::random(), 0, 3),
+            create_op(Address::random(), 0, 2),
+            create_op(Address::random(), 0, 1),
+        ];
+
+        let mut hashes = vec![];
+        for op in ops.iter() {
+            hashes.push(pool.add_operation(op.clone()).unwrap());
+        }
+
+        pool.remove_operation_by_hash(hashes[0]);
+        check_map_entry(pool.by_hash.get(&hashes[0]), None);
+        check_map_entry(pool.best.iter().next(), Some(&ops[1]));
+
+        pool.remove_operation_by_hash(hashes[1]);
+        check_map_entry(pool.by_hash.get(&hashes[1]), None);
+        check_map_entry(pool.best.iter().next(), Some(&ops[2]));
+
+        pool.remove_operation_by_hash(hashes[2]);
+        check_map_entry(pool.by_hash.get(&hashes[2]), None);
+        check_map_entry(pool.best.iter().next(), None);
+    }
+
+    fn create_op(sender: Address, nonce: usize, max_fee_per_gas: usize) -> UserOperation {
+        UserOperation {
+            sender,
+            nonce: nonce.into(),
+            max_fee_per_gas: max_fee_per_gas.into(),
+            ..UserOperation::default()
+        }
+    }
+
+    fn check_map_entry(actual: Option<&PoolOperation>, expected: Option<&UserOperation>) {
+        match (actual, expected) {
+            (Some(actual), Some(expected)) => assert_eq!(*actual.op, *expected),
+            (None, None) => (),
+            _ => panic!("Expected {expected:?}, got {actual:?}"),
+        }
+    }
+}

--- a/src/op_pool/mempool/uo_pool.rs
+++ b/src/op_pool/mempool/uo_pool.rs
@@ -1,0 +1,128 @@
+use super::{pool::PoolInner, Mempool, OnNewBlockEvent, OperationOrigin};
+use crate::common::types::UserOperation;
+use ethers::types::{Address, H256, U256};
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+/// User Operation Mempool
+///
+/// Wrapper around a pool object that implements thread-safety
+/// via a RwLock. Safe to call from multiple threads. Methods
+/// block on write locks.
+pub struct UoPool {
+    pool: RwLock<PoolInner>,
+    entry_point: Address,
+}
+
+impl UoPool {
+    pub fn new(entry_point: Address, chain_id: U256) -> Self {
+        Self {
+            pool: RwLock::new(PoolInner::new(entry_point, chain_id)),
+            entry_point,
+        }
+    }
+}
+
+impl Mempool for UoPool {
+    fn entry_point(&self) -> Address {
+        self.entry_point
+    }
+
+    fn on_new_block(&self, event: OnNewBlockEvent) {
+        // hold the lock for the duration of the operation
+        let mut lg = self.pool.write();
+        for hash in event.mined_operations {
+            lg.remove_operation_by_hash(hash);
+        }
+    }
+
+    fn add_operation(
+        &self,
+        _origin: OperationOrigin,
+        operation: UserOperation,
+    ) -> anyhow::Result<H256> {
+        self.pool.write().add_operation(operation)
+    }
+
+    fn add_operations(
+        &self,
+        _origin: OperationOrigin,
+        operations: impl IntoIterator<Item = UserOperation>,
+    ) -> Vec<anyhow::Result<H256>> {
+        self.pool.write().add_operations(operations)
+    }
+
+    fn best_operations(&self, max: usize) -> Vec<Arc<UserOperation>> {
+        self.pool.read().best_operations(max)
+    }
+
+    fn clear(&self) {
+        self.pool.write().clear()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_single_op() {
+        let pool = UoPool::new(Address::zero(), 1.into());
+        let op = create_op(Address::random(), 0, 0);
+        let hash = pool
+            .add_operation(OperationOrigin::Local, op.clone())
+            .unwrap();
+        check_ops(pool.best_operations(1), vec![op]);
+        pool.on_new_block(OnNewBlockEvent {
+            mined_operations: vec![hash],
+        });
+        assert_eq!(pool.best_operations(1), vec![]);
+    }
+
+    #[test]
+    fn test_add_multiple_ops() {
+        let pool = UoPool::new(Address::zero(), 1.into());
+        let ops = vec![
+            create_op(Address::random(), 0, 3),
+            create_op(Address::random(), 0, 2),
+            create_op(Address::random(), 0, 1),
+        ];
+        let res = pool.add_operations(OperationOrigin::Local, ops.clone());
+        let hashes = res.into_iter().map(|r| r.unwrap()).collect();
+        check_ops(pool.best_operations(3), ops);
+        pool.on_new_block(OnNewBlockEvent {
+            mined_operations: hashes,
+        });
+        assert_eq!(pool.best_operations(3), vec![]);
+    }
+
+    #[test]
+    fn test_clear() {
+        let pool = UoPool::new(Address::zero(), 1.into());
+        let ops = vec![
+            create_op(Address::random(), 0, 3),
+            create_op(Address::random(), 0, 2),
+            create_op(Address::random(), 0, 1),
+        ];
+        pool.add_operations(OperationOrigin::Local, ops.clone());
+        check_ops(pool.best_operations(3), ops);
+        pool.clear();
+        assert_eq!(pool.best_operations(3), vec![]);
+    }
+
+    fn create_op(sender: Address, nonce: usize, max_fee_per_gas: usize) -> UserOperation {
+        UserOperation {
+            sender,
+            nonce: nonce.into(),
+            max_fee_per_gas: max_fee_per_gas.into(),
+            ..UserOperation::default()
+        }
+    }
+
+    fn check_ops(ops: Vec<Arc<UserOperation>>, expected: Vec<UserOperation>) {
+        assert_eq!(ops.len(), expected.len());
+        for (actual, expected) in ops.into_iter().zip(expected) {
+            assert_eq!(*actual, expected);
+        }
+    }
+}

--- a/src/op_pool/mod.rs
+++ b/src/op_pool/mod.rs
@@ -1,3 +1,4 @@
+mod mempool;
 mod metrics;
 mod run;
 mod server;

--- a/src/op_pool/server.rs
+++ b/src/op_pool/server.rs
@@ -1,3 +1,4 @@
+use super::mempool::{Mempool, OperationOrigin};
 use super::metrics::OpPoolMetrics;
 use crate::common::protos::op_pool::op_pool_server::OpPool;
 use crate::common::protos::op_pool::{
@@ -5,39 +6,88 @@ use crate::common::protos::op_pool::{
     DebugDumpMempoolRequest, DebugDumpMempoolResponse, DebugDumpReputationRequest,
     DebugDumpReputationResponse, DebugSetReputationRequest, DebugSetReputationResponse,
     GetOpsRequest, GetOpsResponse, GetReputationRequest, GetReputationResponse,
-    GetSupportedEntryPointsRequest, GetSupportedEntryPointsResponse,
+    GetSupportedEntryPointsRequest, GetSupportedEntryPointsResponse, UserOperation,
 };
+use ethers::types::{Address, U256};
 use tonic::{async_trait, Request, Response};
 
 #[derive(Default)]
-pub struct OpPoolImpl {
+pub struct OpPoolImpl<T: Mempool> {
+    chain_id: U256,
+    mempool: T,
     metrics: OpPoolMetrics,
 }
 
+impl<T> OpPoolImpl<T>
+where
+    T: Mempool,
+{
+    pub fn new(chain_id: U256, mempool: T) -> Self {
+        Self {
+            chain_id,
+            metrics: OpPoolMetrics::default(),
+            mempool,
+        }
+    }
+}
+
 #[async_trait]
-impl OpPool for OpPoolImpl {
+impl<T> OpPool for OpPoolImpl<T>
+where
+    T: Mempool + Send + Sync + 'static,
+{
     async fn get_supported_entry_points(
         &self,
         _request: Request<GetSupportedEntryPointsRequest>,
     ) -> tonic::Result<Response<GetSupportedEntryPointsResponse>> {
         self.metrics.request_counter.increment(1);
-        unimplemented!("get_supported_entry_points not implemented");
+        let mempool_ep = self.mempool.entry_point();
+        let cid: [u8; 32] = self.chain_id.into();
+        Ok(Response::new(GetSupportedEntryPointsResponse {
+            chain_id: cid.to_vec(),
+            entry_points: vec![mempool_ep.as_bytes().to_vec()],
+        }))
     }
 
     async fn add_op(
         &self,
-        _request: Request<AddOpRequest>,
+        request: Request<AddOpRequest>,
     ) -> tonic::Result<Response<AddOpResponse>> {
         self.metrics.request_counter.increment(1);
-        unimplemented!("add_op not implemented");
+
+        let req = request.into_inner();
+        self.check_entry_point(&req.entry_point, self.mempool.entry_point())?;
+
+        let op = req.op.ok_or_else(|| {
+            tonic::Status::invalid_argument("Operation is required in AddOpRequest")
+        })?;
+
+        let hash = self
+            .mempool
+            .add_operation(OperationOrigin::Local, op.into())
+            .map_err(|e| {
+                tonic::Status::internal(format!("Failed to add operation to mempool: {e}"))
+            })?;
+
+        Ok(Response::new(AddOpResponse {
+            hash: hash.as_bytes().to_vec(),
+        }))
     }
 
     async fn get_ops(
         &self,
-        _request: Request<GetOpsRequest>,
+        request: Request<GetOpsRequest>,
     ) -> tonic::Result<Response<GetOpsResponse>> {
         self.metrics.request_counter.increment(1);
-        unimplemented!("get_ops not implemented");
+
+        let req = request.into_inner();
+        self.check_entry_point(&req.entry_point, self.mempool.entry_point())?;
+
+        let ops = self.mempool.best_operations(req.max_ops as usize);
+
+        Ok(Response::new(GetOpsResponse {
+            ops: ops.iter().map(|op| UserOperation::from(&(**op))).collect(),
+        }))
     }
 
     async fn get_reputation(
@@ -45,7 +95,9 @@ impl OpPool for OpPoolImpl {
         _request: Request<GetReputationRequest>,
     ) -> tonic::Result<Response<GetReputationResponse>> {
         self.metrics.request_counter.increment(1);
-        unimplemented!("get_reputation not implemented");
+        Err(tonic::Status::unimplemented(
+            "get_reputation not implemented",
+        ))
     }
 
     async fn debug_clear_state(
@@ -53,15 +105,24 @@ impl OpPool for OpPoolImpl {
         _request: Request<DebugClearStateRequest>,
     ) -> tonic::Result<Response<DebugClearStateResponse>> {
         self.metrics.request_counter.increment(1);
-        unimplemented!("debug_clear_state not implemented");
+        self.mempool.clear();
+        Ok(Response::new(DebugClearStateResponse {}))
     }
 
     async fn debug_dump_mempool(
         &self,
-        _request: Request<DebugDumpMempoolRequest>,
+        request: Request<DebugDumpMempoolRequest>,
     ) -> tonic::Result<Response<DebugDumpMempoolResponse>> {
         self.metrics.request_counter.increment(1);
-        unimplemented!("debug_dump_mempool not implemented");
+
+        let req = request.into_inner();
+        self.check_entry_point(&req.entry_point, self.mempool.entry_point())?;
+
+        let ops = self.mempool.best_operations(usize::MAX);
+
+        Ok(Response::new(DebugDumpMempoolResponse {
+            ops: ops.iter().map(|op| UserOperation::from(&(**op))).collect(),
+        }))
     }
 
     async fn debug_set_reputation(
@@ -69,7 +130,9 @@ impl OpPool for OpPoolImpl {
         _request: Request<DebugSetReputationRequest>,
     ) -> tonic::Result<Response<DebugSetReputationResponse>> {
         self.metrics.request_counter.increment(1);
-        unimplemented!("debug_set_reputation not implemented");
+        Err(tonic::Status::unimplemented(
+            "debug_set_reputation not implemented",
+        ))
     }
 
     async fn debug_dump_reputation(
@@ -77,6 +140,35 @@ impl OpPool for OpPoolImpl {
         _request: Request<DebugDumpReputationRequest>,
     ) -> tonic::Result<Response<DebugDumpReputationResponse>> {
         self.metrics.request_counter.increment(1);
-        unimplemented!("debug_dump_reputation not implemented");
+        Err(tonic::Status::unimplemented(
+            "debug_dump_reputation not implemented",
+        ))
+    }
+}
+
+impl<T> OpPoolImpl<T>
+where
+    T: Mempool,
+{
+    fn check_entry_point(
+        &self,
+        req_entry_point: &[u8],
+        pool_entry_point: Address,
+    ) -> tonic::Result<()> {
+        let ep_len = req_entry_point.len();
+        if ep_len != 20 {
+            return Err(tonic::Status::invalid_argument(format!(
+                "Invalid entry point length: {ep_len}, expected 20"
+            )));
+        }
+
+        let req_ep = Address::from_slice(req_entry_point);
+        if req_ep != pool_entry_point {
+            return Err(tonic::Status::invalid_argument(format!(
+                "Invalid entry point: {req_ep:?}, expected {pool_entry_point:?}"
+            )));
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Started putting together a simple mempool implementation.

Features:
* Add operations
* Get "best" operations sorted by gas price, up to some max. Only one per sender
* Replace stuck operations with same sender/nonce by increasing the gas price
* Limit the amount of operations per sender in the mempool

Missing:
* Reputation management
* Removing from mempool based on block events

Issues:
* I want to think a lot more about nonce management. I think there are a bunch of problems with handling nonces at the moment. For example, `best_operations` doesn't order by nonce and likely should. Might need to shake the data structures up a bit.
* Testing, need to add a bunch more unit tests

Note that this interface is likely going to change drastically when we try to integrate this with block events, reputation, P2P, and bundling.