### PR TITLE
fix(estimation): enforce MIN_CALL_GAS_LIMIT in estimation

### DIFF
--- a/src/common/precheck.rs
+++ b/src/common/precheck.rs
@@ -15,7 +15,7 @@ use crate::common::{
 };
 
 /// The min cost of a `CALL` with nonzero value, as required by the spec.
-const MIN_CALL_GAS_LIMIT: U256 = U256([9000, 0, 0, 0]);
+pub const MIN_CALL_GAS_LIMIT: U256 = U256([9100, 0, 0, 0]);
 
 #[async_trait]
 pub trait Prechecker {

--- a/src/rpc/eth/estimation.rs
+++ b/src/rpc/eth/estimation.rs
@@ -21,6 +21,7 @@ use crate::{
             CALLGASESTIMATIONPROXY_DEPLOYED_BYTECODE,
         },
         eth,
+        precheck::MIN_CALL_GAS_LIMIT,
         types::{EntryPointLike, ProviderLike, UserOperation},
     },
     rpc::{GasEstimate, UserOperationOptionalGas},
@@ -109,7 +110,7 @@ impl<P: ProviderLike, E: EntryPointLike> GasEstimator for GasEstimatorImpl<P, E>
                 * (100 + VERIFICATION_GAS_BUFFER_PERCENT)
                 / 100)
                 .min(settings.max_verification_gas.into()),
-            call_gas_limit: call_gas_limit.min(settings.max_call_gas.into()),
+            call_gas_limit: call_gas_limit.clamp(MIN_CALL_GAS_LIMIT, settings.max_call_gas.into()),
         })
     }
 }


### PR DESCRIPTION
When returning estimates for `min_call_gas`, ensure that the returned value is at least `MIN_CALL_GAS_LIMIT`, a value mandated by the spec below which the precheck should reject the operation.

While we're at it, update `MIN_CALL_GAS_LIMIT` from 9000 to 9100. The spec says it should be the minimum cost of a call with nonzero value, which is 9100.