### PR TITLE
Include the block hash in the simulation result

### DIFF
--- a/src/common/eth.rs
+++ b/src/common/eth.rs
@@ -135,7 +135,7 @@ pub async fn get_static_block_id(
     Ok(get_block_hash(provider, block_id).await?.into())
 }
 
-async fn get_block_hash(provider: &Provider<Http>, block_id: BlockId) -> anyhow::Result<H256> {
+pub async fn get_block_hash(provider: &Provider<Http>, block_id: BlockId) -> anyhow::Result<H256> {
     if let BlockId::Hash(hash) = block_id {
         return Ok(hash);
     }

--- a/src/common/simulation.rs
+++ b/src/common/simulation.rs
@@ -18,6 +18,7 @@ const MIN_UNSTAKE_DELAY: u32 = 84600;
 
 #[derive(Clone, Debug)]
 pub struct SimulationSuccess {
+    pub block_hash: H256,
     pub pre_op_gas: U256,
     pub signature_failed: bool,
     pub valid_after: Timestamp,
@@ -131,11 +132,12 @@ impl Simulator for SimulatorImpl {
         block_id: Option<BlockId>,
         expected_code_hash: Option<H256>,
     ) -> Result<SimulationSuccess, SimulationError> {
-        let block_id = eth::get_static_block_id(
+        let block_hash = eth::get_block_hash(
             &self.provider,
             block_id.unwrap_or(BlockNumber::Latest.into()),
         )
         .await?;
+        let block_id = block_hash.into();
         let context = match self.create_context(op, block_id).await {
             Ok(context) => context,
             error @ Err(_) => error?,
@@ -235,6 +237,7 @@ impl Simulator for SimulatorImpl {
             Err(violations)?
         }
         Ok(SimulationSuccess {
+            block_hash,
             pre_op_gas: entry_point_out.return_info.pre_op_gas,
             signature_failed: entry_point_out.return_info.sig_failed,
             valid_after: entry_point_out.return_info.valid_after,


### PR DESCRIPTION
This allows us to avoid resimulating if the latest block hasn't changed.