### PR TITLE
Validate with aggregator during simulation

### DIFF
--- a/src/rpc/eth/mod.rs
+++ b/src/rpc/eth/mod.rs
@@ -645,6 +645,7 @@ impl From<SimulationError> for EthRpcError {
 
                 Self::StakeTooLow(err_data)
             }
+            Violation::AggregatorValidationFailed => Self::SignatureCheckFailed,
             _ => Self::Internal(value.into()),
         }
     }


### PR DESCRIPTION
If an op uses a validator, then as part of simulation use it to validate their signature and return the aggregator signature.