### PR TITLE
feat(builder): Track paymaster balances when building

### DIFF
--- a/src/common/precheck.rs
+++ b/src/common/precheck.rs
@@ -170,7 +170,6 @@ where
         let AsyncData {
             paymaster_exists,
             payer_funds,
-            base_fee,
             ..
         } = async_data;
         if !op.paymaster_and_data.is_empty() {
@@ -181,7 +180,7 @@ where
                 return Some(PrecheckViolation::PaymasterIsNotContract(paymaster));
             }
         }
-        let max_gas_cost = max_gas_cost_for_op(op, base_fee);
+        let max_gas_cost = op.max_gas_cost();
         if payer_funds < max_gas_cost {
             if op.paymaster_and_data.is_empty() {
                 return Some(PrecheckViolation::SenderFundsTooLow(
@@ -265,14 +264,6 @@ where
             .base_fee_per_gas
             .context("latest block should have a nonempty base fee")
     }
-}
-
-fn max_gas_cost_for_op(op: &UserOperation, base_fee: U256) -> U256 {
-    let max_gas = op.call_gas_limit + op.verification_gas_limit + op.pre_verification_gas;
-    let fee_per_gas = op
-        .max_fee_per_gas
-        .min(op.max_priority_fee_per_gas + base_fee);
-    max_gas * fee_per_gas
 }
 
 #[derive(Clone, Debug, parse_display::Display, Eq, PartialEq)]

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -90,6 +90,11 @@ impl UserOperation {
         ])
         .into()
     }
+
+    pub fn max_gas_cost(&self) -> U256 {
+        let max_gas = self.call_gas_limit + self.verification_gas_limit + self.pre_verification_gas;
+        max_gas * self.max_fee_per_gas
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/common/types/entry_point_like.rs
+++ b/src/common/types/entry_point_like.rs
@@ -33,6 +33,8 @@ pub trait EntryPointLike: Send + Sync + 'static {
         beneficiary: Address,
         gas: U256,
     ) -> anyhow::Result<H256>;
+
+    async fn get_deposit(&self, address: Address, block_hash: H256) -> anyhow::Result<U256>;
 }
 
 #[derive(Clone, Debug)]
@@ -86,6 +88,16 @@ where
             .await
             .context("should send bundle transaction")?
             .tx_hash())
+    }
+
+    async fn get_deposit(&self, address: Address, block_hash: H256) -> anyhow::Result<U256> {
+        let deposit_info = self
+            .get_deposit_info(address)
+            .block(block_hash)
+            .call()
+            .await
+            .context("entry point should return deposit info")?;
+        Ok(deposit_info.deposit.into())
     }
 }
 

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -171,11 +171,11 @@ impl UserOperationOptionalGas {
             verification_gas_limit: self
                 .verification_gas_limit
                 .map(|v| v.min(settings.max_verification_gas.into()))
-                .unwrap_or(settings.max_verification_gas.into()),
+                .unwrap_or_else(|| settings.max_verification_gas.into()),
             call_gas_limit: self
                 .call_gas_limit
                 .map(|c| c.min(settings.max_call_gas.into()))
-                .unwrap_or(settings.max_call_gas.into()),
+                .unwrap_or_else(|| settings.max_call_gas.into()),
             // These aren't used in gas estimation, set to if unset 0 so that there are no payment attempts during gas estimation
             pre_verification_gas: self.pre_verification_gas.unwrap_or_default(),
             max_fee_per_gas: self.max_fee_per_gas.unwrap_or_default(),


### PR DESCRIPTION
Don't build bundles where the total possible costs of ops using a given paymaster is greater than that paymaster's current balance. When this occurs, instead reject all ops from that paymaster.

Fixes https://github.com/OMGWINNING/rundler/issues/151.
