### PR TITLE
Fix build.rs always rerunning

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -53,7 +53,7 @@ fn generate_protos() -> Result<(), Box<dyn error::Error>> {
         .compile(&["proto/op_pool.proto"], &["proto"])?;
     tonic_build::configure()
         .file_descriptor_set_path(out_dir.join("builder_descriptor.bin"))
-        .compile(&["proto/builder.proto"], &["builder"])?;
+        .compile(&["proto/builder.proto"], &["proto"])?;
     Ok(())
 }
 


### PR DESCRIPTION
A typo in `build.rs` was causing it to re-run on every build instead of only when the files it depends on change.

My guess for why this happens: Tonic's build script emits a "rerun-if-changed" for its "includes" directory. Here the "includes" directory was set to "builder" which doesn't exist, and emitting "rerun-if-changed" for a nonexistent file causes it to rerun every time.