### PR TITLE
Add paymaster example, new user op helpers

### DIFF
--- a/src/bin/get_example_ops.rs
+++ b/src/bin/get_example_ops.rs
@@ -1,0 +1,23 @@
+use alchemy_bundler::common::dev::DevClients;
+use dotenv::dotenv;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    dotenv()?;
+    let clients = DevClients::new_from_env()?;
+    // We'll make operations that call the entry point's addStake.
+    let op = clients
+        .new_wallet_op(clients.entry_point.add_stake(1), 1.into())
+        .await?;
+    println!("User operation to make wallet call EntryPoint#addStake():");
+    println!();
+    println!("{}", serde_json::to_string_pretty(&op)?);
+    let op = clients
+        .new_wallet_op_with_paymaster(clients.entry_point.add_stake(1), 1.into())
+        .await?;
+    println!();
+    println!("User operation to make wallet call EntryPoint#addStake() with paymaster:");
+    println!();
+    println!("{}", serde_json::to_string_pretty(&op)?);
+    Ok(())
+}

--- a/src/bin/send_ops.rs
+++ b/src/bin/send_ops.rs
@@ -1,51 +1,22 @@
 use alchemy_bundler::common::dev::DevClients;
-use alchemy_bundler::common::types::UserOperation;
-use alchemy_bundler::common::{dev, eth};
-use anyhow::Context;
+use alchemy_bundler::common::eth;
 use dotenv::dotenv;
-use ethers::signers::Signer;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv()?;
+    let clients = DevClients::new_from_env()?;
     let DevClients {
-        bundler_client,
+        wallet,
         entry_point,
-        wallet: scw,
-        wallet_owner_signer,
+        bundler_client,
         ..
-    } = DevClients::new_from_env()?;
+    } = &clients;
 
     // simply call the nonce method multiple times
-    let call_data = scw
-        .nonce()
-        .calldata()
-        .expect("should encode nonce calldata");
-
     for i in 0..10 {
         println!("Sending op {i}");
-        let nonce = scw
-            .nonce()
-            .call()
-            .await
-            .context("should get nonce of simple account")?;
-        let mut op = UserOperation {
-            sender: scw.address(),
-            call_data: call_data.clone(),
-            nonce,
-            ..dev::base_user_op()
-        };
-        let op_hash = entry_point
-            .get_user_op_hash(op.clone())
-            .call()
-            .await
-            .context("entry point should compute hash of user operation")?;
-        let signature = wallet_owner_signer
-            .sign_message(op_hash)
-            .await
-            .context("user eoa should sign op hash")?;
-        op.signature = signature.to_vec().into();
-
+        let op = clients.new_wallet_op(wallet.nonce(), 0.into()).await?;
         let call = entry_point.handle_ops(vec![op], bundler_client.address());
         eth::await_mined_tx(call.send(), "send user operation").await?;
     }


### PR DESCRIPTION
Add new helper functions for easily creating signed user operations, and refactor `send_ops.rs` to use them. Also add a helper for doing so with a paymaster, and add a new example script which prints out user operation JSON that can be used for testing from Postman.