### PR TITLE
refactor: Replace `ProtoBytes` struct with `from_bytes` helper

### DIFF
--- a/src/op_pool/mempool/mod.rs
+++ b/src/op_pool/mempool/mod.rs
@@ -176,8 +176,8 @@ mod tests {
         let po = PoolOperation {
             uo: UserOperation {
                 sender,
-                paymaster_and_data: Bytes::from(paymaster.as_fixed_bytes()),
-                init_code: Bytes::from(factory.as_fixed_bytes()),
+                paymaster_and_data: paymaster.as_fixed_bytes().into(),
+                init_code: factory.as_fixed_bytes().into(),
                 ..Default::default()
             },
             aggregator: Some(aggregator),

--- a/src/op_pool/mempool/pool.rs
+++ b/src/op_pool/mempool/pool.rs
@@ -245,8 +245,6 @@ impl PartialEq for OrderedPoolOperation {
 
 #[cfg(test)]
 mod tests {
-    use ethers::types::Bytes;
-
     use super::*;
 
     #[test]
@@ -361,8 +359,8 @@ mod tests {
         let aggregator = Address::random();
 
         let mut op = create_op(sender, 0, 1);
-        op.uo.paymaster_and_data = Bytes::from(paymaster.as_bytes().to_vec());
-        op.uo.init_code = Bytes::from(factory.as_bytes().to_vec());
+        op.uo.paymaster_and_data = paymaster.as_bytes().to_vec().into();
+        op.uo.init_code = factory.as_bytes().to_vec().into();
         op.aggregator = Some(aggregator);
 
         let count = 5;

--- a/src/op_pool/types.rs
+++ b/src/op_pool/types.rs
@@ -4,8 +4,9 @@ use ethers::types::{Address, H256};
 use super::mempool::{ExpectedStorageSlot, PoolOperation};
 use crate::common::{
     protos::{
+        self,
         op_pool::{Entity as ProtoEntity, MempoolOp, StorageSlot, UserOperation},
-        to_le_bytes, ConversionError, ProtoBytes,
+        to_le_bytes, ConversionError,
     },
     types::ValidTimeRange,
 };
@@ -42,7 +43,7 @@ impl TryFrom<MempoolOp> for PoolOperation {
         let aggregator: Option<Address> = if op.aggregator.is_empty() {
             None
         } else {
-            Some(ProtoBytes(&op.aggregator).try_into()?)
+            Some(protos::from_bytes(&op.aggregator)?)
         };
 
         let valid_time_range = ValidTimeRange::new(op.valid_after.into(), op.valid_until.into());
@@ -81,12 +82,12 @@ impl TryFrom<&StorageSlot> for ExpectedStorageSlot {
     type Error = anyhow::Error;
 
     fn try_from(ss: &StorageSlot) -> Result<Self, Self::Error> {
-        let address = ProtoBytes(&ss.address).try_into()?;
-        let slot = ProtoBytes(&ss.slot).try_into()?;
+        let address = protos::from_bytes(&ss.address)?;
+        let slot = protos::from_bytes(&ss.slot)?;
         let expected_value = if ss.value.is_empty() {
             None
         } else {
-            Some(ProtoBytes(&ss.value).try_into()?)
+            Some(protos::from_bytes(&ss.value)?)
         };
 
         Ok(ExpectedStorageSlot {

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -16,8 +16,8 @@ use strum;
 use crate::common::{
     gas,
     protos::{
+        self,
         op_pool::{Reputation, ReputationStatus},
-        ProtoBytes,
     },
     types::UserOperation,
 };
@@ -266,7 +266,7 @@ impl TryFrom<Reputation> for RpcReputation {
 
     fn try_from(reputation: Reputation) -> Result<Self, Self::Error> {
         Ok(RpcReputation {
-            address: ProtoBytes(&reputation.address).try_into()?,
+            address: protos::from_bytes(&reputation.address)?,
             ops_seen: reputation.ops_seen.into(),
             ops_included: reputation.ops_included.into(),
             status: reputation.status.try_into()?,


### PR DESCRIPTION
Simplify conversion of protobuf `bytes` fields into specific types like
`Address` and `U256` by removing the intermediary `ProtoBytes` type.
Also factor out the common logic of checking the length before
converting.

Also simplify conversions of `Vec<u8>` to `Bytes`.