### PR TITLE
fix(rpc): set resonable gas limits when unset during estimation

### DIFF
--- a/src/cli/builder.rs
+++ b/src/cli/builder.rs
@@ -126,7 +126,7 @@ impl BuilderArgs {
             chain_id: common.chain_id,
             max_bundle_size: self.max_bundle_size,
             eth_poll_interval: Duration::from_millis(self.eth_poll_interval_millis),
-            sim_settings: common.into(),
+            sim_settings: common.try_into()?,
         })
     }
 

--- a/src/cli/node.rs
+++ b/src/cli/node.rs
@@ -56,7 +56,7 @@ pub async fn run(bundler_args: NodeCliArgs, common_args: CommonArgs) -> anyhow::
             pool_url,
             builder_url,
             (&common_args).into(),
-            (&common_args).into(),
+            (&common_args).try_into()?,
         )?,
         shutdown_rx,
         shutdown_scope,

--- a/src/cli/rpc.rs
+++ b/src/cli/rpc.rs
@@ -127,7 +127,7 @@ pub async fn run(rpc_args: RpcCliArgs, common_args: CommonArgs) -> anyhow::Resul
             pool_url,
             builder_url,
             (&common_args).into(),
-            (&common_args).into(),
+            (&common_args).try_into()?,
         )?,
         shutdown_rx,
         shutdown_scope,

--- a/src/common/simulation.rs
+++ b/src/common/simulation.rs
@@ -116,6 +116,10 @@ where
         }
     }
 
+    pub fn settings(&self) -> &Settings {
+        &self.sim_settings
+    }
+
     async fn create_context(
         &self,
         op: UserOperation,
@@ -659,6 +663,8 @@ pub struct Settings {
     pub min_unstake_delay: u32,
     pub min_stake_value: u64,
     pub max_simulate_handle_ops_gas: u64,
+    pub max_call_gas: u64,
+    pub max_verification_gas: u64,
 }
 
 impl Settings {
@@ -666,11 +672,15 @@ impl Settings {
         min_unstake_delay: u32,
         min_stake_value: u64,
         max_simulate_handle_ops_gas: u64,
+        max_call_gas: u64,
+        max_verification_gas: u64,
     ) -> Self {
         Self {
             min_unstake_delay,
             min_stake_value,
             max_simulate_handle_ops_gas,
+            max_call_gas,
+            max_verification_gas,
         }
     }
 }
@@ -684,6 +694,8 @@ impl Default for Settings {
             min_stake_value: 1_000_000_000_000_000_000,
             // 550 million gas: currently the defaults for Alchemy eth_call
             max_simulate_handle_ops_gas: 550_000_000,
+            max_call_gas: 500_000_000,
+            max_verification_gas: 5_000_000,
         }
     }
 }


### PR DESCRIPTION
Fixes #156 

## Proposed Changes

  - Sets gas limits based on the max gas limit allowed when gas limits are not set during gas estimation.
  - This lets users leave these unset when estimating gas, and just fill them in with the results of the estimation.
  - Figuring the max value out is a little hairy, but a conservative value makes sense here (hence the 31/32 multiplier).
