### PR TITLE
feat(op_pool): add pool size metrics

### DIFF
--- a/src/op_pool/mempool/pool.rs
+++ b/src/op_pool/mempool/pool.rs
@@ -120,6 +120,8 @@ impl PoolInner {
             Err(MempoolError::DiscardedOnInsert)?;
         }
 
+        metrics::gauge!("op_pool_num_ops_in_pool", self.by_hash.len() as f64, "entrypoint_addr" => self.config.entry_point.to_string());
+        metrics::gauge!("op_pool_size_bytes", self.size.0 as f64, "entrypoint_addr" => self.config.entry_point.to_string());
         Ok(hash)
     }
 
@@ -150,6 +152,8 @@ impl PoolInner {
                 self.decrement_address_count(addr);
             }
 
+            metrics::gauge!("op_pool_num_ops_in_pool", self.by_hash.len() as f64, "entrypoint_addr" => self.config.entry_point.to_string());
+            metrics::gauge!("op_pool_size_bytes", self.size.0 as f64, "entrypoint_addr" => self.config.entry_point.to_string());
             return Some(op.po);
         }
 

--- a/src/op_pool/mempool/size.rs
+++ b/src/op_pool/mempool/size.rs
@@ -8,7 +8,7 @@ use std::ops::{AddAssign, SubAssign};
 /// additions and subtractions the total size might be slightly off. Therefore, the underlying value
 /// is an `isize`, so that the value does not wrap.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct SizeTracker(isize);
+pub struct SizeTracker(pub isize);
 
 impl AddAssign<usize> for SizeTracker {
     fn add_assign(&mut self, rhs: usize) {


### PR DESCRIPTION
Closes #149 

## Proposed Changes

  - Adds metrics to track the number of ops and the total size of the mempool by entrypoint
