### PR TITLE
Fix rerun-if-changed filepath in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,8 +8,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     println!("cargo:rerun-if-changed=contracts/lib");
     println!("cargo:rerun-if-changed=contracts/src");
     println!("cargo:rerun-if-changed=proto");
+    println!("cargo:rerun-if-changed=tracer/package.json");
     println!("cargo:rerun-if-changed=tracer/src/index.ts");
-    println!("cargo:rerun-if-changed=tracer/src/package.json");
     generate_contract_bindings()?;
     generate_protos()?;
     compile_tracer()?;


### PR DESCRIPTION
By having the wrong path to `package.json`, we were having `build.rs` re-run on every single run. This change reduces build times by 5-10 seconds when non-Rust dependencies haven't changed.