### PR TITLE
fix(rpc): fix crash in get UO revert reason

### DIFF
--- a/src/rpc/eth/mod.rs
+++ b/src/rpc/eth/mod.rs
@@ -242,7 +242,7 @@ where
     ) -> Result<Option<String>, anyhow::Error> {
         let revert_reason_evt: Option<UserOperationRevertReasonFilter> = logs
             .iter()
-            .filter(|l| l.topics[1] == user_op_hash)
+            .filter(|l| l.topics.len() > 1 && l.topics[1] == user_op_hash)
             .map_while(|l| {
                 UserOperationRevertReasonFilter::decode_log(&RawLog {
                     topics: l.topics.clone(),


### PR DESCRIPTION
Fixes #159 

## Proposed Changes

  - Check the length before indexing. The `UserOperationRevertReasonFilter` should have `> 1` topics so its okay to filter on that. 

