### PR TITLE
Simulation updates

### DIFF
--- a/src/common/tracer.rs
+++ b/src/common/tracer.rs
@@ -29,7 +29,7 @@ pub struct Phase {
     pub forbidden_opcodes_used: Vec<Opcode>,
     pub used_invalid_gas_opcode: bool,
     pub storage_accesses: Vec<StorageAccess>,
-    pub called_handle_ops: bool,
+    pub called_banned_entry_point_method: bool,
     pub called_with_value: bool,
     pub ran_out_of_gas: bool,
     pub undeployed_contract_accesses: Vec<Address>,

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -199,7 +199,7 @@ impl From<UserOperationOptionalGas> for UserOperation {
             call_data: op.call_data,
             call_gas_limit: op.call_gas_limit.unwrap_or_default(),
             verification_gas_limit: op.verification_gas_limit.unwrap_or_default(),
-            pre_verification_gas: op.pre_verification_gas.unwrap_or(21000.into()), // this dummy is used in calc_pre_verification_gas
+            pre_verification_gas: op.pre_verification_gas.unwrap_or_else(|| 21000.into()), // this dummy is used in calc_pre_verification_gas
             max_fee_per_gas: op.max_fee_per_gas.unwrap_or_default(),
             max_priority_fee_per_gas: op.max_priority_fee_per_gas.unwrap_or_default(),
             paymaster_and_data: op.paymaster_and_data,


### PR DESCRIPTION
Based on a discussion with the ERC-4337 authors, senders don't actually
need to be staked in order to access their own associated storage during
account creation.

Also, the new version of the spec bans calling any entry point method other
than `depositTo`, by contrast to the old version which only banned
`handleOps`.