### PR TITLE
Nightly rustfmt

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+echo 'Running rustfmt in pre-commit hook'
+
+cargo +nightly fmt --version &>/dev/null || {
+  echo >&2 'Nightly rustfmt is required for pre-commit hook. Try running "rustup toolchain add nightly"'
+  exit 1
+}
+
+# Format all the files, then `git add` any Rust files which were staged and had
+# no staged changes.
+
+git_short_status=$(git status -s | grep '\.rs$')
+files_to_git_add=$(echo "$git_short_status" | grep '^[^ ] ' | awk '{ print $NF }')
+files_with_unstaged_changes=$(echo "$git_short_status" | grep '^[^ ][^ ]' | awk '{ print $NF }')
+
+cargo +nightly fmt --all || {
+  echo >&2 'Formatting failed. This most likely means you have syntax errors'
+  exit 1
+}
+
+declare -a file_array=()
+for file in $files_to_git_add; do
+  file_array+=("${file}")
+done
+if [ ${#file_array[@]} -ne 0 ]; then
+  git add "${file_array[@]}"
+fi
+
+for file in $files_with_unstaged_changes; do
+  echo "Formatting hook skipped adding file with uncommitted changes: ${file}"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,14 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-      - name: Install deps
+      - name: Install protobuf
         run: sudo apt-get -y install protobuf-compiler
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: clippy
+      - name: Install toolchain (nightly)
+        run: rustup toolchain add nightly --component rustfmt --profile minimal
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -45,12 +47,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-      - name: cargo fmt
+      - name: cargo +nightly fmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
+          toolchain: nightly
           args: --all --check
-
       - name: cargo clippy
         uses: actions-rs/clippy-check@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,11 @@
 .vscode
 
 # Foundry, configured in foundry.toml
-/contracts/cache/
-/contracts/out/
+contracts/cache/
+contracts/out/
 
 # Generated contract bindings, created in build.rs
-/src/common/contracts
+src/common/contracts/
 
 .env
 *.log

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,3 @@
+group_imports = "StdExternalCrate"
+ignore = ["src/common/contracts/"] # Generated files
+imports_granularity = "Crate"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Alchemy Bundler (working name)
 
+## Development
+
+### Getting started
+
+Make sure nightly Rust is installed to get nightly rustfmt:
+```
+rustup toolchain add nightly
+```
+Enable githooks to automatically run rustfmt on commit. Or don't, but then
+you'll need to run `cargo +nightly fmt` yourself before you can merge.
+```
+git config core.hooksPath .githooks
+```
+
 ### Build & Test
 
 Prerequisites:

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,6 @@
+use std::{env, error, io::ErrorKind, path::PathBuf, process::Command};
+
 use ethers::contract::{Abigen, MultiAbigen};
-use std::io::ErrorKind;
-use std::path::PathBuf;
-use std::process::Command;
-use std::{env, error};
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     println!("cargo:rerun-if-changed=contracts/lib");

--- a/src/bin/deploy_dev_contracts.rs
+++ b/src/bin/deploy_dev_contracts.rs
@@ -1,6 +1,6 @@
-use alchemy_bundler::common::dev;
-use alchemy_bundler::common::dev::{
-    DevAddresses, BUNDLER_ACCOUNT_ID, PAYMASTER_SIGNER_ACCOUNT_ID, WALLET_OWNER_ACCOUNT_ID,
+use alchemy_bundler::common::{
+    dev,
+    dev::{DevAddresses, BUNDLER_ACCOUNT_ID, PAYMASTER_SIGNER_ACCOUNT_ID, WALLET_OWNER_ACCOUNT_ID},
 };
 use ethers::utils::hex;
 

--- a/src/bin/send_ops.rs
+++ b/src/bin/send_ops.rs
@@ -1,5 +1,4 @@
-use alchemy_bundler::common::dev::DevClients;
-use alchemy_bundler::common::eth;
+use alchemy_bundler::common::{dev::DevClients, eth};
 use dotenv::dotenv;
 
 #[tokio::main]

--- a/src/builder/run.rs
+++ b/src/builder/run.rs
@@ -1,11 +1,14 @@
-use crate::builder::server::BuilderImpl;
-use crate::common::protos::builder::builder_server::BuilderServer;
-use crate::common::protos::builder::BUILDER_FILE_DESCRIPTOR_SET;
-use crate::common::server::format_socket_addr;
 use anyhow::Context;
-use tokio::sync::broadcast;
-use tokio::sync::mpsc;
+use tokio::sync::{broadcast, mpsc};
 use tonic::transport::Server;
+
+use crate::{
+    builder::server::BuilderImpl,
+    common::{
+        protos::builder::{builder_server::BuilderServer, BUILDER_FILE_DESCRIPTOR_SET},
+        server::format_socket_addr,
+    },
+};
 
 #[derive(Debug)]
 pub struct Args {

--- a/src/builder/server.rs
+++ b/src/builder/server.rs
@@ -1,8 +1,9 @@
+use tonic::{async_trait, Request, Response, Result};
+
 use crate::common::protos::builder::{
     builder_server::Builder, DebugSendBundleNowRequest, DebugSendBundleNowResponse,
     DebugSetBundlingModeRequest, DebugSetBundlingModeResponse,
 };
-use tonic::{async_trait, Request, Response, Result};
 
 pub struct BuilderImpl {}
 

--- a/src/cli/builder.rs
+++ b/src/cli/builder.rs
@@ -1,11 +1,13 @@
 use anyhow::bail;
 use clap::Args;
-use tokio::{signal, sync::broadcast, sync::mpsc};
+use tokio::{
+    signal,
+    sync::{broadcast, mpsc},
+};
 use tracing::{error, info};
 
-use crate::{builder, common::server::format_server_addr};
-
 use super::CommonArgs;
+use crate::{builder, common::server::format_server_addr};
 
 /// CLI options for the builder
 #[derive(Args, Debug)]

--- a/src/cli/bundler.rs
+++ b/src/cli/bundler.rs
@@ -2,16 +2,14 @@ use std::time::Duration;
 
 use anyhow::bail;
 use clap::Args;
-use tokio::signal;
-use tokio::sync::{broadcast, mpsc};
+use tokio::{
+    signal,
+    sync::{broadcast, mpsc},
+};
 use tracing::{error, info};
 
-use crate::builder;
-use crate::common::server::format_server_addr;
-use crate::op_pool;
-use crate::rpc;
-
 use super::{builder::BuilderArgs, pool::PoolArgs, rpc::RpcArgs, CommonArgs};
+use crate::{builder, common::server::format_server_addr, op_pool, rpc};
 
 #[derive(Debug, Args)]
 pub struct BundlerCliArgs {

--- a/src/cli/pool.rs
+++ b/src/cli/pool.rs
@@ -1,11 +1,13 @@
 use anyhow::{bail, Context};
 use clap::Args;
-use tokio::{signal, sync::broadcast, sync::mpsc};
+use tokio::{
+    signal,
+    sync::{broadcast, mpsc},
+};
 use tracing::{error, info};
 
-use crate::op_pool::{self, PoolConfig};
-
 use super::CommonArgs;
+use crate::op_pool::{self, PoolConfig};
 
 /// CLI options for the OP Pool
 #[derive(Args, Debug)]

--- a/src/cli/prometheus_exporter.rs
+++ b/src/cli/prometheus_exporter.rs
@@ -1,6 +1,7 @@
+use std::net::SocketAddr;
+
 use metrics_exporter_prometheus::PrometheusBuilder;
 use metrics_util::layers::{PrefixLayer, Stack};
-use std::net::SocketAddr;
 
 pub fn initialize(listen_addr: SocketAddr) -> anyhow::Result<()> {
     let (recorder, exporter) = PrometheusBuilder::new()

--- a/src/cli/rpc.rs
+++ b/src/cli/rpc.rs
@@ -1,11 +1,13 @@
 use anyhow::{bail, Context};
 use clap::Args;
-use tokio::{signal, sync::broadcast, sync::mpsc};
+use tokio::{
+    signal,
+    sync::{broadcast, mpsc},
+};
 use tracing::{error, info};
 
-use crate::{common::simulation, rpc};
-
 use super::CommonArgs;
+use crate::{common::simulation, rpc};
 
 /// CLI options for the RPC server
 #[derive(Args, Debug)]

--- a/src/common/dev.rs
+++ b/src/common/dev.rs
@@ -1,22 +1,25 @@
-use crate::common::contracts::entry_point::EntryPoint;
-use crate::common::contracts::simple_account::SimpleAccount;
-use crate::common::contracts::simple_account_factory::SimpleAccountFactory;
-use crate::common::contracts::verifying_paymaster::VerifyingPaymaster;
-use crate::common::eth;
-use crate::common::types::UserOperation;
+use std::{env, io::Write, sync::Arc, time::Duration};
+
 use anyhow::Context;
-use ethers::abi::AbiEncode;
-use ethers::contract::builders::ContractCall;
-use ethers::core::k256::ecdsa::SigningKey;
-use ethers::middleware::SignerMiddleware;
-use ethers::providers::{Http, Middleware, Provider};
-use ethers::signers::{LocalWallet, Signer};
-use ethers::types::{Address, Bytes, TransactionRequest, U256};
-use ethers::utils;
-use std::env;
-use std::io::Write;
-use std::sync::Arc;
-use std::time::Duration;
+use ethers::{
+    abi::AbiEncode,
+    contract::builders::ContractCall,
+    core::k256::ecdsa::SigningKey,
+    middleware::SignerMiddleware,
+    providers::{Http, Middleware, Provider},
+    signers::{LocalWallet, Signer},
+    types::{Address, Bytes, TransactionRequest, U256},
+    utils,
+};
+
+use crate::common::{
+    contracts::{
+        entry_point::EntryPoint, simple_account::SimpleAccount,
+        simple_account_factory::SimpleAccountFactory, verifying_paymaster::VerifyingPaymaster,
+    },
+    eth,
+    types::UserOperation,
+};
 
 pub const DEV_CHAIN_ID: u64 = 1337;
 pub const DEPLOYER_ACCOUNT_ID: u8 = 1;

--- a/src/common/eth.rs
+++ b/src/common/eth.rs
@@ -1,19 +1,18 @@
-use crate::common::contracts::get_code_hashes::{CodeHashesResult, GETCODEHASHES_BYTECODE};
+use std::{error, future::Future, mem, ops::Deref, sync::Arc};
+
 use anyhow::Context;
-use ethers::abi::{AbiDecode, AbiEncode, RawLog};
-use ethers::contract::builders::ContractCall;
-use ethers::contract::{Contract, ContractDeployer, ContractError};
-use ethers::providers::{
-    Http, HttpClientError, JsonRpcClient, Middleware, PendingTransaction, Provider, ProviderError,
-};
-use ethers::types::{
-    Address, BlockId, Bytes, Eip1559TransactionRequest, Log, TransactionReceipt, H256,
+use ethers::{
+    abi::{AbiDecode, AbiEncode, RawLog},
+    contract::{builders::ContractCall, Contract, ContractDeployer, ContractError},
+    providers::{
+        Http, HttpClientError, JsonRpcClient, Middleware, PendingTransaction, Provider,
+        ProviderError,
+    },
+    types::{Address, BlockId, Bytes, Eip1559TransactionRequest, Log, TransactionReceipt, H256},
 };
 use serde_json::Value;
-use std::future::Future;
-use std::ops::Deref;
-use std::sync::Arc;
-use std::{error, mem};
+
+use crate::common::contracts::get_code_hashes::{CodeHashesResult, GETCODEHASHES_BYTECODE};
 
 /// Waits for a pending transaction to be mined, providing appropriate error
 /// messages for each point of failure.

--- a/src/common/protos.rs
+++ b/src/common/protos.rs
@@ -1,8 +1,10 @@
-use crate::common::types::BundlingMode as RpcBundlingMode;
-use crate::common::types::Entity as EntityType;
-use crate::common::types::UserOperation as RpcUserOperation;
-use ethers::types::{Address, Bytes, H256, U256};
 use std::mem;
+
+use ethers::types::{Address, Bytes, H256, U256};
+
+use crate::common::types::{
+    BundlingMode as RpcBundlingMode, Entity as EntityType, UserOperation as RpcUserOperation,
+};
 
 pub mod op_pool {
     use super::*;

--- a/src/common/simulation.rs
+++ b/src/common/simulation.rs
@@ -1,22 +1,30 @@
-use super::types::Entity;
-use crate::common::contracts::entry_point::{EntryPoint, FailedOp};
-use crate::common::tracer::{
-    AssociatedSlotsByAddress, ExpectedSlot, ExpectedStorage, StorageAccess, TracerOutput,
+use std::{
+    collections::HashSet,
+    fmt::{Debug, Display, Formatter},
+    mem,
+    sync::Arc,
 };
-use crate::common::types::{
-    ExpectedStorageSlot, StakeInfo, UserOperation, ValidTimeRange, ValidationOutput,
-    ValidationReturnInfo,
+
+use ethers::{
+    abi::AbiDecode,
+    providers::{Http, Provider},
+    types::{Address, BlockId, BlockNumber, OpCode, H256, U256},
 };
-use crate::common::{eth, tracer};
-use ethers::abi::AbiDecode;
-use ethers::providers::{Http, Provider};
-use ethers::types::{Address, BlockId, BlockNumber, OpCode, H256, U256};
 use indexmap::IndexSet;
-use std::collections::HashSet;
-use std::fmt::{Debug, Display, Formatter};
-use std::mem;
-use std::sync::Arc;
 use tonic::async_trait;
+
+use super::types::Entity;
+use crate::common::{
+    contracts::entry_point::{EntryPoint, FailedOp},
+    eth, tracer,
+    tracer::{
+        AssociatedSlotsByAddress, ExpectedSlot, ExpectedStorage, StorageAccess, TracerOutput,
+    },
+    types::{
+        ExpectedStorageSlot, StakeInfo, UserOperation, ValidTimeRange, ValidationOutput,
+        ValidationReturnInfo,
+    },
+};
 
 #[derive(Clone, Debug)]
 pub struct SimulationSuccess {

--- a/src/common/tracer.rs
+++ b/src/common/tracer.rs
@@ -1,13 +1,16 @@
-use crate::common::contracts::entry_point::EntryPoint;
-use crate::common::types::UserOperation;
+use std::{
+    collections::{BTreeSet, HashMap},
+    fmt::Debug,
+};
+
 use anyhow::Context;
-use ethers::providers::{JsonRpcClient, Middleware, Provider};
-use ethers::types::transaction::eip2718::TypedTransaction;
-use ethers::types::{Address, BlockId, OpCode, U256};
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
-use std::collections::{BTreeSet, HashMap};
-use std::fmt::Debug;
+use ethers::{
+    providers::{JsonRpcClient, Middleware, Provider},
+    types::{transaction::eip2718::TypedTransaction, Address, BlockId, OpCode, U256},
+};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use crate::common::{contracts::entry_point::EntryPoint, types::UserOperation};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -3,19 +3,19 @@ mod validation_results;
 
 use std::str::FromStr;
 
-pub use crate::common::contracts::shared_types::UserOperation;
 use anyhow::bail;
-use serde::{Deserialize, Serialize};
-use strum::EnumIter;
-pub use timestamp::*;
-pub use validation_results::*;
-
 use ethers::{
     abi::{encode, AbiEncode, Token},
     types::{Address, Bytes, H256, U256},
     utils::keccak256,
 };
 use parse_display::Display;
+use serde::{Deserialize, Serialize};
+use strum::EnumIter;
+pub use timestamp::*;
+pub use validation_results::*;
+
+pub use crate::common::contracts::shared_types::UserOperation;
 
 /// Unique identifier for a user operation from a given sender
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/src/common/types/timestamp.rs
+++ b/src/common/types/timestamp.rs
@@ -1,11 +1,14 @@
+use std::{
+    error::Error,
+    fmt,
+    fmt::{Debug, Display, Formatter},
+    ops::{Add, AddAssign, Sub, SubAssign},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
 use chrono::{DateTime, LocalResult, TimeZone, Utc};
 use ethers::types::U64;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::error::Error;
-use std::fmt;
-use std::fmt::{Debug, Display, Formatter};
-use std::ops::{Add, AddAssign, Sub, SubAssign};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// An on-chain timestamp expressed as seconds since the epoch, as might be
 /// returned in a block header or in the `valid_before`/`valid_after` bounds in

--- a/src/common/types/validation_results.rs
+++ b/src/common/types/validation_results.rs
@@ -1,8 +1,13 @@
-use crate::common::contracts::entry_point::{ValidationResult, ValidationResultWithAggregation};
-use crate::common::types::Timestamp;
-use ethers::abi;
-use ethers::abi::{AbiDecode, AbiError};
-use ethers::types::{Address, Bytes, U256};
+use ethers::{
+    abi,
+    abi::{AbiDecode, AbiError},
+    types::{Address, Bytes, U256},
+};
+
+use crate::common::{
+    contracts::entry_point::{ValidationResult, ValidationResultWithAggregation},
+    types::Timestamp,
+};
 
 /// Equivalent to the generated `ValidationResult` or
 /// `ValidationResultWithAggregation` from `EntryPoint`, but with named structs

--- a/src/op_pool/events.rs
+++ b/src/op_pool/events.rs
@@ -1,10 +1,11 @@
+use std::{sync::Arc, time::Duration};
+
 use anyhow::Context;
 use ethers::{
     prelude::StreamExt,
     providers::{Middleware, Provider, Ws},
     types::{Address, H256, U256, U64},
 };
-use std::{sync::Arc, time::Duration};
 use tokio::sync::broadcast;
 use tracing::{debug, error, info};
 

--- a/src/op_pool/mempool/mod.rs
+++ b/src/op_pool/mempool/mod.rs
@@ -2,19 +2,17 @@ pub mod error;
 mod pool;
 pub mod uo_pool;
 
-use ethers::types::{Address, H256, U256};
 use std::sync::Arc;
+
+use ethers::types::{Address, H256, U256};
 use strum::IntoEnumIterator;
 
-use crate::common::types::ValidTimeRange;
+use self::error::MempoolResult;
+use super::events::NewBlockEvent;
 use crate::common::{
     protos::op_pool::Reputation,
-    types::{Entity, UserOperation},
+    types::{Entity, UserOperation, ValidTimeRange},
 };
-
-use self::error::MempoolResult;
-
-use super::events::NewBlockEvent;
 
 /// In-memory operation pool
 pub trait Mempool: Send + Sync {

--- a/src/op_pool/mempool/pool.rs
+++ b/src/op_pool/mempool/pool.rs
@@ -1,15 +1,16 @@
-use crate::common::types::{UserOperation, UserOperationId};
-use ethers::{abi::Address, types::H256};
 use std::{
     cmp::Ordering,
     collections::{hash_map::Entry, BTreeSet, HashMap},
     sync::Arc,
 };
 
+use ethers::{abi::Address, types::H256};
+
 use super::{
     error::{MempoolError, MempoolResult},
     PoolConfig, PoolOperation,
 };
+use crate::common::types::{UserOperation, UserOperationId};
 
 /// Pool of user operations
 #[derive(Debug)]

--- a/src/op_pool/mempool/uo_pool.rs
+++ b/src/op_pool/mempool/uo_pool.rs
@@ -1,3 +1,13 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use ethers::types::{Address, H256};
+use parking_lot::RwLock;
+use strum::IntoEnumIterator;
+use tokio::sync::broadcast;
+
 use super::{
     error::{MempoolError, MempoolResult},
     pool::PoolInner,
@@ -11,14 +21,6 @@ use crate::{
     },
     op_pool::reputation::ReputationManager,
 };
-use ethers::types::{Address, H256};
-use parking_lot::RwLock;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
-use strum::IntoEnumIterator;
-use tokio::sync::broadcast;
 
 /// The number of blocks that a throttled operation is allowed to be in the mempool
 const THROTTLED_OPS_BLOCK_LIMIT: u64 = 10;
@@ -206,10 +208,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::common::protos::op_pool::{Reputation, ReputationStatus};
-    use crate::common::types::UserOperation;
-
     use super::*;
+    use crate::common::{
+        protos::op_pool::{Reputation, ReputationStatus},
+        types::UserOperation,
+    };
 
     #[test]
     fn test_add_single_op() {

--- a/src/op_pool/reputation.rs
+++ b/src/op_pool/reputation.rs
@@ -1,7 +1,7 @@
+use std::{collections::HashMap, time::Duration};
+
 use ethers::types::Address;
 use parking_lot::RwLock;
-use std::collections::HashMap;
-use std::time::Duration;
 use tokio::time::interval;
 
 use crate::common::protos::op_pool::{Reputation, ReputationStatus};

--- a/src/op_pool/run.rs
+++ b/src/op_pool/run.rs
@@ -1,12 +1,5 @@
 use std::sync::Arc;
 
-use crate::common::protos::op_pool::{op_pool_server::OpPoolServer, OP_POOL_FILE_DESCRIPTOR_SET};
-use crate::op_pool::{
-    events::EventListener,
-    mempool::uo_pool::UoPool,
-    reputation::{HourlyMovingAverageReputation, ReputationParams},
-    server::OpPoolImpl,
-};
 use anyhow::bail;
 use tokio::{
     sync::{broadcast, mpsc},
@@ -15,6 +8,15 @@ use tokio::{
 use tonic::transport::Server;
 
 use super::mempool::PoolConfig;
+use crate::{
+    common::protos::op_pool::{op_pool_server::OpPoolServer, OP_POOL_FILE_DESCRIPTOR_SET},
+    op_pool::{
+        events::EventListener,
+        mempool::uo_pool::UoPool,
+        reputation::{HourlyMovingAverageReputation, ReputationParams},
+        server::OpPoolImpl,
+    },
+};
 
 pub struct Args {
     pub port: u16,

--- a/src/op_pool/server.rs
+++ b/src/op_pool/server.rs
@@ -1,22 +1,27 @@
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
-use super::mempool::error::MempoolError;
-use super::mempool::{Mempool, OperationOrigin};
-use super::metrics::OpPoolMetrics;
-use crate::common::protos::op_pool::op_pool_server::OpPool;
-use crate::common::protos::op_pool::{
-    AddOpRequest, AddOpResponse, DebugClearStateRequest, DebugClearStateResponse,
-    DebugDumpMempoolRequest, DebugDumpMempoolResponse, DebugDumpReputationRequest,
-    DebugDumpReputationResponse, DebugSetReputationRequest, DebugSetReputationResponse, ErrorInfo,
-    ErrorReason, GetOpsRequest, GetOpsResponse, GetSupportedEntryPointsRequest,
-    GetSupportedEntryPointsResponse, MempoolOp, RemoveOpsRequest, RemoveOpsResponse,
+use ethers::{
+    types::{Address, H256},
+    utils::hex::ToHex,
 };
-use crate::common::protos::ProtoBytes;
-use ethers::types::{Address, H256};
-use ethers::utils::hex::ToHex;
 use prost::Message;
 use tonic::{async_trait, Code, Request, Response, Result, Status};
+
+use super::{
+    mempool::{error::MempoolError, Mempool, OperationOrigin},
+    metrics::OpPoolMetrics,
+};
+use crate::common::protos::{
+    op_pool::{
+        op_pool_server::OpPool, AddOpRequest, AddOpResponse, DebugClearStateRequest,
+        DebugClearStateResponse, DebugDumpMempoolRequest, DebugDumpMempoolResponse,
+        DebugDumpReputationRequest, DebugDumpReputationResponse, DebugSetReputationRequest,
+        DebugSetReputationResponse, ErrorInfo, ErrorReason, GetOpsRequest, GetOpsResponse,
+        GetSupportedEntryPointsRequest, GetSupportedEntryPointsResponse, MempoolOp,
+        RemoveOpsRequest, RemoveOpsResponse,
+    },
+    ProtoBytes,
+};
 
 pub struct OpPoolImpl<M: Mempool> {
     chain_id: u64,
@@ -260,10 +265,13 @@ mod tests {
     ];
     const TEST_ADDRESS_STR: &str = "0x11aBB05d9Ad318bf65652672B13b1dcB0E6D4a32";
 
-    use crate::common::protos::op_pool::{self, Reputation};
-    use crate::op_pool::events::NewBlockEvent;
-    use crate::op_pool::mempool::error::MempoolResult;
-    use crate::op_pool::mempool::PoolOperation;
+    use crate::{
+        common::protos::op_pool::{self, Reputation},
+        op_pool::{
+            events::NewBlockEvent,
+            mempool::{error::MempoolResult, PoolOperation},
+        },
+    };
 
     #[test]
     fn test_check_entry_point() {

--- a/src/op_pool/types.rs
+++ b/src/op_pool/types.rs
@@ -1,11 +1,14 @@
-use super::mempool::{ExpectedStorageSlot, PoolOperation};
-use crate::common::protos::op_pool::{
-    Entity as ProtoEntity, MempoolOp, StorageSlot, UserOperation,
-};
-use crate::common::protos::{to_le_bytes, ConversionError, ProtoBytes};
-use crate::common::types::ValidTimeRange;
 use anyhow::Context;
 use ethers::types::{Address, H256};
+
+use super::mempool::{ExpectedStorageSlot, PoolOperation};
+use crate::common::{
+    protos::{
+        op_pool::{Entity as ProtoEntity, MempoolOp, StorageSlot, UserOperation},
+        to_le_bytes, ConversionError, ProtoBytes,
+    },
+    types::ValidTimeRange,
+};
 
 impl TryFrom<&PoolOperation> for MempoolOp {
     type Error = anyhow::Error;
@@ -106,12 +109,10 @@ impl From<&ExpectedStorageSlot> for StorageSlot {
 
 #[cfg(test)]
 mod tests {
-    use crate::common::contracts::shared_types;
-    use crate::common::protos::op_pool;
-    use crate::common::types::Timestamp;
     use ethers::types::U256;
 
     use super::*;
+    use crate::common::{contracts::shared_types, protos::op_pool, types::Timestamp};
 
     const TEST_ADDRESS_ARR: [u8; 20] = [
         0x11, 0xAB, 0xB0, 0x5d, 0x9A, 0xd3, 0x18, 0xbf, 0x65, 0x65, 0x26, 0x72, 0xB1, 0x3b, 0x1d,

--- a/src/rpc/debug.rs
+++ b/src/rpc/debug.rs
@@ -1,18 +1,24 @@
-use super::{RpcReputation, RpcUserOperation};
-use crate::common::protos::builder::BundlingMode as ProtoBundlingMode;
-use crate::common::protos::builder::{
-    builder_client, DebugSendBundleNowRequest, DebugSetBundlingModeRequest,
-};
-use crate::common::protos::op_pool::{
-    op_pool_client, DebugClearStateRequest, DebugDumpMempoolRequest, DebugDumpReputationRequest,
-    DebugSetReputationRequest,
-};
-use crate::common::types::{BundlingMode, UserOperation};
 use ethers::types::{Address, H256};
-use jsonrpsee::core::{Error as RpcError, RpcResult};
-use jsonrpsee::proc_macros::rpc;
-use tonic::async_trait;
-use tonic::transport::Channel;
+use jsonrpsee::{
+    core::{Error as RpcError, RpcResult},
+    proc_macros::rpc,
+};
+use tonic::{async_trait, transport::Channel};
+
+use super::{RpcReputation, RpcUserOperation};
+use crate::common::{
+    protos::{
+        builder::{
+            builder_client, BundlingMode as ProtoBundlingMode, DebugSendBundleNowRequest,
+            DebugSetBundlingModeRequest,
+        },
+        op_pool::{
+            op_pool_client, DebugClearStateRequest, DebugDumpMempoolRequest,
+            DebugDumpReputationRequest, DebugSetReputationRequest,
+        },
+    },
+    types::{BundlingMode, UserOperation},
+};
 
 /// Debug API
 #[rpc(server, namespace = "debug")]

--- a/src/rpc/eth/error.rs
+++ b/src/rpc/eth/error.rs
@@ -1,4 +1,3 @@
-use crate::common::types::{Entity, Timestamp};
 use ethers::types::{Address, OpCode, U256};
 use jsonrpsee::{
     core::Error as RpcError,
@@ -8,6 +7,8 @@ use jsonrpsee::{
     },
 };
 use serde::Serialize;
+
+use crate::common::types::{Entity, Timestamp};
 
 // Error codes borrowed from jsonrpsee
 // INVALID_PARAMS_CODE = -32602

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -2,6 +2,15 @@ mod debug;
 mod eth;
 mod run;
 
+use anyhow::bail;
+use ethers::{
+    types::{Address, Bytes, Log, TransactionReceipt, H160, H256, U256},
+    utils::to_checksum,
+};
+pub use run::*;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use strum;
+
 use crate::common::{
     protos::{
         op_pool::{Reputation, ReputationStatus},
@@ -9,15 +18,6 @@ use crate::common::{
     },
     types::UserOperation,
 };
-use anyhow::bail;
-use ethers::{
-    types::{Address, Bytes, Log, TransactionReceipt, H160, H256, U256},
-    utils::to_checksum,
-};
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-use strum;
-
-pub use run::*;
 
 /// API namespace
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::EnumString)]

--- a/src/rpc/run.rs
+++ b/src/rpc/run.rs
@@ -1,23 +1,25 @@
-use std::net::SocketAddr;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::{bail, Context};
-use ethers::providers::{Http, Provider, ProviderExt};
-use ethers::types::{Address, Chain};
-use jsonrpsee::server::ServerBuilder;
-use jsonrpsee::RpcModule;
-use tokio::sync::broadcast;
-use tokio::sync::mpsc;
-
-use crate::common::protos::builder::builder_client;
-use crate::common::protos::op_pool::op_pool_client;
-use crate::common::server::format_socket_addr;
-use crate::common::simulation;
-use crate::rpc::debug::{DebugApi, DebugApiServer};
-use crate::rpc::eth::{EthApi, EthApiServer};
+use ethers::{
+    providers::{Http, Provider, ProviderExt},
+    types::{Address, Chain},
+};
+use jsonrpsee::{server::ServerBuilder, RpcModule};
+use tokio::sync::{broadcast, mpsc};
 
 use super::ApiNamespace;
+use crate::{
+    common::{
+        protos::{builder::builder_client, op_pool::op_pool_client},
+        server::format_socket_addr,
+        simulation,
+    },
+    rpc::{
+        debug::{DebugApi, DebugApiServer},
+        eth::{EthApi, EthApiServer},
+    },
+};
 
 pub struct Args {
     pub port: u16,


### PR DESCRIPTION
This allows us to use nightly-only options for rustfmt, including those that organize the imports.

Also adds a githook to automatically format when committing.