### PR TITLE
refactor(op_pool): Revert "remove expected_storage_slots"

### DIFF
--- a/proto/op_pool.proto
+++ b/proto/op_pool.proto
@@ -30,8 +30,15 @@ message MempoolOp {
   uint64 valid_until = 4;
   bytes expected_code_hash = 5;
   repeated Entity entities_needing_stake = 6;
-  bytes sim_block_hash = 7;
-  bool account_is_staked = 8;
+  repeated StorageSlot expected_storage_slots = 7;
+  bytes sim_block_hash = 8;
+  bool account_is_staked = 9;
+}
+
+message StorageSlot {
+  bytes address = 1;
+  bytes slot = 2;
+  bytes value = 3;
 }
 
 service OpPool {

--- a/src/op_pool/mempool/mod.rs
+++ b/src/op_pool/mempool/mod.rs
@@ -5,7 +5,7 @@ pub mod uo_pool;
 
 use std::sync::Arc;
 
-use ethers::types::{Address, H256};
+use ethers::types::{Address, H256, U256};
 use strum::IntoEnumIterator;
 
 use self::error::MempoolResult;
@@ -92,6 +92,15 @@ pub enum OperationOrigin {
     External,
 }
 
+// TODO(danc): remove this once PR #26 is merged
+/// An expected storage slot value for a user operation during validation.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ExpectedStorageSlot {
+    pub address: Address,
+    pub slot: U256,
+    pub expected_value: Option<U256>,
+}
+
 /// A user operation with additional metadata from validation.
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct PoolOperation {
@@ -101,6 +110,7 @@ pub struct PoolOperation {
     pub expected_code_hash: H256,
     pub sim_block_hash: H256,
     pub entities_needing_stake: Vec<Entity>,
+    pub expected_storage_slots: Vec<ExpectedStorageSlot>,
     pub account_is_staked: bool,
 }
 
@@ -175,6 +185,7 @@ mod tests {
             expected_code_hash: H256::random(),
             sim_block_hash: H256::random(),
             entities_needing_stake: vec![Entity::Account, Entity::Aggregator],
+            expected_storage_slots: vec![],
             account_is_staked: true,
         };
 

--- a/src/op_pool/types.rs
+++ b/src/op_pool/types.rs
@@ -1,12 +1,12 @@
 use anyhow::Context;
 use ethers::types::{Address, H256};
 
-use super::mempool::PoolOperation;
+use super::mempool::{ExpectedStorageSlot, PoolOperation};
 use crate::common::{
     protos::{
         self,
-        op_pool::{Entity as ProtoEntity, MempoolOp, UserOperation},
-        ConversionError,
+        op_pool::{Entity as ProtoEntity, MempoolOp, StorageSlot, UserOperation},
+        to_le_bytes, ConversionError,
     },
     types::ValidTimeRange,
 };
@@ -27,6 +27,7 @@ impl TryFrom<&PoolOperation> for MempoolOp {
                 .iter()
                 .map(|e| ProtoEntity::from(*e).into())
                 .collect(),
+            expected_storage_slots: op.expected_storage_slots.iter().map(|s| s.into()).collect(),
             account_is_staked: op.account_is_staked,
         })
     }
@@ -47,6 +48,12 @@ impl TryFrom<MempoolOp> for PoolOperation {
 
         let valid_time_range = ValidTimeRange::new(op.valid_after.into(), op.valid_until.into());
 
+        let expected_storage_slots = op
+            .expected_storage_slots
+            .into_iter()
+            .map(|s| (&s).try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+
         let expected_code_hash = H256::from_slice(&op.expected_code_hash);
         let sim_block_hash = H256::from_slice(&op.sim_block_hash);
         let entities_needing_stake = op
@@ -64,14 +71,47 @@ impl TryFrom<MempoolOp> for PoolOperation {
             valid_time_range,
             expected_code_hash,
             entities_needing_stake,
+            expected_storage_slots,
             sim_block_hash,
             account_is_staked: op.account_is_staked,
         })
     }
 }
 
+impl TryFrom<&StorageSlot> for ExpectedStorageSlot {
+    type Error = anyhow::Error;
+
+    fn try_from(ss: &StorageSlot) -> Result<Self, Self::Error> {
+        let address = protos::from_bytes(&ss.address)?;
+        let slot = protos::from_bytes(&ss.slot)?;
+        let expected_value = if ss.value.is_empty() {
+            None
+        } else {
+            Some(protos::from_bytes(&ss.value)?)
+        };
+
+        Ok(ExpectedStorageSlot {
+            address,
+            slot,
+            expected_value,
+        })
+    }
+}
+
+impl From<&ExpectedStorageSlot> for StorageSlot {
+    fn from(ess: &ExpectedStorageSlot) -> Self {
+        StorageSlot {
+            address: ess.address.as_bytes().to_vec(),
+            slot: to_le_bytes(ess.slot),
+            value: ess.expected_value.map_or(vec![], to_le_bytes),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use ethers::types::U256;
+
     use super::*;
     use crate::common::{contracts::shared_types, protos::op_pool, types::Timestamp};
 
@@ -102,6 +142,11 @@ mod tests {
             expected_code_hash: vec![0; 32],
             sim_block_hash: vec![0; 32],
             entities_needing_stake: vec![],
+            expected_storage_slots: vec![op_pool::StorageSlot {
+                address: TEST_ADDRESS_ARR.to_vec(),
+                slot: vec![0; 32],
+                value: vec![0; 32],
+            }],
             account_is_staked: false,
         };
 
@@ -110,11 +155,24 @@ mod tests {
         assert_eq!(pool_op.uo.sender, TEST_ADDRESS_STR.parse().unwrap());
         assert_eq!(pool_op.aggregator, Some(TEST_ADDRESS_STR.parse().unwrap()));
         assert_eq!(pool_op.expected_code_hash, H256::zero());
+        assert_eq!(
+            pool_op.expected_storage_slots[0],
+            ExpectedStorageSlot {
+                address: TEST_ADDRESS_STR.parse().unwrap(),
+                slot: U256::zero(),
+                expected_value: Some(U256::zero()),
+            }
+        );
     }
 
     #[test]
     fn test_pool_op_to_mempool_op() {
         let now = Timestamp::now();
+        let expected_ss = ExpectedStorageSlot {
+            address: TEST_ADDRESS_STR.parse().unwrap(),
+            slot: 1234.into(),
+            expected_value: Some(12345.into()),
+        };
         let pool_op = PoolOperation {
             uo: shared_types::UserOperation {
                 ..Default::default()
@@ -124,6 +182,11 @@ mod tests {
             expected_code_hash: H256::random(),
             entities_needing_stake: vec![],
             sim_block_hash: H256::random(),
+            expected_storage_slots: vec![ExpectedStorageSlot {
+                address: TEST_ADDRESS_STR.parse().unwrap(),
+                slot: 1234.into(),
+                expected_value: Some(12345.into()),
+            }],
             account_is_staked: false,
         };
 
@@ -145,5 +208,63 @@ mod tests {
         assert_eq!(mempool_op.aggregator, TEST_ADDRESS_ARR.to_vec());
         assert_eq!(mempool_op.valid_after, now.seconds_since_epoch());
         assert_eq!(mempool_op.valid_until, now.seconds_since_epoch());
+        assert_eq!(
+            mempool_op.expected_storage_slots[0],
+            (&expected_ss).try_into().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_storage_slot_from_expected_storage_slot() {
+        let ess_w_ev = ExpectedStorageSlot {
+            address: Address::random(),
+            slot: 1234.into(),
+            expected_value: Some(12345.into()),
+        };
+
+        let ss: StorageSlot = (&ess_w_ev).into();
+
+        assert_eq!(ss.address, ess_w_ev.address.as_bytes().to_vec());
+        assert_eq!(ss.slot[0..4], [210, 4, 0, 0]);
+        assert_eq!(ss.value[0..4], [57, 48, 0, 0]);
+
+        let ess_wo_ev = ExpectedStorageSlot {
+            address: Address::random(),
+            slot: 1234.into(),
+            expected_value: None,
+        };
+
+        let ss: StorageSlot = (&ess_wo_ev).into();
+        assert_eq!(ss.value, Vec::<u8>::new());
+    }
+
+    #[test]
+    fn test_expected_storage_slot_to_storage_slot() {
+        let mut slot_bytes: [u8; 32] = [0; 32];
+        U256::from(1234).to_little_endian(&mut slot_bytes);
+        let slot_vec = slot_bytes.to_vec();
+
+        let mut value_bytes: [u8; 32] = [0; 32];
+        U256::from(12345).to_little_endian(&mut value_bytes);
+        let value_vec = value_bytes.to_vec();
+
+        let mut ss = StorageSlot {
+            address: TEST_ADDRESS_ARR.into(),
+            slot: slot_vec,
+            value: value_vec,
+        };
+
+        let ess: ExpectedStorageSlot = (&ss).try_into().unwrap();
+
+        assert_eq!(ess.address, TEST_ADDRESS_STR.parse().unwrap());
+        assert_eq!(ess.slot, 1234.into());
+        assert_eq!(ess.expected_value, Some(12345.into()));
+
+        ss.value = vec![];
+        let ess: ExpectedStorageSlot = (&ss).try_into().unwrap();
+
+        assert_eq!(ess.address, TEST_ADDRESS_STR.parse().unwrap());
+        assert_eq!(ess.slot, 1234.into());
+        assert_eq!(ess.expected_value, None);
     }
 }

--- a/src/rpc/eth/mod.rs
+++ b/src/rpc/eth/mod.rs
@@ -32,9 +32,12 @@ use crate::common::{
     },
     eth::log_to_raw_log,
     precheck::{self, PrecheckError, Prechecker, PrecheckerImpl},
-    protos::op_pool::{
-        op_pool_client::OpPoolClient, AddOpRequest, Entity as OpPoolEntity, ErrorInfo, ErrorReason,
-        MempoolOp,
+    protos::{
+        op_pool::{
+            op_pool_client::OpPoolClient, AddOpRequest, Entity as OpPoolEntity, ErrorInfo,
+            ErrorReason, MempoolOp, StorageSlot,
+        },
+        to_le_bytes,
     },
     simulation::{
         self, GasSimulationError, SimulationError, SimulationSuccess, SimulationViolation,
@@ -296,6 +299,7 @@ where
             valid_time_range,
             code_hash,
             aggregator_address,
+            expected_storage_slots,
             signature_failed,
             entities_needing_stake,
             block_hash,
@@ -337,6 +341,14 @@ where
                     entities_needing_stake: entities_needing_stake
                         .iter()
                         .map(|&e| OpPoolEntity::from(e).into())
+                        .collect(),
+                    expected_storage_slots: expected_storage_slots
+                        .iter()
+                        .map(|ss| StorageSlot {
+                            address: ss.address.as_bytes().to_vec(),
+                            slot: to_le_bytes(ss.slot),
+                            value: to_le_bytes(ss.value),
+                        })
                         .collect(),
                     account_is_staked,
                 }),


### PR DESCRIPTION
Keeping expected storage slots in the mempool is useful after all: it allows us to skip re-simulation if the latest block hasn't changed since the first simulation.

This reverts commit d5f8bf544857a4039a9a62b20a62b31ae66472d1.