### PR TITLE
feat(builder): Run `eth_estimateGas` when proposing a bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,6 +2450,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3632,6 +3638,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "jsonrpsee",
+ "linked-hash-map",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-process",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ futures = "0.3.28"
 indexmap = "1.9.2"
 itertools = "0.10.5"
 jsonrpsee = { version = "0.16.2", features = ["macros", "server"] }
+linked-hash-map = "0.5.6"
 metrics = "0.20.1"
 metrics-exporter-prometheus = "0.11.0"
 metrics-process = "1.0.9"

--- a/src/builder/bundle_proposer.rs
+++ b/src/builder/bundle_proposer.rs
@@ -7,6 +7,7 @@ use std::{
 use anyhow::Context;
 use ethers::types::{Address, Bytes, H256, U256};
 use futures::future;
+use linked_hash_map::LinkedHashMap;
 #[cfg(test)]
 use mockall::automock;
 use tonic::{async_trait, transport::Channel};
@@ -18,16 +19,17 @@ use crate::common::{
         self,
         op_pool::{op_pool_client::OpPoolClient, GetOpsRequest, MempoolOp},
     },
-    simulation::{AggregatorSimOut, SimulationError, SimulationSuccess, Simulator},
-    types::{ProviderLike, Timestamp, UserOperation},
+    simulation::{SimulationError, SimulationSuccess, Simulator},
+    types::{EntryPointLike, HandleOpsOut, ProviderLike, Timestamp, UserOperation},
 };
 
 /// A user op must be valid for at least this long into the future to be included.
 const TIME_RANGE_BUFFER: Duration = Duration::from_secs(60);
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Bundle {
     pub ops_per_aggregator: Vec<UserOpsPerAggregator>,
+    pub gas_estimate: U256,
     pub expected_storage_slots: HashMap<Address, HashMap<U256, U256>>,
     pub rejected_ops: Vec<UserOperation>,
 }
@@ -39,22 +41,33 @@ pub trait BundleProposer {
 }
 
 #[derive(Debug)]
-pub struct BundleProposerImpl<S: Simulator, P: ProviderLike> {
-    entry_point_address: Address,
+pub struct BundleProposerImpl<S, E, P>
+where
+    S: Simulator,
+    E: EntryPointLike,
+    P: ProviderLike,
+{
     bundle_size: u64,
+    beneficiary: Address,
     op_pool: OpPoolClient<Channel>,
     simulator: S,
+    entry_point: E,
     provider: Arc<P>,
 }
 
 #[async_trait]
-impl<S: Simulator, P: ProviderLike> BundleProposer for BundleProposerImpl<S, P> {
+impl<S, E, P> BundleProposer for BundleProposerImpl<S, E, P>
+where
+    S: Simulator,
+    E: EntryPointLike,
+    P: ProviderLike,
+{
     async fn make_bundle(&self) -> anyhow::Result<Bundle> {
         let ops = self
             .op_pool
             .clone()
             .get_ops(GetOpsRequest {
-                entry_point: self.entry_point_address.as_bytes().to_vec(),
+                entry_point: self.entry_point.address().as_bytes().to_vec(),
                 max_ops: self.bundle_size,
             })
             .await
@@ -77,25 +90,47 @@ impl<S: Simulator, P: ProviderLike> BundleProposer for BundleProposerImpl<S, P> 
                 }
             })
             .collect::<Vec<_>>();
-        Ok(self.assemble_ops(ops_with_simulations).await)
+        let mut context = self.assemble_context(ops_with_simulations).await;
+        while !context.is_empty() {
+            let gas_estimate = self.estimate_gas_rejecting_failed_ops(&mut context).await?;
+            if let Some(gas_estimate) = gas_estimate {
+                return Ok(Bundle {
+                    ops_per_aggregator: context.to_ops_per_aggregator(),
+                    gas_estimate,
+                    expected_storage_slots: HashMap::default(), // TODO: actually compute this
+                    rejected_ops: context.rejected_ops,
+                });
+            }
+        }
+        Ok(Bundle {
+            rejected_ops: context.rejected_ops,
+            ..Default::default()
+        })
     }
 }
 
-impl<S: Simulator, P: ProviderLike> BundleProposerImpl<S, P> {
+impl<S, E, P> BundleProposerImpl<S, E, P>
+where
+    S: Simulator,
+    E: EntryPointLike,
+    P: ProviderLike,
+{
     // TODO: Remove the allow directive after we start using this.
     #[allow(dead_code)]
     pub fn new(
-        entry_point_address: Address,
         bundle_size: u64,
+        beneficiary: Address,
         op_pool: OpPoolClient<Channel>,
         simulator: S,
+        entry_point: E,
         provider: Arc<P>,
     ) -> Self {
         Self {
-            entry_point_address,
             bundle_size,
+            beneficiary,
             op_pool,
             simulator,
+            entry_point,
             provider,
         }
     }
@@ -127,16 +162,15 @@ impl<S: Simulator, P: ProviderLike> BundleProposerImpl<S, P> {
         }
     }
 
-    async fn assemble_ops(
+    async fn assemble_context(
         &self,
         ops_with_simulations: Vec<(UserOperation, Option<SimulationSuccess>)>,
-    ) -> Bundle {
+    ) -> ProposalContext {
         let all_sender_addresses: HashSet<Address> = ops_with_simulations
             .iter()
             .map(|(op, _)| op.sender)
             .collect();
-        let mut ops_without_aggregator = Vec::<UserOperation>::new();
-        let mut ops_by_aggregator = HashMap::<Address, Vec<AggregatedOp>>::new();
+        let mut groups_by_aggregator = LinkedHashMap::<Option<Address>, AggregatorGroup>::new();
         let mut rejected_ops = Vec::<UserOperation>::new();
         for (op, simulation) in ops_with_simulations {
             let Some(simulation) = simulation else {
@@ -148,69 +182,108 @@ impl<S: Simulator, P: ProviderLike> BundleProposerImpl<S, P> {
                 .iter()
                 .any(|&address| address != op.sender && all_sender_addresses.contains(&address))
             {
-                // Exclude ops that access the sender of another op in the batch.
+                // Exclude ops that access the sender of another op in the
+                // batch, but don't reject them (remove them from pool).
                 continue;
             }
-            if let Some(AggregatorSimOut { address, signature }) = simulation.aggregator {
-                ops_by_aggregator
-                    .entry(address)
-                    .or_default()
-                    .push(AggregatedOp { op, signature });
-            } else {
-                ops_without_aggregator.push(op);
-            }
+            groups_by_aggregator
+                .entry(simulation.aggregator_address())
+                .or_default()
+                .ops_with_simulations
+                .push(OpWithSimulation { op, simulation });
             // TODO: Track paymaster balances
         }
-        let mut signed_ops_by_aggregator = Vec::<UserOpsPerAggregator>::new();
-        if !ops_without_aggregator.is_empty() {
-            signed_ops_by_aggregator.push(UserOpsPerAggregator {
-                user_ops: ops_without_aggregator,
-                aggregator: Address::default(),
-                signature: Bytes::default(),
-            });
-        }
-        let aggregation_futures = ops_by_aggregator.iter().map(|(&aggregator, ops)| {
-            self.aggregate_signatures(aggregator, ops.iter().map(|op| op.op.clone()).collect())
-        });
-        let aggregation_signatures = future::join_all(aggregation_futures).await;
-        for (aggregator, signature) in aggregation_signatures {
-            match signature {
-                Ok(Some(signature)) => signed_ops_by_aggregator.push(UserOpsPerAggregator {
-                    user_ops: ops_by_aggregator
-                        .remove(&aggregator)
-                        .unwrap_or_default()
-                        .into_iter()
-                        .map(|op| op.with_replaced_signature())
-                        .collect(),
-                    aggregator,
-                    signature,
-                }),
-                Ok(None) => {
-                    rejected_ops.extend(
-                        ops_by_aggregator
-                            .remove(&aggregator)
-                            .unwrap_or_default()
-                            .into_iter()
-                            .map(|op| op.op),
-                    );
-                }
-                Err(error) => {
-                    error!("Failed to compute aggregator signature: {error}");
-                }
-            }
-        }
-        Bundle {
-            ops_per_aggregator: signed_ops_by_aggregator,
-            expected_storage_slots: Default::default(), // TODO: actually compute storage slots
+        let mut context = ProposalContext {
+            groups_by_aggregator,
             rejected_ops,
+        };
+        self.compute_aggregator_signatures(&mut context).await;
+        context
+    }
+
+    async fn compute_aggregator_signatures(&self, context: &mut ProposalContext) {
+        let signature_futures =
+            context
+                .groups_by_aggregator
+                .iter()
+                .filter_map(|(option_address, group)| {
+                    option_address.map(|address| self.aggregate_signatures(address, group))
+                });
+        let signatures = future::join_all(signature_futures).await;
+        for (aggregator, result) in signatures {
+            context.apply_aggregation_signature_result(aggregator, result);
+        }
+    }
+
+    async fn reject_index(&self, context: &mut ProposalContext, i: usize) {
+        let mut remaining_i = i;
+        let mut found_aggregator: Option<Option<Address>> = None;
+        for (&aggregator, group) in &mut context.groups_by_aggregator {
+            if remaining_i < group.ops_with_simulations.len() {
+                let rejected = group.ops_with_simulations.remove(remaining_i);
+                context.rejected_ops.push(rejected.op);
+                found_aggregator = Some(aggregator);
+                break;
+            }
+            remaining_i -= group.ops_with_simulations.len();
+        }
+        let Some(found_aggregator) = found_aggregator else {
+            error!("The entry point indicated a failed op at index {i}, but the bundle size is only {}", i - remaining_i);
+            return;
+        };
+        // If we just removed the last op from a group, delete that group.
+        // Otherwise, the signature is invalidated and we need to recompute it.
+        if context.groups_by_aggregator[&found_aggregator]
+            .ops_with_simulations
+            .is_empty()
+        {
+            context.groups_by_aggregator.remove(&found_aggregator);
+        } else if let Some(aggregator) = found_aggregator {
+            let (_, sig_result) = self
+                .aggregate_signatures(aggregator, &context.groups_by_aggregator[&found_aggregator])
+                .await;
+            context.apply_aggregation_signature_result(aggregator, sig_result);
+        }
+    }
+
+    /// Estimates the gas needed to send this bundle. If successful, returns the
+    /// amount of gas, but if not then mutates the context to remove whichever
+    /// op(s) caused the failure.
+    async fn estimate_gas_rejecting_failed_ops(
+        &self,
+        context: &mut ProposalContext,
+    ) -> anyhow::Result<Option<U256>> {
+        let handle_ops_out = self
+            .entry_point
+            .estimate_handle_ops_gas(context.to_ops_per_aggregator(), self.beneficiary)
+            .await
+            .context("should estimate gas for proposed bundle")?;
+        match handle_ops_out {
+            HandleOpsOut::SuccessWithGas(gas) => Ok(Some(gas)),
+            HandleOpsOut::FailedOp(index, _message) => {
+                // TODO: look at message to see if caused by a factory or
+                // paymaster. If so, return something to purge the op pool of
+                // all other ops using that entity.
+                self.reject_index(context, index).await;
+                Ok(None)
+            }
+            HandleOpsOut::SignatureValidationFailed(aggregator) => {
+                context.reject_aggregator(aggregator);
+                Ok(None)
+            }
         }
     }
 
     async fn aggregate_signatures(
         &self,
         aggregator: Address,
-        ops: Vec<UserOperation>,
+        group: &AggregatorGroup,
     ) -> (Address, anyhow::Result<Option<Bytes>>) {
+        let ops = group
+            .ops_with_simulations
+            .iter()
+            .map(|op_with_simulation| op_with_simulation.op.clone())
+            .collect();
         let result = Arc::clone(&self.provider)
             .aggregate_signatures(aggregator, ops)
             .await;
@@ -238,17 +311,81 @@ impl TryFrom<MempoolOp> for OpFromPool {
     }
 }
 
-#[derive(Clone, Debug)]
-struct AggregatedOp {
+#[derive(Debug)]
+struct OpWithSimulation {
     op: UserOperation,
+    simulation: SimulationSuccess,
+}
+
+impl OpWithSimulation {
+    fn op_with_replaced_sig(&self) -> UserOperation {
+        let mut op = self.op.clone();
+        if let Some(aggregator) = &self.simulation.aggregator {
+            op.signature = aggregator.signature.clone();
+        }
+        op
+    }
+}
+
+/// A struct used internally to represent the current state of a proposed bundle
+/// as it goes through iterations. Contains similar data to the
+/// `Vec<UserOpsPerAggregator>` that will eventually be passed to the entry
+/// point, but contains extra context needed for the computation.
+#[derive(Debug)]
+struct ProposalContext {
+    groups_by_aggregator: LinkedHashMap<Option<Address>, AggregatorGroup>,
+    rejected_ops: Vec<UserOperation>,
+}
+
+#[derive(Debug, Default)]
+struct AggregatorGroup {
+    ops_with_simulations: Vec<OpWithSimulation>,
     signature: Bytes,
 }
 
-impl AggregatedOp {
-    fn with_replaced_signature(self) -> UserOperation {
-        let Self { mut op, signature } = self;
-        op.signature = signature;
-        op
+impl ProposalContext {
+    fn is_empty(&self) -> bool {
+        self.groups_by_aggregator.is_empty()
+    }
+
+    fn apply_aggregation_signature_result(
+        &mut self,
+        aggregator: Address,
+        result: anyhow::Result<Option<Bytes>>,
+    ) {
+        match result {
+            Ok(Some(sig)) => self.groups_by_aggregator[&Some(aggregator)].signature = sig,
+            Ok(None) => self.reject_aggregator(aggregator),
+            Err(error) => {
+                error!("Failed to compute aggregator signature: {error}");
+                self.groups_by_aggregator.remove(&Some(aggregator));
+            }
+        }
+    }
+
+    fn reject_aggregator(&mut self, address: Address) {
+        let rejected = self.groups_by_aggregator.remove(&Some(address));
+        let Some(rejected) = rejected else {
+            error!("tried to reject ops from aggregator {address}, but no such ops exist in bundle");
+            return;
+        };
+        let rejected_ops = rejected.ops_with_simulations.into_iter().map(|op| op.op);
+        self.rejected_ops.extend(rejected_ops);
+    }
+
+    fn to_ops_per_aggregator(&self) -> Vec<UserOpsPerAggregator> {
+        self.groups_by_aggregator
+            .iter()
+            .map(|(&aggregator, group)| UserOpsPerAggregator {
+                user_ops: group
+                    .ops_with_simulations
+                    .iter()
+                    .map(|op| op.op_with_replaced_sig())
+                    .collect(),
+                aggregator: aggregator.unwrap_or_default(),
+                signature: group.signature.clone(),
+            })
+            .collect()
     }
 }
 
@@ -262,14 +399,14 @@ mod tests {
     use crate::common::{
         grpc::mocks::{self, MockOpPool},
         protos::op_pool::GetOpsResponse,
-        simulation::{MockSimulator, SimulationError, SimulationSuccess},
-        types::{MockProviderLike, ValidTimeRange},
+        simulation::{AggregatorSimOut, MockSimulator, SimulationError, SimulationSuccess},
+        types::{MockEntryPointLike, MockProviderLike, ValidTimeRange},
     };
 
     #[tokio::test]
     async fn test_singleton_valid_bundle() {
         let op = UserOperation::default();
-        let bundle = make_bundle(vec![MockOp {
+        let bundle = simple_make_bundle(vec![MockOp {
             op: op.clone(),
             simulation_result: Box::new(|| Ok(SimulationSuccess::default())),
         }])
@@ -281,12 +418,13 @@ mod tests {
                 ..Default::default()
             }]
         );
+        assert_eq!(bundle.gas_estimate, default_estimated_gas());
     }
 
     #[tokio::test]
     async fn test_rejects_on_violation() {
         let op = UserOperation::default();
-        let bundle = make_bundle(vec![MockOp {
+        let bundle = simple_make_bundle(vec![MockOp {
             op: op.clone(),
             simulation_result: Box::new(|| Err(SimulationError::Violations(vec![]))),
         }])
@@ -298,7 +436,7 @@ mod tests {
     #[tokio::test]
     async fn test_drops_but_not_rejects_on_simulation_failure() {
         let op = UserOperation::default();
-        let bundle = make_bundle(vec![MockOp {
+        let bundle = simple_make_bundle(vec![MockOp {
             op: op.clone(),
             simulation_result: Box::new(|| {
                 Err(SimulationError::Other(anyhow!("simulation failed")))
@@ -312,7 +450,7 @@ mod tests {
     #[tokio::test]
     async fn test_rejects_on_signature_failure() {
         let op = UserOperation::default();
-        let bundle = make_bundle(vec![MockOp {
+        let bundle = simple_make_bundle(vec![MockOp {
             op: op.clone(),
             simulation_result: Box::new(|| {
                 Ok(SimulationSuccess {
@@ -334,7 +472,7 @@ mod tests {
         ];
         for time_range in invalid_time_ranges {
             let op = UserOperation::default();
-            let bundle = make_bundle(vec![MockOp {
+            let bundle = simple_make_bundle(vec![MockOp {
                 op: op.clone(),
                 simulation_result: Box::new(move || {
                     Ok(SimulationSuccess {
@@ -353,7 +491,7 @@ mod tests {
     async fn test_drops_but_not_rejects_op_accessing_another_sender() {
         let op1 = op_with_sender(address(1));
         let op2 = op_with_sender(address(2));
-        let bundle = make_bundle(vec![
+        let bundle = simple_make_bundle(vec![
             MockOp {
                 op: op1,
                 simulation_result: Box::new(|| {
@@ -399,7 +537,7 @@ mod tests {
         let op_b_aggregated_sig = 21;
         let aggregator_a_signature = 101;
         let aggregator_b_signature = 102;
-        let bundle = make_bundle_with_aggregators(
+        let bundle = make_bundle(
             vec![
                 MockOp {
                     op: unaggregated_op.clone(),
@@ -452,6 +590,7 @@ mod tests {
                     signature: Box::new(move || Ok(Some(bytes(aggregator_b_signature)))),
                 },
             ],
+            vec![HandleOpsOut::SuccessWithGas(default_estimated_gas())],
         )
         .await;
         // Ops should be grouped by aggregator. Further, the `signature` field
@@ -501,18 +640,24 @@ mod tests {
         signature: Box<dyn Fn() -> anyhow::Result<Option<Bytes>> + Send + Sync>,
     }
 
-    async fn make_bundle(mock_ops: Vec<MockOp>) -> Bundle {
-        make_bundle_with_aggregators(mock_ops, vec![]).await
+    async fn simple_make_bundle(mock_ops: Vec<MockOp>) -> Bundle {
+        make_bundle(
+            mock_ops,
+            vec![],
+            vec![HandleOpsOut::SuccessWithGas(default_estimated_gas())],
+        )
+        .await
     }
 
-    #[allow(clippy::mutable_key_type)]
-    async fn make_bundle_with_aggregators(
+    async fn make_bundle(
         mock_ops: Vec<MockOp>,
         mock_aggregators: Vec<MockAggregator>,
+        mock_estimate_gasses: Vec<HandleOpsOut>,
     ) -> Bundle {
         let entry_point_address = address(123);
-        let current_block_hash = hash(124);
-        let expected_code_hash = hash(125);
+        let beneficiary_address = address(124);
+        let current_block_hash = hash(125);
+        let expected_code_hash = hash(126);
         let bundle_size = mock_ops.len() as u64;
         let mut op_pool = MockOpPool::new();
         let ops: Vec<_> = mock_ops
@@ -538,6 +683,17 @@ mod tests {
                 block_hash == Some(current_block_hash) && code_hash == Some(expected_code_hash)
             })
             .returning(move |op, _, _| simulations_by_op[&op]());
+        let mut entry_point = MockEntryPointLike::new();
+        entry_point
+            .expect_address()
+            .return_const(entry_point_address);
+        for estimated_gas in mock_estimate_gasses {
+            entry_point
+                .expect_estimate_handle_ops_gas()
+                .times(..=1)
+                .withf(move |_, &beneficiary| beneficiary == beneficiary_address)
+                .return_once(|_, _| Ok(estimated_gas));
+        }
         let signatures_by_aggregator: HashMap<_, _> = mock_aggregators
             .into_iter()
             .map(|agg| (agg.address, agg.signature))
@@ -550,10 +706,11 @@ mod tests {
             .expect_aggregate_signatures()
             .returning(move |address, _| signatures_by_aggregator[&address]());
         let proposer = BundleProposerImpl::new(
-            entry_point_address,
             bundle_size,
+            beneficiary_address,
             op_pool_handle.client.clone(),
             simulator,
+            entry_point,
             Arc::new(provider),
         );
         proposer.make_bundle().await.expect("should make a bundle")
@@ -580,5 +737,9 @@ mod tests {
             sender,
             ..Default::default()
         }
+    }
+
+    fn default_estimated_gas() -> U256 {
+        20000.into()
     }
 }

--- a/src/common/simulation.rs
+++ b/src/common/simulation.rs
@@ -47,6 +47,12 @@ pub struct AggregatorSimOut {
     pub signature: Bytes,
 }
 
+impl SimulationSuccess {
+    pub fn aggregator_address(&self) -> Option<Address> {
+        self.aggregator.as_ref().map(|agg| agg.address)
+    }
+}
+
 #[derive(Clone, Debug, Default, Eq, PartialEq, ethers::contract::EthError)]
 #[etherror(name = "Error", abi = "Error(string)")]
 /// This is the abi for what happens when you just revert("message") in a contract

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -1,3 +1,4 @@
+mod entry_point_like;
 mod provider_like;
 mod timestamp;
 mod validation_results;
@@ -6,6 +7,7 @@ mod violations;
 use std::str::FromStr;
 
 use anyhow::bail;
+pub use entry_point_like::*;
 use ethers::{
     abi::{encode, Token},
     types::{Address, Bytes, H256, U256},
@@ -31,8 +33,8 @@ pub struct UserOperationId {
 impl UserOperation {
     /// Hash a user operation with the given entry point and chain ID.
     ///
-    /// The hash is used to uniquely identify a user operation in the entry point
-    /// it does not include the signature field.
+    /// The hash is used to uniquely identify a user operation in the entry point.
+    /// It does not include the signature field.
     pub fn op_hash(&self, entry_point: Address, chain_id: u64) -> H256 {
         keccak256(encode(&[
             Token::FixedBytes(keccak256(self.pack()).to_vec()),

--- a/src/common/types/entry_point_like.rs
+++ b/src/common/types/entry_point_like.rs
@@ -1,0 +1,76 @@
+use std::ops::Deref;
+
+use ethers::{
+    abi::AbiDecode,
+    contract::ContractError,
+    providers::Middleware,
+    types::{Address, U256},
+};
+#[cfg(test)]
+use mockall::automock;
+use tonic::async_trait;
+
+use crate::common::contracts::{
+    i_entry_point::{FailedOp, IEntryPoint, SignatureValidationFailed},
+    shared_types::UserOpsPerAggregator,
+};
+
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait EntryPointLike: Send + Sync {
+    fn address(&self) -> Address;
+
+    async fn estimate_handle_ops_gas(
+        &self,
+        ops_per_aggregator: Vec<UserOpsPerAggregator>,
+        beneficiary: Address,
+    ) -> anyhow::Result<HandleOpsOut>;
+}
+
+#[derive(Clone, Debug)]
+pub enum HandleOpsOut {
+    SuccessWithGas(U256),
+    FailedOp(usize, String),
+    SignatureValidationFailed(Address),
+}
+
+#[async_trait]
+impl<M> EntryPointLike for IEntryPoint<M>
+where
+    M: Middleware + 'static,
+{
+    fn address(&self) -> Address {
+        self.deref().address()
+    }
+
+    async fn estimate_handle_ops_gas(
+        &self,
+        mut ops_per_aggregator: Vec<UserOpsPerAggregator>,
+        beneficiary: Address,
+    ) -> anyhow::Result<HandleOpsOut> {
+        let result = if ops_per_aggregator.len() == 1
+            && ops_per_aggregator[0].aggregator == Address::zero()
+        {
+            self.handle_ops(ops_per_aggregator.swap_remove(0).user_ops, beneficiary)
+                .estimate_gas()
+                .await
+        } else {
+            self.handle_aggregated_ops(ops_per_aggregator, beneficiary)
+                .estimate_gas()
+                .await
+        };
+        let error = match result {
+            Ok(gas) => return Ok(HandleOpsOut::SuccessWithGas(gas)),
+            Err(error) => error,
+        };
+        if let ContractError::Revert(revert_data) = &error {
+            if let Ok(FailedOp { op_index, reason }) = FailedOp::decode(revert_data) {
+                return Ok(HandleOpsOut::FailedOp(op_index.as_usize(), reason));
+            }
+            if let Ok(failure) = SignatureValidationFailed::decode(revert_data) {
+                return Ok(HandleOpsOut::SignatureValidationFailed(failure.aggregator));
+            }
+        }
+        Err(error)?
+    }
+}


### PR DESCRIPTION
Updates the bundle proposer logic so that after putting together a bundle, it runs `eth_estimateGas` calling `handleOps` (or `handleAggregatedOps`). If successful, it inclues the gas estimate in the returned bundle. If one of the ops or aggregators fails, then reject that op and try again.

This turns out to be incredibly painful to write. To do so, refactor the bundle proposer logic so that it maintains a `ProposerContext` struct that represents the current state what is needed to assemble a bundle. This context has various helper methods such as for rejecting the op with a specified index, and is mutated as the proposer iterates on the bundle until it finds one that succeeds.

Also introduce a new mockable trait, `EntryPointLike`, which exposes convenience methods for what we'll need from an `IEntryPoint`, then update the tests to use it.