### PR TITLE
test: Create utilities for mocking gRPC clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,6 +886,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +937,12 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dunce"
@@ -1032,6 +1044,17 @@ dependencies = [
  "errno-dragonfly",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1426,6 +1449,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +1471,12 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fs2"
@@ -1962,7 +2000,7 @@ checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
 dependencies = [
  "hermit-abi 0.3.0",
  "io-lifetimes",
- "rustix",
+ "rustix 0.36.8",
  "windows-sys 0.45.0",
 ]
 
@@ -2177,7 +2215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b18cbf29f8ff3542ba22bdce9ac610fcb75d74bb4e2b306b2a2762242025b4f"
 dependencies = [
  "bindgen",
- "errno",
+ "errno 0.2.8",
  "libc",
 ]
 
@@ -2195,6 +2233,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lock_api"
@@ -2383,6 +2427,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,6 +2492,12 @@ checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2590,7 +2667,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -2816,6 +2893,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2892,7 +2999,7 @@ dependencies = [
  "byteorder",
  "hex",
  "lazy_static",
- "rustix",
+ "rustix 0.36.8",
 ]
 
 [[package]]
@@ -3067,13 +3174,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -3224,6 +3340,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "metrics-process",
  "metrics-util",
+ "mockall",
  "parking_lot",
  "parse-display",
  "pin-project",
@@ -3278,10 +3395,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
+dependencies = [
+ "bitflags",
+ "errno 0.3.0",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.1",
  "windows-sys 0.45.0",
 ]
 
@@ -3798,15 +3929,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.42.0",
+ "redox_syscall 0.3.5",
+ "rustix 0.37.3",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3838,6 +3969,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ arrayvec = "0.7.2"
 
 [dev-dependencies]
 tokio-util = "0.7.7"
+mockall = "0.11.4"
 
 [build-dependencies]
 ethers = "2.0.2"

--- a/src/common/grpc/mocks.rs
+++ b/src/common/grpc/mocks.rs
@@ -1,0 +1,236 @@
+use std::{future::Future, net::SocketAddr, time::Duration};
+
+use mockall::mock;
+use tokio::{net::TcpListener, task::AbortHandle, time};
+use tonic::{
+    async_trait,
+    transport::{self, Channel, Server},
+    Request, Response,
+};
+
+use crate::common::protos::{
+    builder::{
+        builder_client::BuilderClient,
+        builder_server::{Builder, BuilderServer},
+        DebugSendBundleNowRequest, DebugSendBundleNowResponse, DebugSetBundlingModeRequest,
+        DebugSetBundlingModeResponse,
+    },
+    op_pool::{
+        op_pool_client::OpPoolClient,
+        op_pool_server::{OpPool, OpPoolServer},
+        AddOpRequest, AddOpResponse, DebugClearStateRequest, DebugClearStateResponse,
+        DebugDumpMempoolRequest, DebugDumpMempoolResponse, DebugDumpReputationRequest,
+        DebugDumpReputationResponse, DebugSetReputationRequest, DebugSetReputationResponse,
+        GetOpsRequest, GetOpsResponse, GetSupportedEntryPointsRequest,
+        GetSupportedEntryPointsResponse, RemoveOpsRequest, RemoveOpsResponse,
+    },
+};
+
+mock! {
+    pub OpPool {}
+
+    #[async_trait]
+    impl OpPool for OpPool {
+        async fn get_supported_entry_points(
+            &self,
+            _request: Request<GetSupportedEntryPointsRequest>,
+        ) -> tonic::Result<Response<GetSupportedEntryPointsResponse>>;
+
+        async fn add_op(&self, request: Request<AddOpRequest>) -> tonic::Result<Response<AddOpResponse>>;
+
+        async fn get_ops(&self, request: Request<GetOpsRequest>) -> tonic::Result<Response<GetOpsResponse>>;
+
+        async fn remove_ops(
+            &self,
+            request: Request<RemoveOpsRequest>,
+        ) -> tonic::Result<Response<RemoveOpsResponse>>;
+
+        async fn debug_clear_state(
+            &self,
+            _request: Request<DebugClearStateRequest>,
+        ) -> tonic::Result<Response<DebugClearStateResponse>>;
+
+        async fn debug_dump_mempool(
+            &self,
+            request: Request<DebugDumpMempoolRequest>,
+        ) -> tonic::Result<Response<DebugDumpMempoolResponse>>;
+
+        async fn debug_set_reputation(
+            &self,
+            request: Request<DebugSetReputationRequest>,
+        ) -> tonic::Result<Response<DebugSetReputationResponse>>;
+
+        async fn debug_dump_reputation(
+            &self,
+            request: Request<DebugDumpReputationRequest>,
+        ) -> tonic::Result<Response<DebugDumpReputationResponse>>;
+    }
+}
+
+mock! {
+    pub Builder {}
+
+    #[async_trait]
+    impl Builder for Builder {
+        async fn debug_send_bundle_now(
+            &self,
+            _request: Request<DebugSendBundleNowRequest>,
+        ) -> tonic::Result<Response<DebugSendBundleNowResponse>>;
+
+        async fn debug_set_bundling_mode(
+            &self,
+            _request: Request<DebugSetBundlingModeRequest>,
+        ) -> tonic::Result<Response<DebugSetBundlingModeResponse>>;
+    }
+}
+
+/// A gRPC client packaged with context that when dropped will cause the
+/// corresponding server to shut down.
+#[derive(Debug)]
+pub struct ClientHandle<T> {
+    pub client: T,
+    abort_handle: AbortHandle,
+}
+
+impl<T> Drop for ClientHandle<T> {
+    fn drop(&mut self) {
+        self.abort_handle.abort();
+    }
+}
+
+pub type OpPoolHandle = ClientHandle<OpPoolClient<Channel>>;
+pub type BuilderHandle = ClientHandle<BuilderClient<Channel>>;
+
+/// Creates an `OpPoolClient` connected to a local gRPC server which uses the
+/// provided `mock` to respond to requests. Returns a handle which exposes the
+/// client and shuts down the server when dropped.
+pub async fn mock_op_pool_client(mock: impl OpPool) -> OpPoolHandle {
+    mock_op_pool_client_with_port(mock, 56776).await
+}
+
+/// Like `mock_op_pool_client`, but accepts a custom port to avoid conflicts.
+pub async fn mock_op_pool_client_with_port(mock: impl OpPool, port: u16) -> OpPoolHandle {
+    mock_client_with_port(
+        |addr| {
+            Server::builder()
+                .add_service(OpPoolServer::new(mock))
+                .serve(addr)
+        },
+        OpPoolClient::connect,
+        port,
+    )
+    .await
+}
+
+/// Creates a `BuilderClient` connected to a local gRPC server which uses the
+/// provided `mock` to respond to requests. Returns a handle which exposes the
+/// client and shuts down the server when dropped.
+pub async fn mock_builder_client(mock: impl Builder) -> BuilderHandle {
+    mock_builder_client_with_port(mock, 52845).await
+}
+
+/// Like `mock_builder_client`, but accepts a custom port to avoid conflicts.
+pub async fn mock_builder_client_with_port(mock: impl Builder, port: u16) -> BuilderHandle {
+    mock_client_with_port(
+        |addr| {
+            Server::builder()
+                .add_service(BuilderServer::new(mock))
+                .serve(addr)
+        },
+        BuilderClient::connect,
+        port,
+    )
+    .await
+}
+
+async fn mock_client_with_port<FnS, FutS, FnC, FutC, C>(
+    new_server: FnS,
+    new_client: FnC,
+    port: u16,
+) -> ClientHandle<C>
+where
+    FnS: FnOnce(SocketAddr) -> FutS,
+    FutS: Future<Output = Result<(), transport::Error>> + Send + 'static,
+    FnC: FnOnce(String) -> FutC,
+    FutC: Future<Output = Result<C, transport::Error>>,
+{
+    let server_addr = format!("[::1]:{port}");
+    assert!(
+        port_is_available(port).await,
+        "port {port} is not available for mock client"
+    );
+    let client_addr = format!("http://{server_addr}");
+    let abort_handle = tokio::spawn(new_server(server_addr.parse().unwrap())).abort_handle();
+    // Sleeping any amount of time is enough for the server to become ready.
+    time::sleep(Duration::from_millis(1)).await;
+    let client = new_client(client_addr)
+        .await
+        .expect("should connect to mock gRPC server");
+    ClientHandle {
+        client,
+        abort_handle,
+    }
+}
+
+async fn port_is_available(port: u16) -> bool {
+    TcpListener::bind(format!("[::1]:{port}")).await.is_ok()
+}
+
+#[cfg(test)]
+mod test {
+    use tokio::time;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_op_pool_mock() {
+        let mut op_pool = MockOpPool::new();
+        op_pool.expect_get_supported_entry_points().returning(|_| {
+            Ok(Response::new(GetSupportedEntryPointsResponse {
+                chain_id: 1337,
+                entry_points: vec![vec![1, 2, 3]],
+            }))
+        });
+        let mut handle = mock_op_pool_client(op_pool).await;
+        let response = handle
+            .client
+            .get_supported_entry_points(GetSupportedEntryPointsRequest {})
+            .await
+            .expect("should get response from mock")
+            .into_inner();
+        assert_eq!(response.chain_id, 1337);
+        assert_eq!(response.entry_points, vec![vec![1, 2, 3]]);
+    }
+
+    #[tokio::test]
+    async fn test_builder_mock() {
+        let mut builder = MockBuilder::new();
+        builder.expect_debug_send_bundle_now().returning(|_| {
+            Ok(Response::new(DebugSendBundleNowResponse {
+                transaction_hash: vec![1, 2, 3],
+            }))
+        });
+        let mut handle = mock_builder_client(builder).await;
+        let transaction_hash = handle
+            .client
+            .debug_send_bundle_now(DebugSendBundleNowRequest {})
+            .await
+            .expect("should get response from mock")
+            .into_inner()
+            .transaction_hash;
+        assert_eq!(transaction_hash, vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn test_server_shutdown_when_handle_drops() {
+        let port = 10000;
+        assert!(port_is_available(port).await);
+        {
+            let _handle = mock_op_pool_client_with_port(MockOpPool::new(), port).await;
+            assert!(!port_is_available(port).await);
+        }
+        // Sleeping any duration is enough for the server to shut down.
+        time::sleep(Duration::from_millis(1)).await;
+        assert!(port_is_available(port).await);
+    }
+}

--- a/src/common/grpc/mod.rs
+++ b/src/common/grpc/mod.rs
@@ -1,1 +1,3 @@
 pub mod metrics;
+#[cfg(test)]
+pub mod mocks;

--- a/src/rpc/eth/mod.rs
+++ b/src/rpc/eth/mod.rs
@@ -107,6 +107,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct EthApi<C: JsonRpcClient + 'static> {
     contexts_by_entry_point: HashMap<Address, EntryPointContext<C>>,
     provider: Arc<Provider<C>>,


### PR DESCRIPTION
Adds helpers for creating mocks of gRPC clients, which are implemented by running a local gRPC server backed by a mock impl of the server.