### PR TITLE
Aggregator validation setup

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,6 +20,7 @@ fn generate_contract_bindings() -> Result<(), Box<dyn error::Error>> {
     generate_abis()?;
     MultiAbigen::from_abigens([
         abigen_of("EntryPoint")?,
+        abigen_of("IAggregator")?,
         abigen_of("GetCodeHashes")?,
         abigen_of("SimpleAccount")?,
         abigen_of("SimpleAccountFactory")?,

--- a/contracts/src/imports.sol
+++ b/contracts/src/imports.sol
@@ -7,3 +7,4 @@ import "account-abstraction/samples/SimpleAccount.sol";
 import "account-abstraction/samples/SimpleAccountFactory.sol";
 import "account-abstraction/samples/VerifyingPaymaster.sol";
 import "account-abstraction/core/EntryPoint.sol";
+import "account-abstraction/interfaces/IAggregator.sol";


### PR DESCRIPTION
Makes `IAggregator` accessible in Rust, and checks aggregator stake. Also as an optimization, don't ask Geth nodes to compute code hashes if the operation has other violations.