### PR TITLE
refactor: rename entity to entityType

### DIFF
--- a/proto/op_pool.proto
+++ b/proto/op_pool.proto
@@ -15,12 +15,12 @@ message UserOperation {
   bytes signature = 11;
 }
 
-enum Entity {
-  ENTITY_UNSPECIFIED = 0;
-  ENTITY_ACCOUNT = 1;
-  ENTITY_PAYMASTER = 2;
-  ENTITY_AGGREGATOR = 3;
-  ENTITY_FACTORY = 4;
+enum EntityType {
+  ENTITY_TYPE_UNSPECIFIED = 0;
+  ENTITY_TYPE_ACCOUNT = 1;
+  ENTITY_TYPE_PAYMASTER = 2;
+  ENTITY_TYPE_AGGREGATOR = 3;
+  ENTITY_TYPE_FACTORY = 4;
 }
 
 message MempoolOp {
@@ -29,7 +29,7 @@ message MempoolOp {
   uint64 valid_after = 3;
   uint64 valid_until = 4;
   bytes expected_code_hash = 5;
-  repeated Entity entities_needing_stake = 6;
+  repeated EntityType entities_needing_stake = 6;
   bytes sim_block_hash = 7;
   bool account_is_staked = 8;
 }

--- a/src/common/protos.rs
+++ b/src/common/protos.rs
@@ -1,7 +1,8 @@
 use ethers::types::{Address, H256, U256};
 
 use crate::common::types::{
-    BundlingMode as RpcBundlingMode, Entity as EntityType, UserOperation as RpcUserOperation,
+    BundlingMode as RpcBundlingMode, EntityType as CommonEntityType,
+    UserOperation as RpcUserOperation,
 };
 
 pub mod op_pool {
@@ -50,27 +51,27 @@ pub mod op_pool {
         }
     }
 
-    impl TryFrom<Entity> for EntityType {
+    impl TryFrom<EntityType> for CommonEntityType {
         type Error = ConversionError;
 
-        fn try_from(entity: Entity) -> Result<Self, Self::Error> {
+        fn try_from(entity: EntityType) -> Result<Self, Self::Error> {
             match entity {
-                Entity::Unspecified => Err(ConversionError::InvalidEntity(entity as i32)),
-                Entity::Account => Ok(EntityType::Account),
-                Entity::Paymaster => Ok(EntityType::Paymaster),
-                Entity::Aggregator => Ok(EntityType::Aggregator),
-                Entity::Factory => Ok(EntityType::Factory),
+                EntityType::Unspecified => Err(ConversionError::InvalidEntity(entity as i32)),
+                EntityType::Account => Ok(CommonEntityType::Account),
+                EntityType::Paymaster => Ok(CommonEntityType::Paymaster),
+                EntityType::Aggregator => Ok(CommonEntityType::Aggregator),
+                EntityType::Factory => Ok(CommonEntityType::Factory),
             }
         }
     }
 
-    impl From<EntityType> for Entity {
-        fn from(entity: EntityType) -> Self {
+    impl From<CommonEntityType> for EntityType {
+        fn from(entity: CommonEntityType) -> Self {
             match entity {
-                EntityType::Account => Entity::Account,
-                EntityType::Paymaster => Entity::Paymaster,
-                EntityType::Aggregator => Entity::Aggregator,
-                EntityType::Factory => Entity::Factory,
+                CommonEntityType::Account => EntityType::Account,
+                CommonEntityType::Paymaster => EntityType::Paymaster,
+                CommonEntityType::Aggregator => EntityType::Aggregator,
+                CommonEntityType::Factory => EntityType::Factory,
             }
         }
     }

--- a/src/common/types/mod.rs
+++ b/src/common/types/mod.rs
@@ -106,23 +106,23 @@ pub struct ExpectedStorageSlot {
 
 #[derive(Display, Debug, Clone, Ord, Copy, Eq, PartialEq, EnumIter, PartialOrd)]
 #[display(style = "lowercase")]
-pub enum Entity {
+pub enum EntityType {
     Account,
     Paymaster,
     Aggregator,
     Factory,
 }
 
-impl FromStr for Entity {
+impl FromStr for EntityType {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "account" => Ok(Entity::Account),
-            "paymaster" => Ok(Entity::Paymaster),
-            "aggregator" => Ok(Entity::Aggregator),
-            "factory" => Ok(Entity::Factory),
-            _ => bail!("Invalid entity: {s}"),
+            "account" => Ok(EntityType::Account),
+            "paymaster" => Ok(EntityType::Paymaster),
+            "aggregator" => Ok(EntityType::Aggregator),
+            "factory" => Ok(EntityType::Factory),
+            _ => bail!("Invalid entity type: {s}"),
         }
     }
 }

--- a/src/op_pool/mempool/error.rs
+++ b/src/op_pool/mempool/error.rs
@@ -1,6 +1,6 @@
 use ethers::{abi::Address, types::U256};
 
-use crate::common::types::Entity;
+use crate::common::types::EntityType;
 
 /// Mempool result type.
 pub type MempoolResult<T> = std::result::Result<T, MempoolError>;
@@ -20,7 +20,7 @@ pub enum MempoolError {
     MaxOperationsReached(usize, Address),
     /// An entity associated with the operation is throttled/banned.
     #[error("Entity {0}:{1} is throttled/banned")]
-    EntityThrottled(Entity, Address),
+    EntityThrottled(EntityType, Address),
     #[error("Operation was discarded on inserting")]
     DiscardedOnInsert,
 }

--- a/src/op_pool/mempool/uo_pool.rs
+++ b/src/op_pool/mempool/uo_pool.rs
@@ -17,7 +17,7 @@ use crate::{
     common::{
         contracts::i_entry_point::IEntryPointEvents,
         protos::op_pool::{Reputation, ReputationStatus},
-        types::Entity,
+        types::EntityType,
     },
     op_pool::{event::NewBlockEvent, reputation::ReputationManager},
 };
@@ -98,7 +98,7 @@ where
             if let IEntryPointEvents::UserOperationEventFilter(uo_event) = &event.contract_event {
                 let op_hash = uo_event.user_op_hash.into();
                 if let Some(op) = state.pool.remove_operation_by_hash(op_hash) {
-                    for entity in Entity::iter() {
+                    for entity in EntityType::iter() {
                         if op.is_staked(entity) {
                             match op.entity_address(entity) {
                                 Some(e) => self.reputation.add_included(e),

--- a/src/op_pool/types.rs
+++ b/src/op_pool/types.rs
@@ -5,7 +5,7 @@ use super::mempool::PoolOperation;
 use crate::common::{
     protos::{
         self,
-        op_pool::{Entity as ProtoEntity, MempoolOp, UserOperation},
+        op_pool::{EntityType as ProtoEntityType, MempoolOp, UserOperation},
         ConversionError,
     },
     types::ValidTimeRange,
@@ -25,7 +25,7 @@ impl TryFrom<&PoolOperation> for MempoolOp {
             entities_needing_stake: op
                 .entities_needing_stake
                 .iter()
-                .map(|e| ProtoEntity::from(*e).into())
+                .map(|e| ProtoEntityType::from(*e).into())
                 .collect(),
             account_is_staked: op.account_is_staked,
         })
@@ -53,7 +53,7 @@ impl TryFrom<MempoolOp> for PoolOperation {
             .entities_needing_stake
             .into_iter()
             .map(|e| {
-                let pe = ProtoEntity::from_i32(e).ok_or(ConversionError::InvalidEntity(e))?;
+                let pe = ProtoEntityType::from_i32(e).ok_or(ConversionError::InvalidEntity(e))?;
                 pe.try_into()
             })
             .collect::<Result<Vec<_>, ConversionError>>()?;

--- a/src/rpc/eth/error.rs
+++ b/src/rpc/eth/error.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use crate::common::{
     precheck::PrecheckError,
     simulation::SimulationError,
-    types::{Entity, Timestamp},
+    types::{EntityType, Timestamp},
 };
 
 // Error codes borrowed from jsonrpsee
@@ -46,13 +46,13 @@ pub enum EthRpcError {
     PaymasterValidationRejected(PaymasterValidationRejectedData),
     /// Opcode violation
     #[error("{0} uses banned opcode: {1:?}")]
-    OpcodeViolation(Entity, Opcode),
+    OpcodeViolation(EntityType, Opcode),
     /// Precompile violation, maps to Opcode Violation
     #[error("{0} uses banned precompile: {1:?}")]
-    PrecompileViolation(Entity, Address),
+    PrecompileViolation(EntityType, Address),
     /// Invalid storage access, maps to Opcode Violation
     #[error("{0} accesses inaccessible storage at {1:?}")]
-    InvalidStorageAccess(Entity, Address),
+    InvalidStorageAccess(EntityType, Address),
     /// Operation is out of time range
     #[error("operation is out of time range")]
     OutOfTimeRange(OutOfTimeRangeData),


### PR DESCRIPTION
Starts #203

Splitting this into 2 PRs. This PR just renames our existing `Entity` structs to `EntityType`. The next PR will add:

```rust
pub struct Entity {
    type: EntityType,
    address: Address
}