### PR TITLE
feat(uo_pool): add remove_ops server method

### DIFF
--- a/proto/op_pool.proto
+++ b/proto/op_pool.proto
@@ -20,6 +20,7 @@ service OpPool {
   rpc AddOp (AddOpRequest) returns (AddOpResponse);
   rpc GetOps (GetOpsRequest) returns (GetOpsResponse);
   rpc GetReputation (GetReputationRequest) returns (GetReputationResponse);
+  rpc RemoveOps(RemoveOpsRequest) returns (RemoveOpsResponse);
 
   rpc DebugClearState (DebugClearStateRequest) returns (DebugClearStateResponse);
   rpc DebugDumpMempool (DebugDumpMempoolRequest) returns (DebugDumpMempoolResponse);
@@ -67,6 +68,13 @@ message GetReputationRequest {
 message GetReputationResponse {
   Reputation reputation = 1;
 }
+
+message RemoveOpsRequest {
+  bytes entry_point = 2;
+  repeated bytes hashes = 1;
+}
+
+message RemoveOpsResponse {}
 
 message DebugClearStateRequest {}
 message DebugClearStateResponse {}

--- a/src/op_pool/mempool/mod.rs
+++ b/src/op_pool/mempool/mod.rs
@@ -37,6 +37,9 @@ pub trait Mempool {
         operations: impl IntoIterator<Item = UserOperation>,
     ) -> Vec<anyhow::Result<H256>>;
 
+    /// Removes a set of operations from the pool.
+    fn remove_operations<'a>(&self, hashes: impl IntoIterator<Item = &'a H256>);
+
     /// Returns the best operations from the pool.
     ///
     /// Returns the best operations from the pool based on their gas bids up to


### PR DESCRIPTION
Adds an endpoint that allows the bundler to tell the `uo_pool` to remove operations after they have failed validation.