### PR TITLE
fix(rpc): add gas cap to simulate handle ops call

### DIFF
--- a/src/common/simulation.rs
+++ b/src/common/simulation.rs
@@ -402,9 +402,13 @@ where
         &self,
         op: UserOperation,
     ) -> Result<GasSimulationSuccess, GasSimulationError> {
-        let tracer_out =
-            tracer::trace_simulate_handle_op(&self.entry_point, op, BlockNumber::Latest.into())
-                .await?;
+        let tracer_out = tracer::trace_simulate_handle_op(
+            &self.entry_point,
+            op,
+            BlockNumber::Latest.into(),
+            self.sim_settings.max_simulate_handle_ops_gas,
+        )
+        .await?;
 
         let Some(ref revert_data) = tracer_out.revert_data else {
             return Err(GasSimulationError::DidNotRevert);

--- a/src/common/tracer.rs
+++ b/src/common/tracer.rs
@@ -117,10 +117,11 @@ pub async fn trace_simulate_handle_op(
     entry_point: &IEntryPoint<impl Middleware>,
     op: UserOperation,
     block_id: BlockId,
+    max_gas: u64,
 ) -> anyhow::Result<GasTracerOutput> {
     let tx = entry_point
         .simulate_handle_op(op, Address::zero(), Bytes::default())
-        .gas(550_000_000)
+        .gas(max_gas)
         .tx;
 
     trace_call(


### PR DESCRIPTION
Closes #152

## Proposed Changes

  - This is the only place I could find.
  - We should make sure that all future calls to the nodes have gas caps.
