### PR TITLE
Represent chain id as a u64

### DIFF
--- a/proto/op_pool.proto
+++ b/proto/op_pool.proto
@@ -53,7 +53,7 @@ service OpPool {
 
 message GetSupportedEntryPointsRequest {}
 message GetSupportedEntryPointsResponse {
-  bytes chain_id = 1;
+  uint64 chain_id = 1;
   repeated bytes entry_points = 2;
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -100,7 +100,7 @@ pub struct CommonArgs {
         default_value = "1337",
         global = true
     )]
-    chain_id: u128,
+    chain_id: u64,
 
     /// ETH Node websocket URL to connect to
     #[arg(long = "node_ws", name = "node_ws", env = "NODE_WS", global = true)]

--- a/src/cli/pool.rs
+++ b/src/cli/pool.rs
@@ -41,7 +41,7 @@ impl PoolArgs {
                 .entry_point
                 .parse()
                 .context("Invalid entry_point argument")?,
-            chain_id: common.chain_id.into(),
+            chain_id: common.chain_id,
             ws_url: common
                 .node_ws
                 .clone()

--- a/src/cli/rpc.rs
+++ b/src/cli/rpc.rs
@@ -67,7 +67,7 @@ impl RpcArgs {
                 .node_http
                 .clone()
                 .context("rpc requires node_http arg")?,
-            chain_id: common.chain_id.into(),
+            chain_id: common.chain_id,
             api_namespaces: apis,
         })
     }

--- a/src/common/dev.rs
+++ b/src/common/dev.rs
@@ -18,7 +18,7 @@ use std::io::Write;
 use std::sync::Arc;
 use std::time::Duration;
 
-pub const DEV_CHAIN_ID: u32 = 1337;
+pub const DEV_CHAIN_ID: u64 = 1337;
 pub const DEPLOYER_ACCOUNT_ID: u8 = 1;
 pub const BUNDLER_ACCOUNT_ID: u8 = 2;
 pub const WALLET_OWNER_ACCOUNT_ID: u8 = 3;
@@ -193,7 +193,7 @@ pub async fn deploy_dev_contracts() -> anyhow::Result<DevAddresses> {
         init_code,
         ..base_user_op()
     };
-    let op_hash = op.op_hash(entry_point.address(), DEV_CHAIN_ID.into());
+    let op_hash = op.op_hash(entry_point.address(), DEV_CHAIN_ID);
     let signature = wallet_owner_eoa
         .sign_message(op_hash)
         .await
@@ -328,7 +328,7 @@ impl DevClients {
             paymaster_and_data.extend(paymaster_signature.to_vec());
             op.paymaster_and_data = paymaster_and_data.into()
         }
-        let op_hash = op.op_hash(self.entry_point.address(), DEV_CHAIN_ID.into());
+        let op_hash = op.op_hash(self.entry_point.address(), DEV_CHAIN_ID);
         let signature = self
             .wallet_owner_signer
             .sign_message(op_hash)

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -25,7 +25,7 @@ impl UserOperation {
     ///
     /// The hash is used to uniquely identify a user operation in the entry point
     /// it does not include the signature field.
-    pub fn op_hash(&self, entry_point: Address, chain_id: U256) -> H256 {
+    pub fn op_hash(&self, entry_point: Address, chain_id: u64) -> H256 {
         keccak256(
             [
                 keccak256(self.pack()).to_vec(),
@@ -145,7 +145,7 @@ mod tests {
         let entry_point = "0x1306b01bc3e4ad202612d3843387e94737673f53"
             .parse()
             .unwrap();
-        let chain_id: U256 = 1337.into();
+        let chain_id = 1337;
         let hash = operation.op_hash(entry_point, chain_id);
         assert_eq!(
             hash,
@@ -205,7 +205,7 @@ mod tests {
         let entry_point = "0x1306b01bc3e4ad202612d3843387e94737673f53"
             .parse()
             .unwrap();
-        let chain_id: U256 = 1337.into();
+        let chain_id = 1337;
         let hash = operation.op_hash(entry_point, chain_id);
         assert_eq!(
             hash,

--- a/src/op_pool/mempool/pool.rs
+++ b/src/op_pool/mempool/pool.rs
@@ -1,8 +1,5 @@
 use crate::common::types::{UserOperation, UserOperationId};
-use ethers::{
-    abi::Address,
-    types::{H256, U256},
-};
+use ethers::{abi::Address, types::H256};
 use std::{
     cmp::Ordering,
     collections::{hash_map::Entry, BTreeSet, HashMap},
@@ -23,7 +20,7 @@ pub struct PoolInner {
     // Address of the entry point this pool targets
     entry_point: Address,
     // Chain ID this pool targets
-    chain_id: U256,
+    chain_id: u64,
     // Operations by hash
     by_hash: HashMap<H256, OrderedPoolOperation>,
     // Operations by operation ID
@@ -37,7 +34,7 @@ pub struct PoolInner {
 }
 
 impl PoolInner {
-    pub fn new(entry_point: Address, chain_id: U256) -> Self {
+    pub fn new(entry_point: Address, chain_id: u64) -> Self {
         Self {
             by_hash: HashMap::new(),
             by_id: HashMap::new(),
@@ -197,7 +194,7 @@ mod tests {
 
     #[test]
     fn add_single_op() {
-        let mut pool = PoolInner::new(Address::zero(), 1.into());
+        let mut pool = PoolInner::new(Address::zero(), 1);
         let op = create_op(Address::random(), 0, 1);
         let hash = pool.add_operation(op.clone()).unwrap();
 
@@ -208,7 +205,7 @@ mod tests {
 
     #[test]
     fn add_multiple_ops() {
-        let mut pool = PoolInner::new(Address::zero(), 1.into());
+        let mut pool = PoolInner::new(Address::zero(), 1);
         let ops = vec![
             create_op(Address::random(), 0, 1),
             create_op(Address::random(), 0, 2),
@@ -234,7 +231,7 @@ mod tests {
 
     #[test]
     fn best_ties() {
-        let mut pool = PoolInner::new(Address::zero(), 1.into());
+        let mut pool = PoolInner::new(Address::zero(), 1);
         let ops = vec![
             create_op(Address::random(), 0, 1),
             create_op(Address::random(), 0, 1),
@@ -255,7 +252,7 @@ mod tests {
 
     #[test]
     fn remove_op() {
-        let mut pool = PoolInner::new(Address::zero(), 1.into());
+        let mut pool = PoolInner::new(Address::zero(), 1);
         let ops = vec![
             create_op(Address::random(), 0, 3),
             create_op(Address::random(), 0, 2),
@@ -286,7 +283,7 @@ mod tests {
 
     #[test]
     fn too_many_ops() {
-        let mut pool = PoolInner::new(Address::zero(), 1.into());
+        let mut pool = PoolInner::new(Address::zero(), 1);
         let addr = Address::random();
         for i in 0..MAX_MEMPOOL_USEROPS_PER_SENDER {
             let op = create_op(addr, i, 1);
@@ -299,7 +296,7 @@ mod tests {
 
     #[test]
     fn address_count() {
-        let mut pool = PoolInner::new(Address::zero(), 1.into());
+        let mut pool = PoolInner::new(Address::zero(), 1);
         let sender = Address::random();
         let paymaster = Address::random();
         let factory = Address::random();

--- a/src/op_pool/mempool/uo_pool.rs
+++ b/src/op_pool/mempool/uo_pool.rs
@@ -12,7 +12,7 @@ use crate::{
     op_pool::reputation::ReputationManager,
 };
 use anyhow::Context;
-use ethers::types::{Address, H256, U256};
+use ethers::types::{Address, H256};
 use parking_lot::RwLock;
 use std::{
     collections::{HashMap, HashSet},
@@ -45,7 +45,7 @@ impl<R> UoPool<R>
 where
     R: ReputationManager,
 {
-    pub fn new(entry_point: Address, chain_id: U256, reputation: Arc<R>) -> Self {
+    pub fn new(entry_point: Address, chain_id: u64, reputation: Arc<R>) -> Self {
         Self {
             entry_point,
             reputation,
@@ -253,7 +253,7 @@ mod tests {
     }
 
     fn create_pool() -> UoPool<MockReputationManager> {
-        UoPool::new(Address::zero(), 1.into(), mock_reputation())
+        UoPool::new(Address::zero(), 1, mock_reputation())
     }
 
     fn create_op(sender: Address, nonce: usize, max_fee_per_gas: usize) -> PoolOperation {

--- a/src/op_pool/run.rs
+++ b/src/op_pool/run.rs
@@ -8,7 +8,7 @@ use crate::op_pool::{
     server::OpPoolImpl,
 };
 use anyhow::bail;
-use ethers::types::{Address, U256};
+use ethers::types::Address;
 use tokio::{
     sync::{broadcast, mpsc},
     try_join,
@@ -19,7 +19,7 @@ pub struct Args {
     pub port: u16,
     pub host: String,
     pub entry_point: Address,
-    pub chain_id: U256,
+    pub chain_id: u64,
     pub ws_url: String,
 }
 

--- a/src/op_pool/server.rs
+++ b/src/op_pool/server.rs
@@ -13,12 +13,12 @@ use crate::common::protos::op_pool::{
     GetSupportedEntryPointsResponse, MempoolOp, RemoveOpsRequest, RemoveOpsResponse,
 };
 use crate::common::protos::ProtoBytes;
-use ethers::types::{Address, H256, U256};
+use ethers::types::{Address, H256};
 use prost::Message;
 use tonic::{async_trait, Code, Request, Response, Result, Status};
 
 pub struct OpPoolImpl<M: Mempool> {
-    chain_id: U256,
+    chain_id: u64,
     mempool: Arc<M>,
     metrics: OpPoolMetrics,
 }
@@ -27,7 +27,7 @@ impl<M> OpPoolImpl<M>
 where
     M: Mempool,
 {
-    pub fn new(chain_id: U256, mempool: Arc<M>) -> Self {
+    pub fn new(chain_id: u64, mempool: Arc<M>) -> Self {
         Self {
             chain_id,
             metrics: OpPoolMetrics::default(),
@@ -61,9 +61,8 @@ where
         self.metrics.request_counter.increment(1);
 
         let mempool_ep = self.mempool.entry_point();
-        let cid: [u8; 32] = self.chain_id.into();
         Ok(Response::new(GetSupportedEntryPointsResponse {
-            chain_id: cid.to_vec(),
+            chain_id: self.chain_id,
             entry_points: vec![mempool_ep.as_bytes().to_vec()],
         }))
     }
@@ -312,7 +311,7 @@ mod tests {
     }
 
     fn given_oppool() -> OpPoolImpl<MockMempool> {
-        OpPoolImpl::<MockMempool>::new(1.into(), MockMempool::default().into())
+        OpPoolImpl::<MockMempool>::new(1, MockMempool::default().into())
     }
 
     pub struct MockMempool {

--- a/src/rpc/eth/mod.rs
+++ b/src/rpc/eth/mod.rs
@@ -55,17 +55,17 @@ pub trait EthApi {
     async fn supported_entry_points(&self) -> RpcResult<Vec<Address>>;
 
     #[method(name = "chainId")]
-    async fn chain_id(&self) -> RpcResult<U256>;
+    async fn chain_id(&self) -> RpcResult<u64>;
 }
 
 pub struct EthApi {
     entry_points: HashMap<Address, EntryPoint<Provider<Http>>>,
     provider: Arc<Provider<Http>>,
-    chain_id: U256,
+    chain_id: u64,
 }
 
 impl EthApi {
-    pub fn new(provider: Arc<Provider<Http>>, entry_points: Vec<Address>, chain_id: U256) -> Self {
+    pub fn new(provider: Arc<Provider<Http>>, entry_points: Vec<Address>, chain_id: u64) -> Self {
         let entry_points: HashMap<Address, EntryPoint<Provider<Http>>> = entry_points
             .iter()
             .map(|&a| (a, EntryPoint::new(a, Arc::clone(&provider))))
@@ -438,7 +438,7 @@ impl EthApiServer for EthApi {
         Ok(self.entry_points.keys().copied().collect())
     }
 
-    async fn chain_id(&self) -> RpcResult<U256> {
+    async fn chain_id(&self) -> RpcResult<u64> {
         Ok(self.chain_id)
     }
 }

--- a/src/rpc/run.rs
+++ b/src/rpc/run.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use anyhow::{bail, Context};
 use ethers::providers::{Http, Provider, ProviderExt};
-use ethers::types::{Address, Chain, U256};
+use ethers::types::{Address, Chain};
 use jsonrpsee::server::ServerBuilder;
 use jsonrpsee::RpcModule;
 use tokio::sync::broadcast;
@@ -23,7 +23,7 @@ pub struct Args {
     pub pool_url: String,
     pub builder_url: Option<String>,
     pub entry_point: Address,
-    pub chain_id: U256,
+    pub chain_id: u64,
     pub api_namespaces: Vec<ApiNamespace>,
     pub rpc_url: String,
 }


### PR DESCRIPTION
Ethers uses `u64` to represent chain ids, so there's no point having the rest of our code represent it with `U256`. It also simplifies slightly, because we can use a `uint64` in the protobuf definition instead of needing to convert to/from `bytes`.