### PR TITLE
chore(rpc): add metrics to debug rpc methods

### DIFF
--- a/src/rpc/debug.rs
+++ b/src/rpc/debug.rs
@@ -68,8 +68,6 @@ impl DebugApiServer for DebugApi {
     async fn bundler_clear_state(&self) -> RpcResult<String> {
         let _ = self
             .op_pool_client
-            // https://docs.rs/tonic/latest/tonic/client/index.html#concurrent-usage
-            // solution to using in concurrent context is to clone
             .clone()
             .debug_clear_state(DebugClearStateRequest {})
             .await
@@ -152,12 +150,12 @@ impl DebugApiServer for DebugApi {
             .await
             .map_err(|e| RpcError::Custom(e.to_string()))?;
 
-        Ok(result
+        result
             .into_inner()
             .reputations
             .into_iter()
             .map(|r| r.try_into())
             .collect::<Result<Vec<_>, anyhow::Error>>()
-            .map_err(|e| RpcError::Custom(e.to_string()))?)
+            .map_err(|e| RpcError::Custom(e.to_string()))
     }
 }

--- a/src/rpc/eth/mod.rs
+++ b/src/rpc/eth/mod.rs
@@ -244,8 +244,6 @@ impl EthApiServer for EthApi {
         op: RpcUserOperation,
         entry_point: Address,
     ) -> RpcResult<H256> {
-        debug!("send_user_operation: {:?}", op);
-
         if !self.entry_points_and_sims.contains_key(&entry_point) {
             return Err(EthRpcError::InvalidParams(
                 "supplied entry_point addr is not a known entry point".to_string(),

--- a/src/rpc/metrics.rs
+++ b/src/rpc/metrics.rs
@@ -1,0 +1,90 @@
+use std::time::{Duration, Instant};
+
+use jsonrpsee::server::logger::Logger;
+
+#[derive(Clone)]
+pub struct RpcMetricsLogger;
+
+impl Logger for RpcMetricsLogger {
+    type Instant = Instant;
+
+    fn on_connect(
+        &self,
+        _remote_addr: std::net::SocketAddr,
+        _request: &jsonrpsee::server::logger::HttpRequest,
+        _t: jsonrpsee::server::logger::TransportProtocol,
+    ) {
+    }
+
+    fn on_request(
+        &self,
+        _transport: jsonrpsee::server::logger::TransportProtocol,
+    ) -> Self::Instant {
+        Instant::now()
+    }
+
+    fn on_call(
+        &self,
+        method_name: &str,
+        _params: jsonrpsee::types::Params,
+        _kind: jsonrpsee::server::logger::MethodKind,
+        _transport: jsonrpsee::server::logger::TransportProtocol,
+    ) {
+        RpcMetrics::increment_num_requests(method_name.to_string());
+        RpcMetrics::increment_open_requests(method_name.to_string());
+    }
+
+    fn on_result(
+        &self,
+        method_name: &str,
+        success: bool,
+        started_at: Self::Instant,
+        _transport: jsonrpsee::server::logger::TransportProtocol,
+    ) {
+        RpcMetrics::record_request_latency(method_name.to_string(), started_at.elapsed());
+        RpcMetrics::decrement_open_requests(method_name.to_string());
+
+        if !success {
+            RpcMetrics::increment_rpc_error_count(method_name.to_string());
+        }
+    }
+
+    fn on_response(
+        &self,
+        _result: &str,
+        _started_at: Self::Instant,
+        _transport: jsonrpsee::server::logger::TransportProtocol,
+    ) {
+    }
+
+    fn on_disconnect(
+        &self,
+        _remote_addr: std::net::SocketAddr,
+        _transport: jsonrpsee::server::logger::TransportProtocol,
+    ) {
+    }
+}
+
+pub struct RpcMetrics {}
+
+impl RpcMetrics {
+    fn increment_num_requests(method_name: String) {
+        metrics::increment_counter!("rpc_num_requests", "method_name" => method_name)
+    }
+
+    fn increment_open_requests(method_name: String) {
+        metrics::increment_gauge!("rpc_open_requests", 1_f64, "method_name" => method_name)
+    }
+
+    fn decrement_open_requests(method_name: String) {
+        metrics::decrement_gauge!("rpc_open_requests", 1_f64, "method_name" => method_name)
+    }
+
+    fn increment_rpc_error_count(method_name: String) {
+        metrics::increment_counter!("rpc_error_count", "method_name" => method_name)
+    }
+
+    fn record_request_latency(method_name: String, latency: Duration) {
+        metrics::histogram!("rpc_request_latency", latency, "method_name" => method_name)
+    }
+}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,5 +1,6 @@
 mod debug;
 mod eth;
+mod metrics;
 mod run;
 
 use anyhow::bail;

--- a/src/rpc/run.rs
+++ b/src/rpc/run.rs
@@ -18,6 +18,7 @@ use crate::{
     rpc::{
         debug::{DebugApi, DebugApiServer},
         eth::{EthApi, EthApiServer},
+        metrics::RpcMetricsLogger,
     },
 };
 
@@ -85,7 +86,11 @@ pub async fn run(
         }
     }
 
-    let server = ServerBuilder::default().http_only().build(addr).await?;
+    let server = ServerBuilder::default()
+        .set_logger(RpcMetricsLogger)
+        .http_only()
+        .build(addr)
+        .await?;
     let handle = server.start(module)?;
 
     tokio::select! {


### PR DESCRIPTION
Adds some request level metrics to the debug rpc methods as PoC before doing the Eth RPC metrics