### PR TITLE
refactor: use a retry client in the RPC modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,6 +3109,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tower = "0.4.13"
 pin-project = "1.0.12"
 tonic-health = "0.9.1"
 rand = "0.8.5"
+url = "2.3.1"
 
 [dev-dependencies]
 tokio-util = "0.7.7"

--- a/src/common/simulation.rs
+++ b/src/common/simulation.rs
@@ -10,7 +10,7 @@ use ethers::{
     abi::AbiDecode,
     contract::ContractError,
     prelude::ProviderError,
-    providers::{Http, Provider},
+    providers::{JsonRpcClient, Provider},
     types::{Address, BlockId, BlockNumber, Bytes, Opcode, H256, U256},
 };
 use indexmap::IndexSet;
@@ -84,15 +84,18 @@ pub trait Simulator {
 }
 
 #[derive(Debug)]
-pub struct SimulatorImpl {
-    provider: Arc<Provider<Http>>,
-    entry_point: IEntryPoint<Provider<Http>>,
+pub struct SimulatorImpl<T: JsonRpcClient> {
+    provider: Arc<Provider<T>>,
+    entry_point: IEntryPoint<Provider<T>>,
     sim_settings: Settings,
 }
 
-impl SimulatorImpl {
+impl<T> SimulatorImpl<T>
+where
+    T: JsonRpcClient + 'static,
+{
     pub fn new(
-        provider: Arc<Provider<Http>>,
+        provider: Arc<Provider<T>>,
         entry_point_address: Address,
         sim_settings: Settings,
     ) -> Self {
@@ -182,7 +185,10 @@ impl SimulatorImpl {
 }
 
 #[async_trait]
-impl Simulator for SimulatorImpl {
+impl<T> Simulator for SimulatorImpl<T>
+where
+    T: JsonRpcClient + 'static,
+{
     async fn simulate_validation(
         &self,
         op: UserOperation,


### PR DESCRIPTION
[Closes/Fixes] #105

## Proposed Changes

  - Refactor parts of the codebase to take a generic Provider type
  - Use a retry client in the eth RPC module
