### PR TITLE
feat: add debug route impls for op_pool rpc calls

### DIFF
--- a/proto/op_pool.proto
+++ b/proto/op_pool.proto
@@ -83,7 +83,7 @@ message DebugDumpMempoolResponse {
 
 message DebugSetReputationRequest {
   bytes entry_point = 1;
-  Reputation reputation = 2;
+  repeated Reputation reputations = 2;
 }
 message DebugSetReputationResponse {}
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -188,6 +188,10 @@ struct RpcArgs {
     )]
     host: String,
 
+    #[clap(flatten)]
+    op_pool_args: OpPoolArgs,
+
+    /// Which APIs to expose over the RPC interface
     #[arg(
         long = "rpc.api",
         name = "rpc.api",
@@ -210,6 +214,8 @@ impl RpcArgs {
         Ok(rpc::Args {
             port: self.port,
             host: self.host.clone(),
+            op_pool_host: self.op_pool_args.host.clone(),
+            op_pool_port: self.op_pool_args.port,
             entry_point: common
                 .entry_point
                 .parse()

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,5 +1,6 @@
 pub mod contracts;
 pub mod eth;
 pub mod protos;
+pub mod server;
 pub mod tracer;
 pub mod types;

--- a/src/common/server.rs
+++ b/src/common/server.rs
@@ -1,0 +1,3 @@
+pub fn format_server_addr(host: String, port: u16) -> String {
+    format!("{}:{}", host, port)
+}


### PR DESCRIPTION
Adds implementation for all of the debug calls that call the op_pool module