### PR TITLE
Add ValidTimeRange type

### DIFF
--- a/src/common/types/timestamp.rs
+++ b/src/common/types/timestamp.rs
@@ -128,6 +128,36 @@ impl Display for TimestampTooLarge {
 
 impl Error for TimestampTooLarge {}
 
+/// Represents a `(valid_after, valid_before)` pair as seen in ERC-4337 validity
+/// checks. A `valid_until` of zero means that there is no bound on end time.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ValidTimeRange {
+    pub valid_after: Timestamp,
+    pub valid_until: Timestamp,
+}
+
+impl ValidTimeRange {
+    pub fn new(valid_after: Timestamp, valid_until: Timestamp) -> Self {
+        Self {
+            valid_after,
+            valid_until,
+        }
+    }
+
+    /// A time range representing that the operation is valid for all time.
+    pub fn all_time() -> Self {
+        Self::default()
+    }
+
+    /// Returns true if the given timestamp falls within this time range,
+    /// including a minimum buffer time that must be remaining before the time
+    /// range expires.
+    pub fn contains(self, timestamp: Timestamp, buffer: Duration) -> bool {
+        self.valid_after <= timestamp
+            && (self.valid_until == Timestamp::default() || timestamp + buffer < self.valid_until)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/op_pool/mempool/mod.rs
+++ b/src/op_pool/mempool/mod.rs
@@ -6,7 +6,7 @@ use ethers::types::{Address, H256, U256};
 use std::sync::Arc;
 use strum::IntoEnumIterator;
 
-use crate::common::types::Timestamp;
+use crate::common::types::ValidTimeRange;
 use crate::common::{
     protos::op_pool::Reputation,
     types::{Entity, UserOperation},
@@ -87,8 +87,7 @@ pub struct ExpectedStorageSlot {
 pub struct PoolOperation {
     pub uo: UserOperation,
     pub aggregator: Option<Address>,
-    pub valid_after: Timestamp,
-    pub valid_until: Timestamp,
+    pub valid_time_range: ValidTimeRange,
     pub expected_code_hash: H256,
     pub entities_needing_stake: Vec<Entity>,
     pub expected_storage_slots: Vec<ExpectedStorageSlot>,
@@ -138,8 +137,7 @@ mod tests {
                 ..Default::default()
             },
             aggregator: Some(aggregator),
-            valid_after: Timestamp::new(0),
-            valid_until: Timestamp::new(0),
+            valid_time_range: ValidTimeRange::all_time(),
             expected_code_hash: H256::random(),
             entities_needing_stake: vec![Entity::Sender, Entity::Aggregator],
             expected_storage_slots: vec![],


### PR DESCRIPTION
Create a new type, `ValidTimeRange`, which represents the `(valid_after, valid_before)` pairs returned by wallets and paymasters. This helps ensure we use the correct range-checking logic each time we use this, including the easy-to-miss rule that a `valid_before` of zero means that the end time is not bounded.