### PR TITLE
Introduce CheapClone trait

### DIFF
--- a/src/cli/bundler.rs
+++ b/src/cli/bundler.rs
@@ -8,6 +8,7 @@ use tracing::{error, info};
 
 use crate::builder;
 use crate::common::server::format_server_addr;
+use crate::common::types::CheapClone;
 use crate::op_pool;
 use crate::rpc;
 
@@ -44,14 +45,14 @@ pub async fn run(bundler_args: BundlerCliArgs, common_args: CommonArgs) -> anyho
     let pool_handle = tokio::spawn(op_pool::run(
         pool_args.to_args(&common_args)?,
         shutdown_tx.subscribe(),
-        shutdown_scope.clone(),
+        shutdown_scope.cheap_clone(),
     ));
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let builder_handle = tokio::spawn(builder::run(
         builder_args.to_args(&common_args, pool_url.clone())?,
         shutdown_tx.subscribe(),
-        shutdown_scope.clone(),
+        shutdown_scope.cheap_clone(),
     ));
     tokio::time::sleep(Duration::from_millis(100)).await;
 

--- a/src/common/simulation.rs
+++ b/src/common/simulation.rs
@@ -1,7 +1,7 @@
 use crate::common::contracts::entry_point::{EntryPoint, FailedOp};
 use crate::common::tracer::{AssociatedSlotsByAddress, SlotAccess, StorageAccess, TracerOutput};
 use crate::common::types::{
-    ExpectedStorageSlot, StakeInfo, UserOperation, ValidTimeRange, ValidationOutput,
+    CheapClone, ExpectedStorageSlot, StakeInfo, UserOperation, ValidTimeRange, ValidationOutput,
     ValidationReturnInfo,
 };
 use crate::common::{eth, tracer};
@@ -62,7 +62,7 @@ impl SimulatorImpl {
         entry_point_address: Address,
         min_stake_value: U256,
     ) -> Self {
-        let entry_point = EntryPoint::new(entry_point_address, provider.clone());
+        let entry_point = EntryPoint::new(entry_point_address, provider.cheap_clone());
         Self {
             provider,
             entry_point,
@@ -156,7 +156,7 @@ impl Simulator for SimulatorImpl {
                 continue;
             };
             for opcode in &phase.forbidden_opcodes_used {
-                violations.push(Violation::UsedForbiddenOpcode(entity, opcode.clone()));
+                violations.push(Violation::UsedForbiddenOpcode(entity, opcode.cheap_clone()));
             }
             if phase.used_invalid_gas_opcode {
                 violations.push(Violation::InvalidGasOpcode(entity));

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -1,7 +1,9 @@
+mod cheap_clone;
 mod timestamp;
 mod validation_results;
 
 pub use crate::common::contracts::shared_types::UserOperation;
+pub use cheap_clone::*;
 use strum::EnumIter;
 pub use timestamp::*;
 pub use validation_results::*;

--- a/src/common/types/cheap_clone.rs
+++ b/src/common/types/cheap_clone.rs
@@ -1,0 +1,33 @@
+use crate::common::protos::op_pool::op_pool_client::OpPoolClient;
+use crate::common::types::UserOperation;
+use ethers::types::{Bytes, OpCode};
+use std::rc::Rc;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+/// Represents types whose `Clone` implementation does not allocate. Allows
+/// calling `.cheap_clone()` instead of `.clone()`, which does the same thing
+/// but is visually clear that the operation is not expensive, and makes it
+/// impossible to accidentally switch to an expensive clone during refactors.
+pub trait CheapClone: Clone {
+    fn cheap_clone(&self) -> Self {
+        self.clone()
+    }
+}
+
+impl<T> CheapClone for Rc<T> {}
+
+impl<T> CheapClone for Arc<T> {}
+
+impl CheapClone for Bytes {}
+
+impl<T> CheapClone for mpsc::Sender<T> {}
+
+impl CheapClone for UserOperation {}
+
+impl CheapClone for OpCode {}
+
+// This one does actually allocate, but it's still an "intended" clone that's
+// cheap for its purpose.
+// See: https://docs.rs/tonic/latest/tonic/client/index.html#concurrent-usage
+impl<T: Clone> CheapClone for OpPoolClient<T> {}

--- a/src/op_pool/events.rs
+++ b/src/op_pool/events.rs
@@ -9,6 +9,7 @@ use tokio::sync::broadcast;
 use tracing::{debug, error, info};
 
 use crate::common::contracts::entry_point::{EntryPoint, EntryPointEvents};
+use crate::common::types::CheapClone;
 
 /// Event when a new block is mined.
 #[derive(Debug)]
@@ -44,7 +45,7 @@ impl EventListener {
                 // TODO: revisit a safe default for production
                 .interval(Duration::from_millis(100)),
         );
-        let entry_point = EntryPoint::new(entry_point, provider.clone());
+        let entry_point = EntryPoint::new(entry_point, provider.cheap_clone());
         Ok(Self {
             provider,
             entry_point,

--- a/src/rpc/debug.rs
+++ b/src/rpc/debug.rs
@@ -1,16 +1,15 @@
-use ethers::types::{Address, H256};
-use jsonrpsee::core::{Error as RpcError, RpcResult};
-use jsonrpsee::proc_macros::rpc;
-use tonic::async_trait;
-use tonic::transport::Channel;
-
 use super::RpcReputation;
 use crate::common::protos;
 use crate::common::protos::op_pool::{
     op_pool_client, DebugClearStateRequest, DebugDumpMempoolRequest, DebugDumpReputationRequest,
     DebugSetReputationRequest,
 };
-use crate::common::types::UserOperation;
+use crate::common::types::{CheapClone, UserOperation};
+use ethers::types::{Address, H256};
+use jsonrpsee::core::{Error as RpcError, RpcResult};
+use jsonrpsee::proc_macros::rpc;
+use tonic::async_trait;
+use tonic::transport::Channel;
 
 /// Debug API
 #[rpc(server, namespace = "debug")]
@@ -55,7 +54,7 @@ impl DebugApiServer for DebugApi {
             .op_pool_client
             // https://docs.rs/tonic/latest/tonic/client/index.html#concurrent-usage
             // solution to using in concurrent context is to clone
-            .clone()
+            .cheap_clone()
             .debug_clear_state(DebugClearStateRequest {})
             .await
             .map_err(|e| RpcError::Custom(e.to_string()))?;
@@ -66,7 +65,7 @@ impl DebugApiServer for DebugApi {
     async fn bundler_dump_mempool(&self, entry_point: Address) -> RpcResult<Vec<UserOperation>> {
         let response = self
             .op_pool_client
-            .clone()
+            .cheap_clone()
             .debug_dump_mempool(DebugDumpMempoolRequest {
                 entry_point: entry_point.to_fixed_bytes().into(),
             })
@@ -99,7 +98,7 @@ impl DebugApiServer for DebugApi {
     ) -> RpcResult<String> {
         let _ = self
             .op_pool_client
-            .clone()
+            .cheap_clone()
             .debug_set_reputation(DebugSetReputationRequest {
                 entry_point: entry_point.to_fixed_bytes().into(),
                 reputations: reputations.into_iter().map(Into::into).collect(),
@@ -112,7 +111,7 @@ impl DebugApiServer for DebugApi {
     async fn bundler_dump_reputation(&self, entry_point: Address) -> RpcResult<Vec<RpcReputation>> {
         let result = self
             .op_pool_client
-            .clone()
+            .cheap_clone()
             .debug_dump_reputation(DebugDumpReputationRequest {
                 entry_point: entry_point.to_fixed_bytes().into(),
             })

--- a/src/rpc/eth/mod.rs
+++ b/src/rpc/eth/mod.rs
@@ -1,5 +1,6 @@
 mod error;
 
+use crate::common::types::CheapClone;
 use crate::common::{
     contracts::entry_point::{
         EntryPoint, EntryPointCalls, EntryPointErrors, UserOperationEventFilter,

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -14,6 +14,7 @@ use ethers::types::{Address, Bytes, Log, TransactionReceipt, H256, U256};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use strum;
 
+use crate::common::types::CheapClone;
 pub use run::*;
 
 /// API namespace
@@ -76,11 +77,7 @@ pub struct UserOperationOptionalGas {
     signature: Bytes,
 }
 
-impl UserOperationOptionalGas {
-    pub fn cheap_clone(&self) -> Self {
-        self.clone()
-    }
-}
+impl CheapClone for UserOperationOptionalGas {}
 
 /// Gas overheads for user operations
 /// used in calculating the pre-verification gas

--- a/src/rpc/run.rs
+++ b/src/rpc/run.rs
@@ -12,6 +12,7 @@ use tokio::sync::mpsc;
 
 use crate::common::protos::op_pool::op_pool_client;
 use crate::common::server::format_socket_addr;
+use crate::common::types::CheapClone;
 use crate::rpc::debug::{DebugApi, DebugApiServer};
 use crate::rpc::eth::{EthApi, EthApiServer};
 
@@ -53,7 +54,12 @@ pub async fn run(
     for api in args.api_namespaces {
         match api {
             ApiNamespace::Eth => module.merge(
-                EthApi::new(provider.clone(), vec![args.entry_point], args.chain_id).into_rpc(),
+                EthApi::new(
+                    provider.cheap_clone(),
+                    vec![args.entry_point],
+                    args.chain_id,
+                )
+                .into_rpc(),
             )?,
             ApiNamespace::Debug => module.merge(
                 DebugApi::new(op_pool_client::OpPoolClient::connect(args.pool_url.clone()).await?)


### PR DESCRIPTION
Adds a trait to types which clone without allocation, giving them a method `cheap_clone()` to visually distinguish between other clone operations that are potentially more expensive.

This commit does not replace `Arc::clone(&x)` with `x.cheap_clone()`, even though it could, because the `Arc::clone` version is about the same amount of typing and IMO conveys useful information.