### PR TITLE
feat(tracer): limit gas simulate handle ops trace

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -135,11 +135,23 @@ pub struct CommonArgs {
         global = true
     )]
     min_unstake_delay: u32,
+
+    #[arg(
+        long = "max_simulate_handle_ops_gas",
+        name = "max_simulate_handle_ops_gas",
+        default_value = "550000000",
+        global = true
+    )]
+    max_simulate_handle_ops_gas: u64,
 }
 
 impl From<&CommonArgs> for simulation::Settings {
     fn from(value: &CommonArgs) -> Self {
-        Self::new(value.min_unstake_delay, value.min_stake_value)
+        Self::new(
+            value.min_unstake_delay,
+            value.min_stake_value,
+            value.max_simulate_handle_ops_gas,
+        )
     }
 }
 

--- a/src/common/tracer.rs
+++ b/src/common/tracer.rs
@@ -113,10 +113,13 @@ pub async fn trace_simulate_handle_op(
     entry_point: &IEntryPoint<impl Middleware>,
     op: UserOperation,
     block_id: BlockId,
+    gas: u64,
 ) -> anyhow::Result<GasTracerOutput> {
     let tx = entry_point
         .simulate_handle_op(op, Address::default(), Bytes::default())
+        .gas(gas)
         .tx;
+
     trace_call(
         entry_point.client().provider(),
         tx,


### PR DESCRIPTION
[Closes/Fixes] #93

## Proposed Changes
  - set the gas limit for simulate handle ops trace call to 550mil which is the eth_call limit we impose
