### PR TITLE
fix(tracer): Avoid TypedArray#slice for Matic

### DIFF
--- a/tracer/src/gasTracer.ts
+++ b/tracer/src/gasTracer.ts
@@ -114,7 +114,9 @@ interface InternalPhase {
 
     enter(frame) {
       if (toHex(frame.getTo()) === entryPointAddress) {
-        if (toHex(frame.getInput().slice(0, 4)) === INNER_HANDLE_OPS_SELECTOR) {
+        if (
+          toHex(frame.getInput().subarray(0, 4)) === INNER_HANDLE_OPS_SELECTOR
+        ) {
           currentPhase.calledInnerHandleOps = true;
         }
       }

--- a/tracer/src/types.ts
+++ b/tracer/src/types.ts
@@ -9,8 +9,12 @@ export interface BigInt {
   toString(radix?: 16): string;
 }
 
-export type Address = number[]; // Always length 20
-export type Bytes = number[];
+// Only the following properties are available on Matic.
+export type Bytes = Pick<
+  Uint8Array,
+  "length" | "byteLength" | "byteOffset" | "buffer" | "set" | "subarray"
+>;
+export type Address = Bytes; // Always length 20
 
 export interface LogContext {
   type: "CALL" | "CREATE"; // one of the two values CALL and CREATE

--- a/tracer/src/validationTracer.ts
+++ b/tracer/src/validationTracer.ts
@@ -316,7 +316,7 @@ type StringSet = Record<string, boolean | undefined>;
         // tests fail
         if (
           input.length > 0 &&
-          toHex(input.slice(0, 4)) !== DEPOSIT_TO_SELECTOR
+          toHex(input.subarray(0, 4)) !== DEPOSIT_TO_SELECTOR
         ) {
           currentPhase.calledBannedEntryPointMethod = true;
         }


### PR DESCRIPTION
The Matic tracer environment is so old and/or weird that its `Uint8Array`s don't have a `.slice` method. Instead, use `.subarray`, and update our TypeScript definitions to reflect this.

Fixes https://github.com/OMGWINNING/rundler/issues/167 (for real this time)