### PR TITLE
Allow EntryPoint to make arbitrary accesses

### DIFF
--- a/src/bin/get_example_ops.rs
+++ b/src/bin/get_example_ops.rs
@@ -10,14 +10,12 @@ async fn main() -> anyhow::Result<()> {
         .new_wallet_op(clients.entry_point.add_stake(1), 1.into())
         .await?;
     println!("User operation to make wallet call EntryPoint#addStake():");
-    println!();
-    println!("{}", serde_json::to_string_pretty(&op)?);
+    println!("{}", serde_json::to_string(&op)?);
     let op = clients
         .new_wallet_op_with_paymaster(clients.entry_point.add_stake(1), 1.into())
         .await?;
     println!();
     println!("User operation to make wallet call EntryPoint#addStake() with paymaster:");
-    println!();
-    println!("{}", serde_json::to_string_pretty(&op)?);
+    println!("{}", serde_json::to_string(&op)?);
     Ok(())
 }

--- a/src/common/tracer.rs
+++ b/src/common/tracer.rs
@@ -17,6 +17,7 @@ pub struct TracerOutput {
     pub accessed_contract_addresses: Vec<Address>,
     pub associated_slots_by_address: AssociatedSlotsByAddress,
     pub factory_called_create2_twice: bool,
+    pub expected_storage: Vec<ExpectedStorage>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -35,14 +36,21 @@ pub struct Phase {
 #[serde(rename_all = "camelCase")]
 pub struct StorageAccess {
     pub address: Address,
-    pub accesses: Vec<SlotAccess>,
+    pub slots: Vec<U256>,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SlotAccess {
+pub struct ExpectedStorage {
+    pub address: Address,
+    pub slots: Vec<ExpectedSlot>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExpectedSlot {
     pub slot: U256,
-    pub initial_value: Option<U256>,
+    pub value: U256,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Accesses made by the entry point (at the top-level) should not count against the operation when calculating violations.

To implemente this, refactor the tracer return format a little bit, since we still need to keep track of entry point accesses to compute expected values for conditional transactions, but we no longer want them to count for violations.