### PR TITLE
feat(builder): Implement builder

### DIFF
--- a/src/builder/run.rs
+++ b/src/builder/run.rs
@@ -1,19 +1,35 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
-use anyhow::Context;
-use ethers::providers::{Http, Provider};
+use anyhow::{bail, Context};
+use ethers::{
+    prelude::SignerMiddleware,
+    providers::{Http, HttpRateLimitRetryPolicy, Provider, RetryClientBuilder},
+    types::Address,
+};
+use ethers_signers::Signer;
 use rusoto_core::Region;
-use tokio::sync::{broadcast, mpsc};
-use tonic::transport::Server;
+use tokio::{
+    select,
+    sync::{broadcast, mpsc},
+};
+use tonic::transport::{Channel, Server};
+use url::Url;
 
 use crate::{
     builder::{
-        server::BuilderImpl,
-        signer::{KmsSigner, LocalSigner, SignerLike},
+        bundle_proposer::BundleProposerImpl,
+        server::{BuilderImpl, DummyBuilder},
+        signer::{BundlerSigner, KmsSigner, LocalSigner},
     },
     common::{
-        protos::builder::{builder_server::BuilderServer, BUILDER_FILE_DESCRIPTOR_SET},
-        server::format_socket_addr,
+        contracts::i_entry_point::IEntryPoint,
+        handle::SpawnGuard,
+        protos::{
+            builder::{builder_server::BuilderServer, BUILDER_FILE_DESCRIPTOR_SET},
+            op_pool::op_pool_client::OpPoolClient,
+        },
+        server::{self, format_socket_addr},
+        simulation::{self, SimulatorImpl},
     },
 };
 
@@ -22,12 +38,17 @@ pub struct Args {
     pub port: u16,
     pub host: String,
     pub rpc_url: String,
+    pub pool_url: String,
+    pub entry_point_address: Address,
     pub private_key: Option<String>,
     pub aws_kms_key_ids: Vec<String>,
     pub aws_kms_region: Region,
     pub redis_uri: String,
     pub redis_lock_ttl_millis: u64,
     pub chain_id: u64,
+    pub max_bundle_size: u64,
+    pub eth_poll_interval: Duration,
+    pub sim_settings: simulation::Settings,
 }
 
 pub async fn run(
@@ -38,17 +59,27 @@ pub async fn run(
     let addr = format_socket_addr(&args.host, args.port).parse()?;
     tracing::info!("Starting builder server on {}", addr);
 
-    let provider =
-        Arc::new(Provider::<Http>::try_from(args.rpc_url).context("should create provider")?);
+    let provider = {
+        let parsed_url = Url::parse(&args.rpc_url).context("Invalid RPC URL")?;
+        let http = Http::new(parsed_url);
+        let client = RetryClientBuilder::default()
+            // these retries are if the server returns a 429
+            .rate_limit_retries(10)
+            // these retries are if the connection is dubious
+            .timeout_retries(3)
+            .initial_backoff(Duration::from_millis(500))
+            .build(http, Box::<HttpRateLimitRetryPolicy>::default());
+        Arc::new(Provider::new(client).interval(args.eth_poll_interval))
+    };
 
-    let _tx_sender: Box<dyn SignerLike> = if let Some(pk) = args.private_key {
+    let signer = if let Some(pk) = args.private_key {
         tracing::info!("Using local signer");
-        Box::new(LocalSigner::connect(provider.clone(), args.chain_id, pk).await?)
+        BundlerSigner::Local(LocalSigner::connect(Arc::clone(&provider), args.chain_id, pk).await?)
     } else {
         tracing::info!("Using AWS KMS signer");
-        Box::new(
+        BundlerSigner::Kms(
             KmsSigner::connect(
-                provider.clone(),
+                Arc::clone(&provider),
                 args.chain_id,
                 args.aws_kms_region,
                 args.aws_kms_key_ids,
@@ -58,9 +89,41 @@ pub async fn run(
             .await?,
         )
     };
+    let beneficiary = signer.address();
+    let op_pool = connect_client_with_shutdown(&args.pool_url, shutdown_rx.resubscribe()).await?;
+    let simulator = SimulatorImpl::new(
+        Arc::clone(&provider),
+        args.entry_point_address,
+        args.sim_settings,
+    );
+    let signer_middleware = Arc::new(SignerMiddleware::new(Arc::clone(&provider), signer));
+    let entry_point = IEntryPoint::new(args.entry_point_address, signer_middleware);
+    let proposer = BundleProposerImpl::new(
+        args.max_bundle_size,
+        beneficiary,
+        op_pool.clone(),
+        simulator,
+        entry_point.clone(),
+        Arc::clone(&provider),
+    );
+    let builder = Arc::new(BuilderImpl::new(
+        args.chain_id,
+        beneficiary,
+        args.eth_poll_interval,
+        op_pool,
+        proposer,
+        entry_point,
+        provider,
+    ));
+
+    let _builder_loop_guard = {
+        let builder = Arc::clone(&builder);
+        SpawnGuard::spawn_with_guard(async move { builder.send_bundles_in_loop().await })
+    };
 
     // gRPC server
-    let builder_server = BuilderServer::new(BuilderImpl::new());
+    let builder_server = BuilderServer::new(builder);
+
     let reflection_service = tonic_reflection::server::Builder::configure()
         .register_encoded_file_descriptor_set(BUILDER_FILE_DESCRIPTOR_SET)
         .build()?;
@@ -68,7 +131,7 @@ pub async fn run(
     // health service
     let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
     health_reporter
-        .set_serving::<BuilderServer<BuilderImpl>>()
+        .set_serving::<BuilderServer<DummyBuilder>>()
         .await;
 
     let server_handle = Server::builder()
@@ -91,6 +154,21 @@ pub async fn run(
         Err(e) => {
             tracing::error!("Builder Server error: {:?}", e);
             Err(e).context("Builder Server error")
+        }
+    }
+}
+
+async fn connect_client_with_shutdown(
+    op_pool_url: &str,
+    mut shutdown_rx: broadcast::Receiver<()>,
+) -> anyhow::Result<OpPoolClient<Channel>> {
+    select! {
+        _ = shutdown_rx.recv() => {
+            tracing::error!("bailing from connecting client, server shutting down");
+            bail!("Server shutting down")
+        }
+        res = server::connect_with_retries(op_pool_url, OpPoolClient::connect) => {
+            res
         }
     }
 }

--- a/src/builder/server.rs
+++ b/src/builder/server.rs
@@ -1,31 +1,259 @@
-use tonic::{async_trait, Request, Response, Result};
-
-use crate::common::protos::builder::{
-    builder_server::Builder, DebugSendBundleNowRequest, DebugSendBundleNowResponse,
-    DebugSetBundlingModeRequest, DebugSetBundlingModeResponse,
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
 };
 
-pub struct BuilderImpl {}
+use anyhow::Context;
+use ethers::{
+    providers::{Http, Middleware, Provider, RetryClient},
+    types::{Address, TransactionReceipt, H256},
+};
+use tokio::{join, time};
+use tonic::{async_trait, transport::Channel, Request, Response, Status};
+use tracing::{
+    error,
+    log::{info, trace},
+};
 
-impl BuilderImpl {
-    pub fn new() -> Self {
-        Self {}
+use crate::{
+    builder::bundle_proposer::BundleProposer,
+    common::{
+        protos::{
+            builder::{
+                builder_server::Builder, BundlingMode, DebugSendBundleNowRequest,
+                DebugSendBundleNowResponse, DebugSetBundlingModeRequest,
+                DebugSetBundlingModeResponse,
+            },
+            op_pool::{op_pool_client::OpPoolClient, RemoveOpsRequest},
+        },
+        types::{EntryPointLike, ProviderLike, UserOperation},
+    },
+};
+
+#[derive(Debug)]
+pub struct BuilderImpl<P, E>
+where
+    P: BundleProposer,
+    E: EntryPointLike,
+{
+    is_manual_bundling_mode: AtomicBool,
+    chain_id: u64,
+    beneficiary: Address,
+    eth_poll_interval: Duration,
+    op_pool: OpPoolClient<Channel>,
+    proposer: P,
+    entry_point: E,
+    // TODO: Figure out what we really want to do for detecting new blocks.
+    provider: Arc<Provider<RetryClient<Http>>>,
+}
+
+impl<P, E> BuilderImpl<P, E>
+where
+    P: BundleProposer,
+    E: EntryPointLike,
+{
+    pub fn new(
+        chain_id: u64,
+        beneficiary: Address,
+        eth_poll_interval: Duration,
+        op_pool: OpPoolClient<Channel>,
+        proposer: P,
+        entry_point: E,
+        provider: Arc<Provider<RetryClient<Http>>>,
+    ) -> Self {
+        Self {
+            is_manual_bundling_mode: AtomicBool::new(false),
+            chain_id,
+            beneficiary,
+            eth_poll_interval,
+            op_pool,
+            proposer,
+            entry_point,
+            provider,
+        }
+    }
+
+    /// Loops forever, attempting to form and send a bundle on each new block,
+    /// then waiting for one bundle to be mined or dropped before forming the
+    /// next one.
+    pub async fn send_bundles_in_loop(&self) -> ! {
+        let mut last_block_number = 0;
+        loop {
+            if self.is_manual_bundling_mode.load(Ordering::Relaxed) {
+                time::sleep(self.eth_poll_interval).await;
+                continue;
+            }
+            last_block_number = self.wait_for_new_block(last_block_number).await;
+            let result = self.send_bundle_and_wait_for_mine().await;
+            match result {
+                Ok(Some(receipt)) => info!(
+                    "Bundle with hash {:?} landed in block {}",
+                    receipt.transaction_hash,
+                    receipt.block_number.unwrap_or_default()
+                ),
+                Ok(None) => trace!("No ops to send at block {last_block_number}"),
+                Err(error) => error!("Failed to send bundle. Will retry next block: {error}"),
+            }
+        }
+    }
+
+    async fn wait_for_new_block(&self, prev_block_number: u64) -> u64 {
+        loop {
+            let block_number = self.provider.get_block_number().await;
+            match block_number {
+                Ok(n) => {
+                    let n = n.as_u64();
+                    if n > prev_block_number {
+                        return n;
+                    }
+                }
+                Err(error) => {
+                    error!(
+                        "Failed to load latest block number in builder. Will keep trying: {error}"
+                    );
+                }
+            }
+            time::sleep(self.eth_poll_interval).await;
+        }
+    }
+
+    /// Returns `None` if no bundle was sent because it would contain no ops.
+    async fn send_bundle_and_wait_for_mine(&self) -> anyhow::Result<Option<TransactionReceipt>> {
+        let tx_hash = self.send_bundle().await?;
+        let Some(tx_hash) = tx_hash else {
+            return Ok(None);
+        };
+        let receipt = self
+            .provider
+            .wait_until_mined(tx_hash)
+            .await
+            .context("builder should wait for bundle to mine")?
+            .context("bundle transaction should not be dropped")?;
+        Ok(Some(receipt))
+    }
+
+    /// Returns `None` if no bundle was sent because it would contain no ops.
+    async fn send_bundle(&self) -> anyhow::Result<Option<H256>> {
+        let bundle = self
+            .proposer
+            .make_bundle()
+            .await
+            .context("proposer should create bundle for builder")?;
+        let remove_ops_future = async {
+            let result = self.remove_ops_from_pool(&bundle.rejected_ops).await;
+            if let Err(error) = result {
+                error!("Failed to remove rejected ops from pool: {error}");
+            }
+        };
+        if bundle.is_empty() {
+            remove_ops_future.await;
+            return Ok(None);
+        }
+        info!(
+            "Selected bundle with {} op(s), with {} rejected op(s)",
+            bundle.len(),
+            bundle.rejected_ops.len()
+        );
+        // Give the estimated gas a 10% overhead to account for inaccuracies.
+        let gas = bundle.gas_estimate * 11 / 10;
+        let (_, send_bundle_result) = join!(
+            remove_ops_future,
+            self.entry_point
+                .send_bundle(bundle.ops_per_aggregator, self.beneficiary, gas)
+        );
+        let tx_hash = send_bundle_result.context("builder should send bundle transaction")?;
+        info!("Sent bundle in transaction with hash: {}", tx_hash);
+        Ok(Some(tx_hash))
+    }
+
+    async fn remove_ops_from_pool(&self, ops: &[UserOperation]) -> anyhow::Result<()> {
+        self.op_pool
+            .clone()
+            .remove_ops(RemoveOpsRequest {
+                entry_point: self.entry_point.address().as_bytes().to_vec(),
+                hashes: ops
+                    .iter()
+                    .map(|op| self.op_hash(op).as_bytes().to_vec())
+                    .collect(),
+            })
+            .await
+            .context("builder should remove rejected ops from pool")?;
+        Ok(())
+    }
+
+    fn op_hash(&self, op: &UserOperation) -> H256 {
+        op.op_hash(self.entry_point.address(), self.chain_id)
     }
 }
 
 #[async_trait]
-impl Builder for BuilderImpl {
+impl<P, E> Builder for Arc<BuilderImpl<P, E>>
+where
+    P: BundleProposer,
+    E: EntryPointLike,
+{
     async fn debug_send_bundle_now(
         &self,
         _request: Request<DebugSendBundleNowRequest>,
-    ) -> Result<Response<DebugSendBundleNowResponse>> {
-        Err(tonic::Status::unimplemented("not implemented"))
+    ) -> tonic::Result<Response<DebugSendBundleNowResponse>> {
+        let result = self.send_bundle().await;
+        let tx_hash = match result {
+            Ok(Some(tx_hash)) => tx_hash,
+            Ok(None) => return Err(Status::internal("no ops to send")),
+            Err(error) => return Err(Status::internal(error.to_string())),
+        };
+        Ok(Response::new(DebugSendBundleNowResponse {
+            transaction_hash: tx_hash.as_bytes().to_vec(),
+        }))
+    }
+
+    async fn debug_set_bundling_mode(
+        &self,
+        request: Request<DebugSetBundlingModeRequest>,
+    ) -> tonic::Result<Response<DebugSetBundlingModeResponse>> {
+        let mode = BundlingMode::from_i32(request.into_inner().mode).unwrap_or_default();
+        let is_manual_bundling = match mode {
+            BundlingMode::Unspecified => {
+                return Err(Status::invalid_argument("invalid bundling mode"))
+            }
+            BundlingMode::Manual => true,
+            BundlingMode::Auto => false,
+        };
+        self.is_manual_bundling_mode
+            .store(is_manual_bundling, Ordering::Relaxed);
+        Ok(Response::new(DebugSetBundlingModeResponse {}))
+    }
+}
+
+/// This stupid type exists because we need to write out some type that
+/// implements `Builder` to set up the health reporter, i.e.
+///
+/// `health_reporter.set_serving::<BuilderService<ANY_BUILDER_HERE>>().await;`
+///
+/// It doesn't matter what the type is: the type parameter there is only used to
+/// read the service name out of `BuilderService` which doesn't depend on the
+/// `Builder` impl. But the only other `Builder` impl we have is `BuilderImpl`,
+/// which has multiple type parameters whose concrete types themselves need type
+/// parameters and is overall extremely nasty to write out. So we make ourselves
+/// a non-instantiatable type that implements `Builder` that we can use instead.
+pub enum DummyBuilder {}
+
+#[async_trait]
+impl Builder for DummyBuilder {
+    async fn debug_send_bundle_now(
+        &self,
+        _request: Request<DebugSendBundleNowRequest>,
+    ) -> tonic::Result<Response<DebugSendBundleNowResponse>> {
+        panic!()
     }
 
     async fn debug_set_bundling_mode(
         &self,
         _request: Request<DebugSetBundlingModeRequest>,
-    ) -> Result<Response<DebugSetBundlingModeResponse>> {
-        Err(tonic::Status::unimplemented("not implemented"))
+    ) -> tonic::Result<Response<DebugSetBundlingModeResponse>> {
+        panic!()
     }
 }

--- a/src/common/server.rs
+++ b/src/common/server.rs
@@ -1,3 +1,8 @@
+use std::{cmp, future::Future, time::Duration};
+
+use anyhow::bail;
+use rand::Rng;
+
 pub fn format_server_addr(host: &String, port: u16, secure: bool) -> String {
     if secure {
         format!("https://{}:{}", host, port)
@@ -8,4 +13,25 @@ pub fn format_server_addr(host: &String, port: u16, secure: bool) -> String {
 
 pub fn format_socket_addr(host: &String, port: u16) -> String {
     format!("{}:{}", host, port)
+}
+
+pub async fn connect_with_retries<F, C, FutF>(url: &str, func: F) -> anyhow::Result<C>
+where
+    F: Fn(String) -> FutF,
+    FutF: Future<Output = Result<C, tonic::transport::Error>> + Send + 'static,
+{
+    for i in 0..10 {
+        match func(url.to_owned()).await {
+            Ok(client) => return Ok(client),
+            Err(e) => tracing::warn!("Failed to connect to server {e:?} (attempt {})", i),
+        }
+        let sleep_dur = {
+            let mut rng = rand::thread_rng();
+            let jitter = rng.gen_range(0..1000);
+            let millis = cmp::min(10, 2_u64.pow(i)) * 1000 + jitter;
+            Duration::from_millis(millis)
+        };
+        tokio::time::sleep(sleep_dur).await;
+    }
+    bail!("Failed to connect to server after 10 attempts");
 }

--- a/src/common/simulation.rs
+++ b/src/common/simulation.rs
@@ -78,7 +78,7 @@ struct StorageSlot {
 
 #[cfg_attr(test, automock)]
 #[async_trait]
-pub trait Simulator: Send + Sync {
+pub trait Simulator: Send + Sync + 'static {
     async fn simulate_validation(
         &self,
         op: UserOperation,
@@ -207,7 +207,7 @@ where
     ) -> Result<SimulationSuccess, SimulationError> {
         let block_hash = match block_hash {
             Some(block_hash) => block_hash,
-            None => ProviderLike::get_latest_block_hash(&self.provider).await?,
+            None => self.provider.get_latest_block_hash().await?,
         };
         let block_id = block_hash.into();
         let context = match self.create_context(op.clone(), block_id).await {

--- a/src/common/types/provider_like.rs
+++ b/src/common/types/provider_like.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use anyhow::Context;
 use ethers::{
     contract::ContractError,
-    providers::Middleware,
-    types::{Address, BlockId, BlockNumber, Bytes, H256},
+    providers::{JsonRpcClient, Middleware, PendingTransaction, Provider},
+    types::{Address, BlockId, BlockNumber, Bytes, TransactionReceipt, H256},
 };
 #[cfg(test)]
 use mockall::automock;
@@ -14,7 +14,7 @@ use crate::common::{contracts::i_aggregator::IAggregator, types::UserOperation};
 
 #[cfg_attr(test, automock)]
 #[async_trait]
-pub trait ProviderLike: Send + Sync {
+pub trait ProviderLike: Send + Sync + 'static {
     async fn get_latest_block_hash(&self) -> anyhow::Result<H256>;
 
     async fn aggregate_signatures(
@@ -22,14 +22,16 @@ pub trait ProviderLike: Send + Sync {
         aggregator_address: Address,
         ops: Vec<UserOperation>,
     ) -> anyhow::Result<Option<Bytes>>;
+
+    async fn wait_until_mined(&self, tx_hash: H256) -> anyhow::Result<Option<TransactionReceipt>>;
 }
 
 #[async_trait]
-impl<M> ProviderLike for M
-where
-    M: Middleware + 'static,
-    M::Error: 'static,
-{
+impl<C: JsonRpcClient + 'static> ProviderLike for Provider<C> {
+    // We implement `ProviderLike` for `Provider` rather than for all
+    // `Middleware` because forming a `PendingTransaction` specifically requires
+    // a `Provider`.
+
     async fn get_latest_block_hash(&self) -> anyhow::Result<H256> {
         self.get_block(BlockId::Number(BlockNumber::Latest))
             .await
@@ -52,5 +54,11 @@ where
             Err(ContractError::Revert(_)) => Ok(None),
             Err(error) => Err(error).context("aggregator contract should aggregate signatures")?,
         }
+    }
+
+    async fn wait_until_mined(&self, tx_hash: H256) -> anyhow::Result<Option<TransactionReceipt>> {
+        PendingTransaction::new(tx_hash, self)
+            .await
+            .context("should wait for transaction to be mined or dropped")
     }
 }


### PR DESCRIPTION
Implements the builder, which looks to the op pool on every new block to try to form a bundle. If it does, it sends the bundle in a transaction, then waits for that transaction to become mined or dropped before attempting any additional bundles.

Various refactorings were needed to support this. Most notably, introduce a new `BundlerSigner` enum which allows us to produce a `Signer` backed by either a local signer or a KMS signer, selected at runtime. This allows us to use an `IEntryPoint` backed by this signer to send our transactions, and we do so behind the `EntryPointLike` trait.