### PR TITLE
chore: add health check endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,9 +1418,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1433,9 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1443,15 +1443,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1460,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-locks"
@@ -1476,26 +1476,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.11",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-timer"
@@ -1509,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3098,6 +3098,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "tonic-health",
  "tonic-reflection",
  "tonic-types",
  "tower",
@@ -3973,6 +3974,20 @@ dependencies = [
  "prost-build",
  "quote",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88aee666ef3a4d1ee46218bbc8e5f69bcf9cc27bf2e871d6b724d83f56d179f"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ strum = { version = "0.24.1", features = ["derive"] }
 tower-http = { version = "0.4.0", features = ["trace"] }
 tower = "0.4.13"
 pin-project = "1.0.12"
+tonic-health = "0.8.0"
 
 [build-dependencies]
 ethers = "2.0.2"

--- a/src/builder/run.rs
+++ b/src/builder/run.rs
@@ -31,9 +31,16 @@ pub async fn run(
         .build()
         .unwrap();
 
+    // health service
+    let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
+    health_reporter
+        .set_serving::<BuilderServer<BuilderImpl>>()
+        .await;
+
     let server_handle = Server::builder()
         .add_service(builder_server)
         .add_service(reflection_service)
+        .add_service(health_service)
         .serve_with_shutdown(addr, async move {
             shutdown_rx
                 .recv()

--- a/src/rpc/health.rs
+++ b/src/rpc/health.rs
@@ -1,0 +1,46 @@
+use anyhow::Context;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use tonic::{async_trait, transport::Channel};
+use tonic_health::proto::{health_client::HealthClient, HealthCheckRequest};
+
+#[rpc(server, namespace = "system")]
+pub trait SystemApi {
+    #[method(name = "health")]
+    async fn get_health(&self) -> RpcResult<String>;
+}
+
+pub struct SystemApi {
+    op_pool_health_client: HealthClient<Channel>,
+    builder_health_client: HealthClient<Channel>,
+}
+
+impl SystemApi {
+    pub fn new(
+        op_pool_health_client: HealthClient<Channel>,
+        builder_health_client: HealthClient<Channel>,
+    ) -> Self {
+        Self {
+            op_pool_health_client,
+            builder_health_client,
+        }
+    }
+}
+
+#[async_trait]
+impl SystemApiServer for SystemApi {
+    async fn get_health(&self) -> RpcResult<String> {
+        self.op_pool_health_client
+            .clone()
+            .check(HealthCheckRequest::default())
+            .await
+            .context("Op pool server should be live")?;
+
+        self.builder_health_client
+            .clone()
+            .check(HealthCheckRequest::default())
+            .await
+            .context("Builder server should be live")?;
+
+        Ok("ok".to_string())
+    }
+}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,5 +1,6 @@
 mod debug;
 mod eth;
+mod health;
 mod metrics;
 mod run;
 

--- a/src/rpc/run.rs
+++ b/src/rpc/run.rs
@@ -1,12 +1,17 @@
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::{bail, Context};
 use ethers::{
     providers::{Http, Provider, ProviderExt},
     types::{Address, Chain},
 };
-use jsonrpsee::{server::ServerBuilder, RpcModule};
+use jsonrpsee::{
+    server::{middleware::proxy_get_request::ProxyGetRequestLayer, ServerBuilder},
+    RpcModule,
+};
 use tokio::sync::{broadcast, mpsc};
+use tonic::transport::{Channel, Uri};
+use tonic_health::proto::health_client::HealthClient;
 
 use super::ApiNamespace;
 use crate::{
@@ -18,6 +23,7 @@ use crate::{
     rpc::{
         debug::{DebugApi, DebugApiServer},
         eth::{EthApi, EthApiServer},
+        health::{SystemApi, SystemApiServer},
         metrics::RpcMetricsLogger,
     },
 };
@@ -56,13 +62,28 @@ pub async fn run(
             .for_chain(chain),
     );
 
+    let op_pool_uri = Uri::from_str(&args.pool_url).context("should be a valid URI for op_pool")?;
     let op_pool_client = op_pool_client::OpPoolClient::connect(args.pool_url)
         .await
         .context("should have been able to connect to op pool")?;
+    let op_pool_health_client = HealthClient::new(
+        Channel::builder(op_pool_uri)
+            .connect()
+            .await
+            .context("should have connected to op_pool health service channel")?,
+    );
 
+    let builder_uri =
+        Uri::from_str(&args.builder_url).context("should be a valid URI for op_pool")?;
     let builder_client = builder_client::BuilderClient::connect(args.builder_url)
         .await
         .context("builder server should be started")?;
+    let builder_health_client = HealthClient::new(
+        Channel::builder(builder_uri)
+            .connect()
+            .await
+            .context("should have connected to builder health service channel")?,
+    );
 
     if args.entry_points.len() != 1 {
         bail!("Only one entry point is supported at the moment");
@@ -86,8 +107,19 @@ pub async fn run(
         }
     }
 
+    // Set up health check endpoint via GET /health
+    // registers the jsonrpc handler
+    // NOTE: I couldn't use module.register_async_method because it requires async move
+    // and neither the clients or the args.*_url are copyable
+    module.merge(SystemApi::new(op_pool_health_client, builder_health_client).into_rpc())?;
+    let service_builder = tower::ServiceBuilder::new()
+        // Proxy `GET /health` requests to internal `system_health` method.
+        .layer(ProxyGetRequestLayer::new("/health", "system_health")?)
+        .timeout(Duration::from_secs(2));
+
     let server = ServerBuilder::default()
         .set_logger(RpcMetricsLogger)
+        .set_middleware(service_builder)
         .http_only()
         .build(addr)
         .await?;


### PR DESCRIPTION
[Closes/Fixes] #86

## Proposed Changes
  - Adds a jRPC module with a system_health method and a proxy middleware to proxy GET /health to that method
  - Health check makes sure it can communicate with the op_pool and builder before returning OK
