### PR TITLE
feat(builder): Use conditional transactions on Arb Goerli

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -10,4 +10,5 @@ pub mod protos;
 pub mod server;
 pub mod simulation;
 pub mod tracer;
+pub mod transaction_sender;
 pub mod types;

--- a/src/common/simulation.rs
+++ b/src/common/simulation.rs
@@ -12,19 +12,16 @@ use indexmap::IndexSet;
 use mockall::automock;
 use tonic::async_trait;
 
-use super::types::Entity;
 use crate::common::{
     contracts::{
         i_aggregator::IAggregator,
         i_entry_point::{FailedOp, IEntryPoint},
     },
     eth, tracer,
-    tracer::{
-        AssociatedSlotsByAddress, ExpectedSlot, ExpectedStorage, StorageAccess, TracerOutput,
-    },
+    tracer::{AssociatedSlotsByAddress, StorageAccess, TracerOutput},
     types::{
-        EntityType, ExpectedStorageSlot, ProviderLike, StakeInfo, UserOperation, ValidTimeRange,
-        ValidationOutput, ValidationReturnInfo, ViolationError,
+        Entity, EntityType, ExpectedStorage, ProviderLike, StakeInfo, UserOperation,
+        ValidTimeRange, ValidationOutput, ValidationReturnInfo, ViolationError,
     },
 };
 
@@ -40,7 +37,7 @@ pub struct SimulationSuccess {
     pub entities_needing_stake: Vec<EntityType>,
     pub account_is_staked: bool,
     pub accessed_addresses: HashSet<Address>,
-    pub expected_storage_slots: Vec<ExpectedStorageSlot>,
+    pub expected_storage: ExpectedStorage,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -430,16 +427,6 @@ where
             accessed_addresses,
             ..
         } = context;
-        let mut expected_storage_slots = vec![];
-        for ExpectedStorage { address, slots } in &tracer_out.expected_storage {
-            for &ExpectedSlot { slot, value } in slots {
-                expected_storage_slots.push(ExpectedStorageSlot {
-                    address: *address,
-                    slot,
-                    value,
-                });
-            }
-        }
         let ValidationOutput {
             return_info,
             sender_info,
@@ -464,7 +451,7 @@ where
             entities_needing_stake,
             account_is_staked,
             accessed_addresses,
-            expected_storage_slots,
+            expected_storage: tracer_out.expected_storage,
         })
     }
 }

--- a/src/common/tracer.rs
+++ b/src/common/tracer.rs
@@ -9,7 +9,11 @@ use ethers::{
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use super::{context::LogWithContext, contracts::i_entry_point::IEntryPoint, types::UserOperation};
+use crate::common::{
+    context::LogWithContext,
+    contracts::i_entry_point::IEntryPoint,
+    types::{ExpectedStorage, UserOperation},
+};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -19,7 +23,7 @@ pub struct TracerOutput {
     pub accessed_contract_addresses: Vec<Address>,
     pub associated_slots_by_address: AssociatedSlotsByAddress,
     pub factory_called_create2_twice: bool,
-    pub expected_storage: Vec<ExpectedStorage>,
+    pub expected_storage: ExpectedStorage,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -41,20 +45,6 @@ pub struct Phase {
 pub struct StorageAccess {
     pub address: Address,
     pub slots: Vec<U256>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ExpectedStorage {
-    pub address: Address,
-    pub slots: Vec<ExpectedSlot>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ExpectedSlot {
-    pub slot: U256,
-    pub value: U256,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/common/transaction_sender.rs
+++ b/src/common/transaction_sender.rs
@@ -1,0 +1,100 @@
+use std::sync::Arc;
+
+use anyhow::Context;
+use ethers::{
+    middleware::SignerMiddleware,
+    providers::{JsonRpcClient, Middleware, PendingTransaction, Provider},
+    types::{transaction::eip2718::TypedTransaction, TransactionReceipt, H256},
+};
+use ethers_signers::Signer;
+#[cfg(test)]
+use mockall::automock;
+use serde_json::json;
+use tonic::async_trait;
+
+use crate::common::types::ExpectedStorage;
+
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait TransactionSender: Send + Sync + 'static {
+    async fn send_transaction(
+        &self,
+        tx: TypedTransaction,
+        expected_storage: &ExpectedStorage,
+    ) -> anyhow::Result<H256>;
+
+    async fn wait_until_mined(&self, tx_hash: H256) -> anyhow::Result<Option<TransactionReceipt>>;
+}
+
+#[derive(Debug)]
+pub struct TransactionSenderImpl<C, S>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    // The `SignerMiddleware` specifically needs to wrap a `Provider`, and not
+    // just any `Middleware`, because `.request()` is only on `Provider` and not
+    // on `Middleware`.
+    provider: SignerMiddleware<Arc<Provider<C>>, S>,
+    use_conditional_endpoint: bool,
+}
+
+#[async_trait]
+impl<C, S> TransactionSender for TransactionSenderImpl<C, S>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    async fn send_transaction(
+        &self,
+        mut tx: TypedTransaction,
+        expected_storage: &ExpectedStorage,
+    ) -> anyhow::Result<H256> {
+        self.provider
+            .fill_transaction(&mut tx, None)
+            .await
+            .context("should fill transaction before signing it")?;
+        let signature = self
+            .provider
+            .signer()
+            .sign_transaction(&tx)
+            .await
+            .context("should sign transaction before sending")?;
+        let raw_tx = tx.rlp_signed(&signature);
+        if self.use_conditional_endpoint {
+            self.provider
+                .provider()
+                .request(
+                    "eth_sendRawTransactionConditional",
+                    (raw_tx, json!({ "knownAccounts": expected_storage })),
+                )
+                .await
+                .context("should send conditional raw transaction to node")
+        } else {
+            self.provider
+                .provider()
+                .request("eth_sendRawTransaction", (raw_tx,))
+                .await
+                .context("should send raw transaction to node")
+        }
+    }
+
+    async fn wait_until_mined(&self, tx_hash: H256) -> anyhow::Result<Option<TransactionReceipt>> {
+        PendingTransaction::new(tx_hash, self.provider.inner())
+            .await
+            .context("should wait for transaction to be mined or dropped")
+    }
+}
+
+impl<C, S> TransactionSenderImpl<C, S>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    pub fn new(provider: Arc<Provider<C>>, signer: S, use_conditional_endpoint: bool) -> Self {
+        Self {
+            provider: SignerMiddleware::new(provider, signer),
+            use_conditional_endpoint,
+        }
+    }
+}

--- a/src/common/types/provider_like.rs
+++ b/src/common/types/provider_like.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use anyhow::Context;
 use ethers::{
     contract::ContractError,
-    providers::{JsonRpcClient, Middleware, PendingTransaction, Provider},
-    types::{Address, BlockId, BlockNumber, Bytes, TransactionReceipt, H256, U256},
+    providers::{JsonRpcClient, Middleware, Provider},
+    types::{Address, BlockId, BlockNumber, Bytes, H256, U256},
 };
 #[cfg(test)]
 use mockall::automock;
@@ -24,8 +24,6 @@ pub trait ProviderLike: Send + Sync + 'static {
         aggregator_address: Address,
         ops: Vec<UserOperation>,
     ) -> anyhow::Result<Option<Bytes>>;
-
-    async fn wait_until_mined(&self, tx_hash: H256) -> anyhow::Result<Option<TransactionReceipt>>;
 
     async fn get_code(&self, address: Address, block_hash: H256) -> anyhow::Result<Bytes>;
 }
@@ -65,12 +63,6 @@ impl<C: JsonRpcClient + 'static> ProviderLike for Provider<C> {
             Err(ContractError::Revert(_)) => Ok(None),
             Err(error) => Err(error).context("aggregator contract should aggregate signatures")?,
         }
-    }
-
-    async fn wait_until_mined(&self, tx_hash: H256) -> anyhow::Result<Option<TransactionReceipt>> {
-        PendingTransaction::new(tx_hash, self)
-            .await
-            .context("should wait for transaction to be mined or dropped")
     }
 
     async fn get_code(&self, address: Address, block_hash: H256) -> anyhow::Result<Bytes> {

--- a/src/rpc/eth/estimation.rs
+++ b/src/rpc/eth/estimation.rs
@@ -244,19 +244,19 @@ impl<P: ProviderLike, E: EntryPointLike> GasEstimatorImpl<P, E> {
                     is_continuation,
                 },),
             );
-            let target_revert_data =  self
-            .entry_point
-            .call_spoofed_simulate_op(
-                callless_op.clone(),
-                self.entry_point.address(),
-                target_call_data,
-                block_hash,
-                self.settings.max_simulate_handle_ops_gas.into(),
-                &spoofed_state,
-            )
-            .await?
-            .map_err(|_| anyhow!("estimateHandleOps call while estimating call gas should only revert with ExecutionResult"))?
-            .target_result;
+            let target_revert_data = self
+                .entry_point
+                .call_spoofed_simulate_op(
+                    callless_op.clone(),
+                    self.entry_point.address(),
+                    target_call_data,
+                    block_hash,
+                    self.settings.max_simulate_handle_ops_gas.into(),
+                    &spoofed_state,
+                )
+                .await?
+                .map_err(GasEstimationError::RevertInCallWithMessage)?
+                .target_result;
             if let Ok(result) = EstimateCallGasResult::decode(&target_revert_data) {
                 return Ok(result.gas_estimate);
             } else if let Ok(revert) = EstimateCallGasRevertAtMax::decode(&target_revert_data) {


### PR DESCRIPTION
On Arb Goerli (or any other network if the flag
`builder.use_conditional_send_transaction` is set), use `eth_sendRawTransactionConditional` when sending transactions, passing in the expected storage values computed during tracing simulation.

This requires some refactorings because Ethers's `Middleware` doesn't natively support this new method. Instead, create a new trait, `TransactionSender`, which sends the transactions using either the conditional method or not, based on configuration.

Also introduce a new type, `ExpectedStorage`, and update the tracer so that it returns expected storage slots in this format instead of its earlier flattened format.

Closes https://github.com/OMGWINNING/rundler/issues/150