### PR TITLE
test: fix the op_code_banning test related to factory calling create2 twice (97/122 passing)

### DIFF
--- a/src/common/simulation.rs
+++ b/src/common/simulation.rs
@@ -160,7 +160,10 @@ impl Simulator for SimulatorImpl {
                 continue;
             };
             for opcode in &phase.forbidden_opcodes_used {
-                violations.push(Violation::UsedForbiddenOpcode(entity, opcode.clone()));
+                violations.push(Violation::UsedForbiddenOpcode(
+                    entity,
+                    ViolationOpCode(opcode.clone()),
+                ));
             }
             if phase.used_invalid_gas_opcode {
                 violations.push(Violation::InvalidGasOpcode(entity));
@@ -321,24 +324,28 @@ impl Display for SimulationError {
     }
 }
 
-#[derive(Clone, Debug, parse_display::Display)]
+#[derive(Clone, Debug, parse_display::Display, Ord, Eq, PartialOrd, PartialEq)]
 pub enum Violation {
-    #[display("reverted while simulating {0} validation")]
-    UnintendedRevert(Entity),
+    // Make sure to maintain the order here based on the importance
+    // of the violation for converting to an JRPC error
     #[display("reverted while simulating {0} validation: {1}")]
     UnintendedRevertWithMessage(Entity, String, Option<Address>),
-    #[display("simulateValidation did not revert. Make sure your EntryPoint is valid")]
-    DidNotRevert,
-    #[display("simulateValidation should have 3 parts but had {0} instead. Make sure your EntryPoint is valid")]
-    WrongNumberOfPhases(u32),
-    #[display("{0} uses banned opcode: {1:?}")]
-    UsedForbiddenOpcode(Entity, OpCode),
+    #[display("{0} uses banned opcode: {1}")]
+    UsedForbiddenOpcode(Entity, ViolationOpCode),
     #[display("{0} uses banned opcode: GAS")]
     InvalidGasOpcode(Entity),
+    #[display("factory may only call CREATE2 once during initialization")]
+    FactoryCalledCreate2Twice,
     #[display("{0} accessed forbidden storage at address {1:?} during validation")]
     InvalidStorageAccess(Entity, Address),
     #[display("{0} must be staked")]
     NotStaked(Entity, Address, U256, U256),
+    #[display("reverted while simulating {0} validation")]
+    UnintendedRevert(Entity),
+    #[display("simulateValidation did not revert. Make sure your EntryPoint is valid")]
+    DidNotRevert,
+    #[display("simulateValidation should have 3 parts but had {0} instead. Make sure your EntryPoint is valid")]
+    WrongNumberOfPhases(u32),
     #[display("{0} must not send ETH during validation (except to entry point)")]
     CallHadValue(Entity),
     #[display("ran out of gas during {0} validation")]
@@ -351,8 +358,25 @@ pub enum Violation {
     CalledHandleOps(Entity),
     #[display("code accessed by validation has changed since the last time validation was run")]
     CodeHashChanged,
-    #[display("factory may only call CREATE2 once during initialization")]
-    FactoryCalledCreate2Twice,
+}
+
+#[derive(Debug, PartialEq, Clone, parse_display::Display, Eq)]
+#[display("{0:?}")]
+pub struct ViolationOpCode(pub OpCode);
+
+impl PartialOrd for ViolationOpCode {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ViolationOpCode {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let left = self.0.clone() as i32;
+        let right = other.0.clone() as i32;
+
+        left.cmp(&right)
+    }
 }
 
 impl Entity {

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -97,7 +97,7 @@ pub struct ExpectedStorageSlot {
     pub value: U256,
 }
 
-#[derive(Display, Debug, Clone, Copy, Eq, PartialEq, EnumIter)]
+#[derive(Display, Debug, Clone, Ord, Copy, Eq, PartialEq, EnumIter, PartialOrd)]
 #[display(style = "lowercase")]
 pub enum Entity {
     Account,

--- a/src/rpc/eth/error.rs
+++ b/src/rpc/eth/error.rs
@@ -119,6 +119,7 @@ pub struct StakeTooLowData {
     paymaster: Option<Address>,
     aggregator: Option<Address>,
     factory: Option<Address>,
+    account: Option<Address>,
     minimum_stake: U256,
     minimum_unstake_delay: U256,
 }
@@ -129,6 +130,7 @@ impl StakeTooLowData {
             paymaster: Some(paymaster),
             aggregator: None,
             factory: None,
+            account: None,
             minimum_stake,
             minimum_unstake_delay,
         }
@@ -143,6 +145,7 @@ impl StakeTooLowData {
             paymaster: None,
             aggregator: Some(aggregator),
             factory: None,
+            account: None,
             minimum_stake,
             minimum_unstake_delay,
         }
@@ -153,6 +156,18 @@ impl StakeTooLowData {
             paymaster: None,
             aggregator: None,
             factory: Some(factory),
+            account: None,
+            minimum_stake,
+            minimum_unstake_delay,
+        }
+    }
+
+    pub fn account(account: Address, minimum_stake: U256, minimum_unstake_delay: U256) -> Self {
+        Self {
+            paymaster: None,
+            aggregator: None,
+            factory: None,
+            account: Some(account),
             minimum_stake,
             minimum_unstake_delay,
         }


### PR DESCRIPTION
# This Diff
Adds Ord and PartialOrd to the violations which allows us to sort by the order in which the enum values are defined. This way, we can just sort the violations and then take the first one and match on that when returning an EthRpcError

# Test
<img width="1520" alt="image" src="https://user-images.githubusercontent.com/4642570/227307359-9e46c0bb-43ec-4ec0-9960-70dda2f03fb3.png">
