### PR TITLE
feat(metrics): add tags to metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3082,6 +3082,7 @@ dependencies = [
  "dotenv",
  "ethers",
  "indexmap",
+ "itertools",
  "jsonrpsee",
  "metrics",
  "metrics-exporter-prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ pin-project = "1.0.12"
 tonic-health = "0.9.1"
 rand = "0.8.5"
 url = "2.3.1"
+itertools = "0.10.5"
 
 [dev-dependencies]
 tokio-util = "0.7.7"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -39,7 +39,8 @@ pub async fn run() -> anyhow::Result<()> {
     tracing::info!("Parsed CLI options: {:#?}", opt);
 
     let metrics_addr = format!("{}:{}", opt.metrics.host, opt.metrics.port).parse()?;
-    prometheus_exporter::initialize(metrics_addr).context("metrics server should start")?;
+    prometheus_exporter::initialize(metrics_addr, &opt.metrics.tags)
+        .context("metrics server should start")?;
 
     match opt.command {
         Command::Node(args) => node::run(args, opt.common).await?,
@@ -121,8 +122,8 @@ pub struct CommonArgs {
     #[arg(
         long = "min_stake_value",
         name = "min_stake_value",
-        default_value = "1000000000000000000",
         env = "MIN_STAKE_VALUE",
+        default_value = "1000000000000000000",
         global = true
     )]
     min_stake_value: u64,
@@ -130,8 +131,8 @@ pub struct CommonArgs {
     #[arg(
         long = "min_unstake_delay",
         name = "min_unstake_delay",
-        default_value = "84600",
         env = "MIN_UNSTAKE_DELAY",
+        default_value = "84600",
         global = true
     )]
     min_unstake_delay: u32,
@@ -139,6 +140,7 @@ pub struct CommonArgs {
     #[arg(
         long = "max_simulate_handle_ops_gas",
         name = "max_simulate_handle_ops_gas",
+        env = "MAX_SIMULATE_HANDLE_OPS_GAS",
         default_value = "550000000",
         global = true
     )]
@@ -178,6 +180,19 @@ struct MetricsArgs {
         global = true
     )]
     host: String,
+
+    /// Tags for metrics
+    ///
+    /// Format: key1=value1,key2=value2,...
+    #[arg(
+        long = "metrics.tags",
+        name = "metrics.tags",
+        env = "METRICS_TAGS",
+        default_values_t = Vec::<String>::new(),
+        value_delimiter = ',',
+        global = true
+    )]
+    tags: Vec<String>,
 }
 
 /// CLI options for logging

--- a/src/cli/prometheus_exporter.rs
+++ b/src/cli/prometheus_exporter.rs
@@ -1,12 +1,24 @@
 use std::net::SocketAddr;
 
+use itertools::Itertools;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use metrics_util::layers::{PrefixLayer, Stack};
 
-pub fn initialize(listen_addr: SocketAddr) -> anyhow::Result<()> {
-    let (recorder, exporter) = PrometheusBuilder::new()
-        .with_http_listener(listen_addr)
-        .build()?;
+pub fn initialize<'a>(
+    listen_addr: SocketAddr,
+    tags: impl IntoIterator<Item = &'a String>,
+) -> anyhow::Result<()> {
+    let mut builder = PrometheusBuilder::new().with_http_listener(listen_addr);
+
+    let tags: Vec<(&str, &str)> = tags
+        .into_iter()
+        .filter_map(|t| t.split('=').collect_tuple())
+        .collect();
+    for (k, v) in tags {
+        builder = builder.add_global_label(k, v);
+    }
+
+    let (recorder, exporter) = builder.build()?;
     tokio::spawn(exporter);
     Stack::new(recorder)
         .push(PrefixLayer::new("rundler"))


### PR DESCRIPTION
## Proposed Changes

  - Adds a `METRICS_TAGS` CLI arg to allow tagging metrics with the form `env=staging,network=ethsepolia`
 
