### PR TITLE
feat(op_pool): add structured errors to op_pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "parse-display",
  "prost",
+ "prost-types",
  "serde",
  "serde_json",
  "strum",
@@ -86,6 +87,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tonic-reflection",
+ "tonic-types",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2944,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
+checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2976,9 +2978,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
+checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2989,11 +2991,10 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
+checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
 dependencies = [
- "bytes",
  "prost",
 ]
 
@@ -4152,6 +4153,17 @@ dependencies = [
  "prost-types",
  "tokio",
  "tokio-stream",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33a7caea455745042e5a13b6aa0f6035b9c7bf224224d4d0126172ca4dc1ced"
+dependencies = [
+ "prost",
+ "prost-types",
  "tonic",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread", "signal"] }
 tonic = "0.8.3"
+tonic-types = "0.6.1"
 tonic-reflection = "0.6.0"
+prost-types = "0.11.8"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 tracing-appender = "0.2.2"

--- a/proto/op_pool.proto
+++ b/proto/op_pool.proto
@@ -68,7 +68,6 @@ message RemoveOpsRequest {
   bytes entry_point = 1;
   repeated bytes hashes = 2;
 }
-
 message RemoveOpsResponse {}
 
 message DebugClearStateRequest {}
@@ -105,4 +104,15 @@ enum ReputationStatus {
   OK = 0;
   THROTTLED = 1;
   BANNED = 2;
+}
+
+message ErrorInfo {
+  string reason = 1;
+  map<string, string> metadata = 2;
+}
+
+enum ErrorReason {
+  UNSPECIFIED = 0;
+  ENTITY_THROTTLED = 1;
+  OPERATION_REJECTED = 2;
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -188,9 +188,8 @@ struct RpcArgs {
     )]
     host: String,
 
-    #[clap(flatten)]
-    op_pool_args: OpPoolArgs,
-
+    // #[clap(flatten)]
+    // op_pool_args: OpPoolArgs,
     /// Which APIs to expose over the RPC interface
     #[arg(
         long = "rpc.api",
@@ -222,8 +221,11 @@ impl RpcArgs {
         Ok(rpc::Args {
             port: self.port,
             host: self.host.clone(),
-            op_pool_host: self.op_pool_args.host.clone(),
-            op_pool_port: self.op_pool_args.port,
+            // TODO(danc): fix this
+            // op_pool_host: self.op_pool_args.host.clone(),
+            // op_pool_port: self.op_pool_args.port,
+            op_pool_host: "localhost".to_string(),
+            op_pool_port: 50051,
             entry_point: common
                 .entry_point
                 .parse()

--- a/src/op_pool/mempool/error.rs
+++ b/src/op_pool/mempool/error.rs
@@ -1,0 +1,29 @@
+use ethers::{abi::Address, types::U256};
+use parse_display::Display;
+
+/// Mempool result type.
+pub type MempoolResult<T> = std::result::Result<T, MempoolError>;
+
+/// Mempool error type.
+#[derive(Debug, thiserror::Error)]
+pub enum MempoolError {
+    /// Operation with same sender/nonce already in pool
+    /// and the replacement operation has lower gas price.
+    #[error("Replacement operation underpriced. Existing priority fee: {0}. Existing fee: {1}")]
+    ReplacementUnderpriced(U256, U256),
+    /// Max operations reached for this sender
+    #[error("Max operations ({0}) reached for sender {1}")]
+    MaxOperationsReached(usize, Address),
+    /// An entity associated with the operation is throttled/banned.
+    #[error("Entity {0}:{1} is throttled/banned")]
+    EntityThrottled(EntityType, Address),
+}
+
+#[derive(Display, Debug, Clone, Copy)]
+#[display(style = "lowercase")]
+pub enum EntityType {
+    Sender,
+    Paymaster,
+    Aggregator,
+    Factory,
+}

--- a/src/op_pool/mempool/mod.rs
+++ b/src/op_pool/mempool/mod.rs
@@ -1,3 +1,4 @@
+pub mod error;
 mod pool;
 pub mod uo_pool;
 
@@ -6,6 +7,8 @@ use ethers::types::{Address, H256, U256};
 use std::sync::Arc;
 
 use crate::common::{protos::op_pool::Reputation, types::UserOperation};
+
+use self::error::MempoolResult;
 
 use super::events::NewBlockEvent;
 
@@ -23,7 +26,7 @@ pub trait Mempool: Send + Sync {
     ///
     /// Adds a user operation to the pool that was submitted via a local
     /// RPC call and was validated before submission.
-    fn add_operation(&self, origin: OperationOrigin, op: PoolOperation) -> anyhow::Result<H256>;
+    fn add_operation(&self, origin: OperationOrigin, op: PoolOperation) -> MempoolResult<H256>;
 
     /// Adds multiple validated user operations to the pool.
     ///
@@ -33,7 +36,7 @@ pub trait Mempool: Send + Sync {
         &self,
         origin: OperationOrigin,
         operations: impl IntoIterator<Item = PoolOperation>,
-    ) -> Vec<anyhow::Result<H256>>;
+    ) -> Vec<MempoolResult<H256>>;
 
     /// Removes a set of operations from the pool.
     fn remove_operations<'a>(&self, hashes: impl IntoIterator<Item = &'a H256>);

--- a/src/op_pool/mempool/uo_pool.rs
+++ b/src/op_pool/mempool/uo_pool.rs
@@ -1,4 +1,6 @@
-use super::{pool::PoolInner, Mempool, NewBlockEvent, OperationOrigin, PoolOperation};
+use super::{
+    error::MempoolResult, pool::PoolInner, Mempool, NewBlockEvent, OperationOrigin, PoolOperation,
+};
 use crate::{
     common::{
         contracts::entry_point::EntryPointEvents,
@@ -118,7 +120,7 @@ where
         }
     }
 
-    fn add_operation(&self, _origin: OperationOrigin, op: PoolOperation) -> anyhow::Result<H256> {
+    fn add_operation(&self, _origin: OperationOrigin, op: PoolOperation) -> MempoolResult<H256> {
         let addrs = Self::get_op_addresses(&op);
         self.reputation.add_seen(&addrs);
         self.pool.write().add_operation(op)
@@ -128,7 +130,7 @@ where
         &self,
         _origin: OperationOrigin,
         operations: impl IntoIterator<Item = PoolOperation>,
-    ) -> Vec<anyhow::Result<H256>> {
+    ) -> Vec<MempoolResult<H256>> {
         self.pool.write().add_operations(operations)
     }
 


### PR DESCRIPTION
gRPC errors attempted to follow the [Richer Error Model](https://grpc.io/docs/guides/error/#richer-error-model) however tonic doesn't directly support it yet (likely coming in next release). Followed the same pattern here.

Follow ups needed:

1.  Populate throttling errors (need to rebase https://github.com/OMGWINNING/alchemy-bundler/pull/29)
2. Client side error conversions