### PR TITLE
fix(rpc): remove entrypoint from debug_sendBundleNow

### DIFF
--- a/proto/builder.proto
+++ b/proto/builder.proto
@@ -12,9 +12,7 @@ service Builder {
     rpc DebugSetBundlingMode(DebugSetBundlingModeRequest) returns (DebugSetBundlingModeResponse);
 }
 
-message DebugSendBundleNowRequest {
-    bytes entry_point = 1;
-}
+message DebugSendBundleNowRequest {}
 
 message DebugSendBundleNowResponse {
     bytes transaction_hash = 1;

--- a/src/rpc/debug.rs
+++ b/src/rpc/debug.rs
@@ -30,7 +30,7 @@ pub trait DebugApi {
     async fn bundler_dump_mempool(&self, entry_point: Address) -> RpcResult<Vec<RpcUserOperation>>;
 
     #[method(name = "bundler_sendBundleNow")]
-    async fn bundler_send_bundle_now(&self, entry_point: Address) -> RpcResult<H256>;
+    async fn bundler_send_bundle_now(&self) -> RpcResult<H256>;
 
     #[method(name = "bundler_setBundlingMode")]
     async fn bundler_set_bundling_mode(&self, mode: BundlingMode) -> RpcResult<String>;
@@ -100,13 +100,11 @@ impl DebugApiServer for DebugApi {
         Ok(ops.into_iter().map(|uo| uo.into()).collect())
     }
 
-    async fn bundler_send_bundle_now(&self, entry_point: Address) -> RpcResult<H256> {
+    async fn bundler_send_bundle_now(&self) -> RpcResult<H256> {
         let response = self
             .builder_client
             .clone()
-            .debug_send_bundle_now(DebugSendBundleNowRequest {
-                entry_point: entry_point.to_fixed_bytes().into(),
-            })
+            .debug_send_bundle_now(DebugSendBundleNowRequest {})
             .await
             .map_err(|e| RpcError::Custom(e.to_string()))?;
 


### PR DESCRIPTION
## Proposed Changes

  - Removes the entrypoint parameter from debug_sendBundleNow. Its not in the spec: https://github.com/eth-infinitism/account-abstraction/blob/v0.5/eip/EIPS/eip-4337.md#-debug_bundler_sendbundlenow
