### PR TITLE
fix(rpc): remove gas cap for gas estimates, use 25% overhead

### DIFF
--- a/src/common/simulation.rs
+++ b/src/common/simulation.rs
@@ -383,13 +383,9 @@ where
         &self,
         op: UserOperation,
     ) -> Result<GasSimulationSuccess, GasSimulationError> {
-        let tracer_out = tracer::trace_simulate_handle_op(
-            &self.entry_point,
-            op,
-            BlockNumber::Latest.into(),
-            self.sim_settings.max_simulate_handle_ops_gas,
-        )
-        .await?;
+        let tracer_out =
+            tracer::trace_simulate_handle_op(&self.entry_point, op, BlockNumber::Latest.into())
+                .await?;
 
         let Some(ref revert_data) = tracer_out.revert_data else {
             return Err(GasSimulationError::DidNotRevert);

--- a/src/common/tracer.rs
+++ b/src/common/tracer.rs
@@ -112,11 +112,9 @@ pub async fn trace_simulate_handle_op(
     entry_point: &IEntryPoint<impl Middleware>,
     op: UserOperation,
     block_id: BlockId,
-    gas: u64,
 ) -> anyhow::Result<GasTracerOutput> {
     let tx = entry_point
         .simulate_handle_op(op, Address::default(), Bytes::default())
-        .gas(gas)
         .tx;
 
     trace_call(

--- a/src/rpc/eth/mod.rs
+++ b/src/rpc/eth/mod.rs
@@ -384,7 +384,7 @@ where
         // TODO - this is a temporary solution, we should have a better way to estimate gas
         Ok(GasEstimate {
             call_gas_limit: (gas_sim_result.call_gas * 5) / 4,
-            verification_gas_limit: gas_sim_result.verification_gas * 3,
+            verification_gas_limit: (gas_sim_result.verification_gas * 5) / 4,
             pre_verification_gas,
         })
     }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -167,12 +167,15 @@ impl UserOperationOptionalGas {
             paymaster_and_data: self.paymaster_and_data,
             signature: self.signature,
             // If unset, default these to gas limits from settings
+            // Cap their values to the gas limits from settings
             verification_gas_limit: self
                 .verification_gas_limit
-                .unwrap_or_else(|| settings.max_verification_gas.into()),
+                .map(|v| v.min(settings.max_verification_gas.into()))
+                .unwrap_or(settings.max_verification_gas.into()),
             call_gas_limit: self
                 .call_gas_limit
-                .unwrap_or_else(|| settings.max_call_gas.into()),
+                .map(|c| c.min(settings.max_call_gas.into()))
+                .unwrap_or(settings.max_call_gas.into()),
             // These aren't used in gas estimation, set to if unset 0 so that there are no payment attempts during gas estimation
             pre_verification_gas: self.pre_verification_gas.unwrap_or_default(),
             max_fee_per_gas: self.max_fee_per_gas.unwrap_or_default(),


### PR DESCRIPTION
Fixes #155 

This isn't a permanent fix as it requires a hardcoded 25% overhead to the estimated gas through the tracer. We believe this is due to the 1/64th rule.

@dphilipson has an idea of an approach that uses binary searches to find the validation/call gas limits that we should implement when we have time. Created an issue for that here: #169
