### PR TITLE
feat(pool): add endpoint to remove ops by entity

### DIFF
--- a/proto/op_pool.proto
+++ b/proto/op_pool.proto
@@ -23,6 +23,11 @@ enum EntityType {
   ENTITY_TYPE_FACTORY = 4;
 }
 
+message Entity {
+  EntityType entity = 1;
+  bytes address = 2;
+}
+
 message MempoolOp {
   UserOperation uo = 1;
   bytes aggregator = 2;
@@ -39,6 +44,7 @@ service OpPool {
   rpc AddOp (AddOpRequest) returns (AddOpResponse);
   rpc GetOps (GetOpsRequest) returns (GetOpsResponse);
   rpc RemoveOps(RemoveOpsRequest) returns (RemoveOpsResponse);
+  rpc RemoveEntities(RemoveEntitiesRequest) returns (RemoveEntitiesResponse);
 
   rpc DebugClearState (DebugClearStateRequest) returns (DebugClearStateResponse);
   rpc DebugDumpMempool (DebugDumpMempoolRequest) returns (DebugDumpMempoolResponse);
@@ -73,6 +79,12 @@ message RemoveOpsRequest {
   repeated bytes hashes = 2;
 }
 message RemoveOpsResponse {}
+
+message RemoveEntitiesRequest {
+  bytes entry_point = 1;
+  repeated Entity entities = 2;
+}
+message RemoveEntitiesResponse {}
 
 message DebugClearStateRequest {}
 message DebugClearStateResponse {}

--- a/src/common/grpc/mocks.rs
+++ b/src/common/grpc/mocks.rs
@@ -23,7 +23,8 @@ use crate::common::protos::{
         DebugDumpMempoolRequest, DebugDumpMempoolResponse, DebugDumpReputationRequest,
         DebugDumpReputationResponse, DebugSetReputationRequest, DebugSetReputationResponse,
         GetOpsRequest, GetOpsResponse, GetSupportedEntryPointsRequest,
-        GetSupportedEntryPointsResponse, RemoveOpsRequest, RemoveOpsResponse,
+        GetSupportedEntryPointsResponse, RemoveEntitiesRequest, RemoveEntitiesResponse,
+        RemoveOpsRequest, RemoveOpsResponse,
     },
 };
 
@@ -50,6 +51,11 @@ mock! {
             &self,
             request: Request<RemoveOpsRequest>,
         ) -> tonic::Result<Response<RemoveOpsResponse>>;
+
+        async fn remove_entities(
+            &self,
+            _request: Request<RemoveEntitiesRequest>,
+        ) -> tonic::Result<Response<RemoveEntitiesResponse>>;
 
         async fn debug_clear_state(
             &self,

--- a/src/op_pool/mempool/mod.rs
+++ b/src/op_pool/mempool/mod.rs
@@ -44,6 +44,9 @@ pub trait Mempool: Send + Sync {
     /// Removes a set of operations from the pool.
     fn remove_operations<'a>(&self, hashes: impl IntoIterator<Item = &'a H256>);
 
+    /// Removes all operations assocaited with a given entity from the pool.
+    fn remove_entity(&self, entity: EntityType, address: Address);
+
     /// Returns the best operations from the pool.
     ///
     /// Returns the best operations from the pool based on their gas bids up to

--- a/src/op_pool/mempool/uo_pool.rs
+++ b/src/op_pool/mempool/uo_pool.rs
@@ -176,6 +176,10 @@ where
         }
     }
 
+    fn remove_entity(&self, entity: EntityType, address: Address) {
+        self.state.write().pool.remove_entity(entity, address);
+    }
+
     fn best_operations(&self, max: usize) -> Vec<Arc<PoolOperation>> {
         // get the best operations from the pool
         let ordered_ops = self.state.read().pool.best_operations();


### PR DESCRIPTION
Closes #139 

## Proposed Changes

  - Adds an endpoint to the pool that removes all operations associated with an entity
  - Uses this endpoint in the builder based on revert messages during gas estimation
