### PR TITLE
fix(rpc): decrease max call gas and increase estimates

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -162,7 +162,7 @@ pub struct CommonArgs {
         long = "max_simulate_handle_ops_gas",
         name = "max_simulate_handle_ops_gas",
         env = "MAX_SIMULATE_HANDLE_OPS_GAS",
-        default_value = "550000000",
+        default_value = "20000000",
         global = true
     )]
     max_simulate_handle_ops_gas: u64,
@@ -197,10 +197,10 @@ impl TryFrom<&CommonArgs> for simulation::Settings {
         // The max call gas used during simulation is the total gas cap, minus the verification gas, minus
         // some overhead. This is then scaled by 31/32 to account for the EVM 1/64th rule which sets asside
         // gas during each call.
-        let max_call_gas = (value.max_simulate_handle_ops_gas
+        let max_call_gas = ((value.max_simulate_handle_ops_gas
             - value.max_verification_gas
             - SIMULATION_GAS_OVERHEAD)
-            * 31
+            * 31)
             / 32;
 
         Ok(Self::new(

--- a/src/rpc/eth/mod.rs
+++ b/src/rpc/eth/mod.rs
@@ -381,9 +381,10 @@ where
                 _ => EthRpcError::Internal(err.into()),
             })?;
 
+        // TODO - this is a temporary solution, we should have a better way to estimate gas
         Ok(GasEstimate {
-            call_gas_limit: gas_sim_result.call_gas,
-            verification_gas_limit: gas_sim_result.verification_gas,
+            call_gas_limit: (gas_sim_result.call_gas * 5) / 4,
+            verification_gas_limit: gas_sim_result.verification_gas * 3,
             pre_verification_gas,
         })
     }


### PR DESCRIPTION
Helps address #155, doesn't fix.

