### PR TITLE
feat(simulation): whitelist allowed precompile addresses

### DIFF
--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -1,2 +1,4 @@
-account-abstraction/=lib/account-abstraction/contracts/
+forge-std/=lib/forge-std/src
+ds-test/=lib/forge-std/lib/ds-test/src/
+@account-abstraction/=lib/account-abstraction/contracts/
 @openzeppelin/=lib/openzeppelin-contracts/

--- a/contracts/src/PrecompileAccount.sol
+++ b/contracts/src/PrecompileAccount.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.13;
+
+import "@account-abstraction/interfaces/IAccount.sol";
+
+contract PrecompileAccount is IAccount {
+    address public precompile;
+
+    constructor(address _precompile) {
+        precompile = _precompile;
+    }
+
+    function validateUserOp(UserOperation calldata, bytes32, uint256) external view override returns (uint256) {
+        assembly {
+            let addr := sload(precompile.slot)
+            let r := staticcall(10000, addr, 0, 0, 0, 0)
+        }
+        return 0;
+    }
+
+    function execute(address dest, uint256 value, bytes calldata func) external {
+        (bool success, bytes memory result) = dest.call{value : value}(func);
+        if (!success) {
+            assembly {
+                revert(add(result, 32), mload(result))
+            }
+        }
+    }
+
+    function getNonce() public view virtual returns (uint256) {
+        return 0;
+    }
+}

--- a/contracts/test/PrecompileAccountTest.sol
+++ b/contracts/test/PrecompileAccountTest.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.14;
+
+import "forge-std/Test.sol";
+import "../src/PrecompileAccount.sol";
+import "@account-abstraction/interfaces/UserOperation.sol";
+
+contract PrecompileAccountTest is Test {
+    PrecompileAccount public account;
+
+    function setUp() public {
+        account = new PrecompileAccount(0x000000000000000000000000000000000000006D);
+    }
+
+    function testValidateUserOp() view public {
+        UserOperation memory userOp = UserOperation(address(0), 0, "", "", 0, 0, 0, 0, 0, "", "");
+        account.validateUserOp(userOp, 0, 0);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -184,7 +184,7 @@ impl TryFrom<&CommonArgs> for simulation::Settings {
 
     fn try_from(value: &CommonArgs) -> Result<Self, Self::Error> {
         if value.max_verification_gas
-            > (value.max_simulate_handle_ops_gas + SIMULATION_GAS_OVERHEAD)
+            > (value.max_simulate_handle_ops_gas - SIMULATION_GAS_OVERHEAD)
         {
             anyhow::bail!(
                 "max_verification_gas ({}) must be less than max_simulate_handle_ops_gas ({}) by at least {}",

--- a/src/common/simulation.rs
+++ b/src/common/simulation.rs
@@ -250,6 +250,12 @@ where
                     ViolationOpCode(*opcode),
                 ));
             }
+            for precompile in &phase.forbidden_precompiles_used {
+                violations.push(SimulationViolation::UsedForbiddenPrecompile(
+                    entity,
+                    *precompile,
+                ));
+            }
             if phase.used_invalid_gas_opcode {
                 violations.push(SimulationViolation::InvalidGasOpcode(entity));
             }
@@ -474,6 +480,8 @@ pub enum SimulationViolation {
     UnintendedRevertWithMessage(Entity, String, Option<Address>),
     #[display("{0} uses banned opcode: {1}")]
     UsedForbiddenOpcode(Entity, ViolationOpCode),
+    #[display("{0} uses banned precompile: {1:?}")]
+    UsedForbiddenPrecompile(Entity, Address),
     #[display("{0} uses banned opcode: GAS")]
     InvalidGasOpcode(Entity),
     #[display("factory may only call CREATE2 once during initialization")]

--- a/src/common/tracer.rs
+++ b/src/common/tracer.rs
@@ -26,6 +26,7 @@ pub struct TracerOutput {
 #[serde(rename_all = "camelCase")]
 pub struct Phase {
     pub forbidden_opcodes_used: Vec<Opcode>,
+    pub forbidden_precompiles_used: Vec<Address>,
     pub used_invalid_gas_opcode: bool,
     pub storage_accesses: Vec<StorageAccess>,
     pub called_banned_entry_point_method: bool,
@@ -119,6 +120,7 @@ pub async fn trace_simulate_handle_op(
 ) -> anyhow::Result<GasTracerOutput> {
     let tx = entry_point
         .simulate_handle_op(op, Address::zero(), Bytes::default())
+        .gas(550_000_000)
         .tx;
 
     trace_call(

--- a/src/rpc/eth/error.rs
+++ b/src/rpc/eth/error.rs
@@ -47,7 +47,10 @@ pub enum EthRpcError {
     /// Opcode violation
     #[error("{0} uses banned opcode: {1:?}")]
     OpcodeViolation(Entity, Opcode),
-    /// Invalid storage access maps to Opcode Violation
+    /// Precompile violation, maps to Opcode Violation
+    #[error("{0} uses banned precompile: {1:?}")]
+    PrecompileViolation(Entity, Address),
+    /// Invalid storage access, maps to Opcode Violation
     #[error("{0} accesses inaccessible storage at {1:?}")]
     InvalidStorageAccess(Entity, Address),
     /// Operation is out of time range
@@ -204,9 +207,9 @@ impl From<EthRpcError> for RpcError {
             EthRpcError::PaymasterValidationRejected(data) => {
                 rpc_err_with_data(PAYMASTER_VALIDATION_REJECTED_CODE, msg, data)
             }
-            EthRpcError::OpcodeViolation(_, _) | EthRpcError::InvalidStorageAccess(_, _) => {
-                rpc_err(OPCODE_VIOLATION_CODE, msg)
-            }
+            EthRpcError::OpcodeViolation(_, _)
+            | EthRpcError::PrecompileViolation(_, _)
+            | EthRpcError::InvalidStorageAccess(_, _) => rpc_err(OPCODE_VIOLATION_CODE, msg),
             EthRpcError::OutOfTimeRange(data) => {
                 rpc_err_with_data(OUT_OF_TIME_RANGE_CODE, msg, data)
             }

--- a/src/rpc/eth/mod.rs
+++ b/src/rpc/eth/mod.rs
@@ -578,6 +578,9 @@ impl From<SimulationError> for EthRpcError {
             SimulationViolation::UsedForbiddenOpcode(entity, op) => {
                 Self::OpcodeViolation(*entity, op.clone().0)
             }
+            SimulationViolation::UsedForbiddenPrecompile(entity, precompile) => {
+                Self::PrecompileViolation(*entity, *precompile)
+            }
             SimulationViolation::InvalidGasOpcode(entity) => {
                 Self::OpcodeViolation(*entity, Opcode::GAS)
             }


### PR DESCRIPTION
Closes #84 

## Proposed Changes

  - Adds a precompile whitelist to the tracer. As precompiles are added on networks this list can be added to.
  - This will block all of the [arbitrum precompiles](https://developer.arbitrum.io/arbos/precompiles) each of which I believe is dynamic
  - Adds an error type, but uses on the OPCODE_VIOLATION RPC code with a different message.

Needs testing, I'm going to have to write an account contract that uses an Arbitrum precompile during validation.
 
