### PR TITLE
fix(simulation): Reject calls with value if not from sender

### DIFF
--- a/src/common/simulation.rs
+++ b/src/common/simulation.rs
@@ -279,7 +279,11 @@ where
             for address in banned_addresses_accessed {
                 violations.push(SimulationViolation::InvalidStorageAccess(entity, address));
             }
-            if phase.called_with_value {
+            let non_sender_called_with_value = phase
+                .addresses_calling_with_value
+                .iter()
+                .any(|address| address != &sender_address);
+            if non_sender_called_with_value || phase.called_non_entry_point_with_value {
                 violations.push(SimulationViolation::CallHadValue(entity));
             }
             if phase.ran_out_of_gas {
@@ -403,7 +407,7 @@ pub enum SimulationViolation {
     DidNotRevert,
     #[display("simulateValidation should have 3 parts but had {0} instead. Make sure your EntryPoint is valid")]
     WrongNumberOfPhases(u32),
-    #[display("{0} must not send ETH during validation (except to entry point)")]
+    #[display("{0} must not send ETH during validation (except from account to entry point)")]
     CallHadValue(EntityType),
     #[display("ran out of gas during {0} validation")]
     OutOfGas(EntityType),

--- a/src/common/tracer.rs
+++ b/src/common/tracer.rs
@@ -30,7 +30,8 @@ pub struct Phase {
     pub used_invalid_gas_opcode: bool,
     pub storage_accesses: Vec<StorageAccess>,
     pub called_banned_entry_point_method: bool,
-    pub called_with_value: bool,
+    pub addresses_calling_with_value: Vec<Address>,
+    pub called_non_entry_point_with_value: bool,
     pub ran_out_of_gas: bool,
     pub undeployed_contract_accesses: Vec<Address>,
 }


### PR DESCRIPTION
The spec says that during validation, calls with value are only allowed from the account to the entry point, but we incorrectly allowed any calls with value to the entry point regardless of whom they were from.

By fixing this, we prevent an attack in which unstaked senders could cause bundles to revert: an earlier sender could call a later sender and cause it to send some of its eth to the entry point, causing the later sender to have a lower balance than it did during simulation. The later sender could then attempt to send to the entry point, see that the call has failed because it doesn't have enough eth, and branch into nondeterminism.