### PR TITLE
fix(estimation): use positive gas fee in validation estimation

### DIFF
--- a/src/common/types/entry_point_like.rs
+++ b/src/common/types/entry_point_like.rs
@@ -50,23 +50,6 @@ pub trait EntryPointLike: Send + Sync + 'static {
         gas: U256,
         spoofed_state: &spoof::State,
     ) -> anyhow::Result<Result<ExecutionResult, String>>;
-
-    async fn call_simulate_op(
-        &self,
-        op: UserOperation,
-        block_hash: H256,
-        gas: U256,
-    ) -> anyhow::Result<Result<ExecutionResult, String>> {
-        self.call_spoofed_simulate_op(
-            op,
-            Address::zero(),
-            Bytes::new(),
-            block_hash,
-            gas,
-            &spoof::State::default(),
-        )
-        .await
-    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
When `maxFeePerGas` is zero, the account's required prepayment is zero as well, which means the account skips an eth transfer to the entry point. This missing transfer means that gas estimates are too low if the user sets their gas fees after performing gas estimation. To avoid this, always do verification gas estimation with a positive `maxFeePerGas`.