### PR TITLE
feat(log): add flag to log in json format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4133,6 +4133,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4142,12 +4152,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tonic-types = "0.9.0"
 tonic-reflection = "0.9.0"
 prost-types = "0.11.8"
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter", "fmt", "json"] }
 tracing-appender = "0.2.2"
 metrics = "0.20.1"
 metrics-exporter-prometheus = "0.11.0"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -30,11 +30,14 @@ pub async fn run() -> anyhow::Result<()> {
         tracing_appender::non_blocking(io::stdout())
     };
 
-    let subscriber = FmtSubscriber::builder()
+    let subscriber_builder = FmtSubscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
-        .with_writer(appender)
-        .finish();
-    tracing::subscriber::set_global_default(subscriber)?;
+        .with_writer(appender);
+    if opt.logs.json {
+        tracing::subscriber::set_global_default(subscriber_builder.json().finish())?;
+    } else {
+        tracing::subscriber::set_global_default(subscriber_builder.pretty().finish())?;
+    }
 
     tracing::info!("Parsed CLI options: {:#?}", opt);
 
@@ -210,6 +213,19 @@ struct LogsArgs {
         global = true
     )]
     file: Option<String>,
+
+    /// Log JSON
+    ///
+    /// If set, logs will be written in JSON format
+    #[arg(
+        long = "log.json",
+        name = "log.json",
+        env = "LOG_JSON",
+        required = false,
+        num_args = 0,
+        global = true
+    )]
+    json: bool,
 }
 
 /// CLI options


### PR DESCRIPTION
## Proposed Changes

  - Adds a `LOG_JSON` CLI flag that causes logs to be emitted in JSON format. Else they're emitted in "pretty" format

JSON:
```
{"timestamp":"2023-04-06T14:48:59.982017Z","level":"DEBUG","fields":{"message":"send","frame":"GoAway { error_code: NO_ERROR, last_stream_id: StreamId(0) }"},"target":"h2::codec::framed_write","span":{"peer":"Client","name":"Connection"},"spans":[{"peer":"Client","name":"Connection"}]}
```

Pretty:
```
  2023-04-06T14:49:16.693808Z DEBUG h2::codec::framed_write: send, frame: GoAway { error_code: NO_ERROR, last_stream_id: StreamId(0) }
    at /Users/dcoombs/.cargo/registry/src/github.com-1ecc6299db9ec823/h2-0.3.15/src/codec/framed_write.rs:232
    in h2::proto::connection::Connection with peer: Server
```
