### PR TITLE
feat(rundler): add a sender for flashbots protect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,6 +1322,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,9 +3757,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "reqwest"
-version = "0.11.16"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -3758,7 +3770,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls 0.23.2",
+ "hyper-rustls 0.24.0",
  "ipnet",
  "js-sys",
  "log",
@@ -3766,13 +3778,13 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.8",
+ "rustls 0.21.1",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls 0.24.0",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3869,9 +3881,12 @@ dependencies = [
  "chrono",
  "clap 4.2.4",
  "dotenv",
+ "enum_dispatch",
  "ethers",
  "ethers-signers",
  "futures",
+ "futures-timer",
+ "futures-util",
  "indexmap",
  "itertools",
  "jsonrpsee",
@@ -3887,6 +3902,7 @@ dependencies = [
  "prost",
  "prost-types",
  "rand",
+ "reqwest",
  "rslock",
  "rusoto_core",
  "rusoto_kms",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,12 @@ arrayvec = "0.7.2"
 chrono = "0.4.24"
 clap = { version = "4.2.4", features = ["derive", "env"] }
 dotenv = "0.15.0"
+enum_dispatch = "0.3.11"
 ethers = { version = "2.0.3", features = ["ws"] }
 ethers-signers = {version = "2.0.3", features = ["aws"] }
 futures = "0.3.28"
+futures-timer = "3.0.2"
+futures-util = "0.3.28"
 indexmap = "1.9.3"
 itertools = "0.10.5"
 jsonrpsee = { version = "0.17.0", features = ["client", "macros", "server"] }
@@ -29,6 +32,7 @@ pin-project = "1.0.12"
 prost = "0.11.9"
 prost-types = "0.11.9"
 rand = "0.8.5"
+reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls"] }
 rslock = "0.1.0"
 rusoto_core = { version = "0.48.0", default-features = false, features = ["rustls"] }
 rusoto_kms = { version = "0.48.0", default-features = false, features = ["rustls"] }

--- a/src/builder/bundle_proposer.rs
+++ b/src/builder/bundle_proposer.rs
@@ -86,6 +86,7 @@ pub struct Settings {
     pub max_bundle_size: u64,
     pub beneficiary: Address,
     pub use_bundle_priority_fee: Option<bool>,
+    pub bundle_priority_fee_overhead_percent: u64,
     pub priority_fee_mode: PriorityFeeMode,
 }
 
@@ -187,6 +188,7 @@ where
                 chain_id,
                 settings.priority_fee_mode,
                 settings.use_bundle_priority_fee,
+                settings.bundle_priority_fee_overhead_percent,
             ),
             settings,
         }
@@ -1163,6 +1165,7 @@ mod tests {
                 beneficiary,
                 use_bundle_priority_fee: Some(true),
                 priority_fee_mode: PriorityFeeMode::PriorityFeePercent(10),
+                bundle_priority_fee_overhead_percent: 0,
             },
         );
         proposer

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,4 +1,5 @@
 mod bundle_proposer;
+mod sender;
 mod server;
 mod signer;
 mod task;

--- a/src/builder/sender/conditional.rs
+++ b/src/builder/sender/conditional.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+
+use anyhow::Context;
+use ethers::{
+    middleware::SignerMiddleware,
+    providers::{JsonRpcClient, Middleware, PendingTransaction, Provider},
+    types::{transaction::eip2718::TypedTransaction, Address, TransactionReceipt, H256},
+};
+use ethers_signers::Signer;
+use serde_json::json;
+use tonic::async_trait;
+
+use super::{fill_and_sign, SentTxInfo, TransactionSender};
+use crate::common::types::ExpectedStorage;
+
+pub struct ConditionalTransactionSender<C, S>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    // The `SignerMiddleware` specifically needs to wrap a `Provider`, and not
+    // just any `Middleware`, because `.request()` is only on `Provider` and not
+    // on `Middleware`.
+    provider: SignerMiddleware<Arc<Provider<C>>, S>,
+}
+
+#[async_trait]
+impl<C, S> TransactionSender for ConditionalTransactionSender<C, S>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    async fn send_transaction(
+        &self,
+        tx: TypedTransaction,
+        expected_storage: &ExpectedStorage,
+    ) -> anyhow::Result<SentTxInfo> {
+        let (raw_tx, nonce) = fill_and_sign(&self.provider, tx).await?;
+
+        let tx_hash = self
+            .provider
+            .provider()
+            .request(
+                "eth_sendRawTransactionConditional",
+                (raw_tx, json!({ "knownAccounts": expected_storage })),
+            )
+            .await
+            .context("should send conditional raw transaction to node")?;
+
+        Ok(SentTxInfo { nonce, tx_hash })
+    }
+
+    async fn wait_until_mined(&self, tx_hash: H256) -> anyhow::Result<Option<TransactionReceipt>> {
+        PendingTransaction::new(tx_hash, self.provider.inner())
+            .await
+            .context("should wait for transaction to be mined or dropped")
+    }
+
+    fn address(&self) -> Address {
+        self.provider.address()
+    }
+}
+
+impl<C, S> ConditionalTransactionSender<C, S>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    pub fn new(provider: Arc<Provider<C>>, signer: S) -> Self {
+        Self {
+            provider: SignerMiddleware::new(provider, signer),
+        }
+    }
+}

--- a/src/builder/sender/flashbots.rs
+++ b/src/builder/sender/flashbots.rs
@@ -1,0 +1,312 @@
+// Adapted from https://github.com/onbjerg/ethers-flashbots and
+// https://github.com/gakonst/ethers-rs/blob/master/ethers-providers/src/toolbox/pending_transaction.rs
+use std::{
+    future::Future,
+    pin::Pin,
+    str::FromStr,
+    sync::Arc,
+    task::{Context as TaskContext, Poll},
+};
+
+use anyhow::Context;
+use ethers::{
+    middleware::SignerMiddleware,
+    providers::{interval, JsonRpcClient, Middleware, Provider},
+    types::{transaction::eip2718::TypedTransaction, Address, TransactionReceipt, H256, U256, U64},
+};
+use ethers_signers::Signer;
+use futures_timer::Delay;
+use futures_util::{Stream, StreamExt, TryFutureExt};
+use pin_project::pin_project;
+use serde::{de, Deserialize};
+use serde_json::Value;
+use tonic::async_trait;
+
+use super::{fill_and_sign, SentTxInfo, TransactionSender};
+use crate::common::types::ExpectedStorage;
+
+#[derive(Debug)]
+pub struct FlashbotsTransactionSender<C, S>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    provider: SignerMiddleware<Arc<Provider<C>>, S>,
+    client: FlashbotsClient,
+}
+
+#[async_trait]
+impl<C, S> TransactionSender for FlashbotsTransactionSender<C, S>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    async fn send_transaction(
+        &self,
+        tx: TypedTransaction,
+        _expected_storage: &ExpectedStorage,
+    ) -> anyhow::Result<SentTxInfo> {
+        let (raw_tx, nonce) = fill_and_sign(&self.provider, tx).await?;
+
+        let tx_hash = self
+            .provider
+            .provider()
+            .request("eth_sendRawTransaction", (raw_tx,))
+            .await
+            .context("should send raw transaction to node")?;
+
+        Ok(SentTxInfo { nonce, tx_hash })
+    }
+
+    async fn wait_until_mined(&self, tx_hash: H256) -> anyhow::Result<Option<TransactionReceipt>> {
+        PendingFlashbotsTransaction::new(tx_hash, self.provider.inner(), &self.client).await
+    }
+
+    fn address(&self) -> Address {
+        self.provider.address()
+    }
+}
+
+impl<C, S> FlashbotsTransactionSender<C, S>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    pub fn new(provider: Arc<Provider<C>>, signer: S) -> Self {
+        Self {
+            provider: SignerMiddleware::new(provider, signer),
+            client: FlashbotsClient::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct FlashbotsAPITransaction {
+    #[serde(deserialize_with = "deserialize_optional_address")]
+    from: Option<Address>,
+    #[serde(deserialize_with = "deserialize_optional_address")]
+    to: Option<Address>,
+    #[serde(deserialize_with = "deserialize_optional_u256")]
+    gas_limit: Option<U256>,
+    #[serde(deserialize_with = "deserialize_optional_u256")]
+    max_fee_per_gas: Option<U256>,
+    #[serde(deserialize_with = "deserialize_optional_u256")]
+    max_priority_fee_per_gas: Option<U256>,
+    #[serde(deserialize_with = "deserialize_optional_u256")]
+    nonce: Option<U256>,
+    #[serde(deserialize_with = "deserialize_optional_u256")]
+    value: Option<U256>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+enum FlashbotsAPITransactionStatus {
+    Pending,
+    Included,
+    Failed,
+    Cancelled,
+    Unknown,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct FlashbotsAPIResponse {
+    status: FlashbotsAPITransactionStatus,
+    hash: H256,
+    #[serde(deserialize_with = "deserialize_u64")]
+    max_block_number: U64,
+    transaction: FlashbotsAPITransaction,
+    seen_in_mempool: bool,
+}
+
+#[derive(Debug, Default)]
+struct FlashbotsClient {}
+
+impl FlashbotsClient {
+    async fn status(&self, tx_hash: H256) -> anyhow::Result<FlashbotsAPIResponse> {
+        let url = format!("https://protect.flashbots.net/tx/{:?}", tx_hash);
+        let resp = reqwest::get(&url).await?;
+        resp.json::<FlashbotsAPIResponse>()
+            .await
+            .context("should deserialize FlashbotsAPIResponse")
+    }
+}
+
+type PinBoxFut<'a, T> = Pin<Box<dyn Future<Output = anyhow::Result<T>> + Send + 'a>>;
+
+enum PendingFlashbotsTxState<'a> {
+    InitialDelay(Pin<Box<Delay>>),
+    PausedGettingTx,
+    GettingTx(PinBoxFut<'a, FlashbotsAPIResponse>),
+    PausedGettingReceipt,
+    GettingReceipt(PinBoxFut<'a, Option<TransactionReceipt>>),
+    Completed,
+}
+
+#[pin_project]
+struct PendingFlashbotsTransaction<'a, P> {
+    tx_hash: H256,
+    provider: &'a Provider<P>,
+    client: &'a FlashbotsClient,
+    state: PendingFlashbotsTxState<'a>,
+    interval: Box<dyn Stream<Item = ()> + Send + Unpin>,
+}
+
+impl<'a, P: JsonRpcClient> PendingFlashbotsTransaction<'a, P> {
+    fn new(tx_hash: H256, provider: &'a Provider<P>, client: &'a FlashbotsClient) -> Self {
+        let delay = Box::pin(Delay::new(provider.get_interval()));
+
+        Self {
+            tx_hash,
+            provider,
+            client,
+            state: PendingFlashbotsTxState::InitialDelay(delay),
+            interval: Box::new(interval(provider.get_interval())),
+        }
+    }
+}
+
+impl<'a, P: JsonRpcClient> Future for PendingFlashbotsTransaction<'a, P> {
+    type Output = anyhow::Result<Option<TransactionReceipt>>;
+
+    fn poll(self: Pin<&mut Self>, ctx: &mut TaskContext) -> Poll<Self::Output> {
+        let this = self.project();
+
+        match this.state {
+            PendingFlashbotsTxState::InitialDelay(fut) => {
+                futures_util::ready!(fut.as_mut().poll(ctx));
+                let status_fut = Box::pin(this.client.status(*this.tx_hash));
+                *this.state = PendingFlashbotsTxState::GettingTx(status_fut);
+                ctx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+            PendingFlashbotsTxState::PausedGettingTx => {
+                let _ready = futures_util::ready!(this.interval.poll_next_unpin(ctx));
+                let status_fut = Box::pin(this.client.status(*this.tx_hash));
+                *this.state = PendingFlashbotsTxState::GettingTx(status_fut);
+                ctx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+            PendingFlashbotsTxState::GettingTx(fut) => {
+                let status = futures_util::ready!(fut.as_mut().poll(ctx))?;
+                tracing::debug!("Transaction:status {:?}:{:?}", *this.tx_hash, status.status);
+                match status.status {
+                    FlashbotsAPITransactionStatus::Pending => {
+                        *this.state = PendingFlashbotsTxState::PausedGettingTx;
+                        ctx.waker().wake_by_ref();
+                    }
+                    FlashbotsAPITransactionStatus::Included => {
+                        let receipt_fut = Box::pin(
+                            this.provider
+                                .get_transaction_receipt(*this.tx_hash)
+                                .map_err(|e| anyhow::anyhow!("failed to get receipt: {:?}", e)),
+                        );
+                        *this.state = PendingFlashbotsTxState::GettingReceipt(receipt_fut);
+                        ctx.waker().wake_by_ref();
+                    }
+                    FlashbotsAPITransactionStatus::Cancelled => {
+                        return Poll::Ready(Ok(None));
+                    }
+                    FlashbotsAPITransactionStatus::Failed
+                    | FlashbotsAPITransactionStatus::Unknown => {
+                        return Poll::Ready(Err(anyhow::anyhow!(
+                            "transaction failed with status {:?}",
+                            status.status
+                        )));
+                    }
+                }
+            }
+            PendingFlashbotsTxState::PausedGettingReceipt => {
+                let _ready = futures_util::ready!(this.interval.poll_next_unpin(ctx));
+                let fut = Box::pin(
+                    this.provider
+                        .get_transaction_receipt(*this.tx_hash)
+                        .map_err(|e| anyhow::anyhow!("failed to get receipt: {:?}", e)),
+                );
+                *this.state = PendingFlashbotsTxState::GettingReceipt(fut);
+                ctx.waker().wake_by_ref();
+            }
+            PendingFlashbotsTxState::GettingReceipt(fut) => {
+                if let Some(receipt) = futures_util::ready!(fut.as_mut().poll(ctx))? {
+                    *this.state = PendingFlashbotsTxState::Completed;
+                    return Poll::Ready(Ok(Some(receipt)));
+                } else {
+                    *this.state = PendingFlashbotsTxState::PausedGettingReceipt;
+                    ctx.waker().wake_by_ref();
+                }
+            }
+            PendingFlashbotsTxState::Completed => {
+                panic!("polled pending flashbots transaction future after completion")
+            }
+        }
+
+        Poll::Pending
+    }
+}
+
+fn deserialize_u64<'de, D>(deserializer: D) -> Result<U64, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    Ok(match Value::deserialize(deserializer)? {
+        Value::String(s) => {
+            if s.as_str() == "0x" {
+                U64::zero()
+            } else if s.as_str().starts_with("0x") {
+                U64::from_str_radix(s.as_str(), 16).map_err(de::Error::custom)?
+            } else {
+                U64::from_dec_str(s.as_str()).map_err(de::Error::custom)?
+            }
+        }
+        Value::Number(num) => U64::from(
+            num.as_u64()
+                .ok_or_else(|| de::Error::custom("Invalid number"))?,
+        ),
+        _ => return Err(de::Error::custom("wrong type")),
+    })
+}
+
+fn deserialize_optional_u256<'de, D>(deserializer: D) -> Result<Option<U256>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    Ok(match Value::deserialize(deserializer)? {
+        Value::String(s) => {
+            if s.is_empty() {
+                None
+            } else if s.as_str() == "0x" {
+                Some(U256::zero())
+            } else if s.as_str().starts_with("0x") {
+                Some(U256::from_str_radix(s.as_str(), 16).map_err(de::Error::custom)?)
+            } else {
+                Some(U256::from_dec_str(s.as_str()).map_err(de::Error::custom)?)
+            }
+        }
+        Value::Number(num) => Some(U256::from(
+            num.as_u64()
+                .ok_or_else(|| de::Error::custom("Invalid number"))?,
+        )),
+        Value::Null => None,
+        _ => return Err(de::Error::custom("wrong type")),
+    })
+}
+
+fn deserialize_optional_address<'de, D>(deserializer: D) -> Result<Option<Address>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    Ok(match Value::deserialize(deserializer)? {
+        Value::String(s) => {
+            if s.is_empty() || s.as_str() == "0x" {
+                None
+            } else {
+                Some(Address::from_str(s.as_str()).map_err(de::Error::custom)?)
+            }
+        }
+        Value::Null => None,
+        _ => return Err(de::Error::custom("expected a hexadecimal string")),
+    })
+}

--- a/src/builder/sender/mod.rs
+++ b/src/builder/sender/mod.rs
@@ -1,0 +1,97 @@
+mod conditional;
+mod flashbots;
+mod raw;
+
+use std::sync::Arc;
+
+use anyhow::Context;
+pub use conditional::ConditionalTransactionSender;
+use enum_dispatch::enum_dispatch;
+use ethers::{
+    prelude::SignerMiddleware,
+    providers::{JsonRpcClient, Middleware, Provider},
+    types::{
+        transaction::eip2718::TypedTransaction, Address, Bytes, TransactionReceipt, H256, U256,
+    },
+};
+use ethers_signers::Signer;
+pub use flashbots::FlashbotsTransactionSender;
+#[cfg(test)]
+use mockall::automock;
+pub use raw::RawTransactionSender;
+use tonic::async_trait;
+
+use crate::common::types::ExpectedStorage;
+
+#[derive(Debug)]
+pub struct SentTxInfo {
+    pub nonce: U256,
+    pub tx_hash: H256,
+}
+#[async_trait]
+#[enum_dispatch(TransactionSenderEnum<_C,_S>)]
+#[cfg_attr(test, automock)]
+pub trait TransactionSender: Send + Sync + 'static {
+    async fn send_transaction(
+        &self,
+        tx: TypedTransaction,
+        expected_storage: &ExpectedStorage,
+    ) -> anyhow::Result<SentTxInfo>;
+
+    async fn wait_until_mined(&self, tx_hash: H256) -> anyhow::Result<Option<TransactionReceipt>>;
+
+    fn address(&self) -> Address;
+}
+
+#[enum_dispatch]
+pub enum TransactionSenderEnum<C, S>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    Raw(RawTransactionSender<C, S>),
+    Conditional(ConditionalTransactionSender<C, S>),
+    Flashbots(FlashbotsTransactionSender<C, S>),
+}
+
+async fn fill_and_sign<C, S>(
+    provider: &SignerMiddleware<Arc<Provider<C>>, S>,
+    mut tx: TypedTransaction,
+) -> anyhow::Result<(Bytes, U256)>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    provider
+        .fill_transaction(&mut tx, None)
+        .await
+        .context("should fill transaction before signing it")?;
+    let nonce = *tx
+        .nonce()
+        .context("nonce should be set when transaction is filled")?;
+    let signature = provider
+        .signer()
+        .sign_transaction(&tx)
+        .await
+        .context("should sign transaction before sending")?;
+    Ok((tx.rlp_signed(&signature), nonce))
+}
+
+pub fn get_sender<C, S>(
+    provider: Arc<Provider<C>>,
+    signer: S,
+    is_conditional: bool,
+    url: &str,
+) -> TransactionSenderEnum<C, S>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    if is_conditional {
+        ConditionalTransactionSender::new(provider, signer).into()
+    } else if url.contains("flashbots") {
+        FlashbotsTransactionSender::new(provider, signer).into()
+    } else {
+        RawTransactionSender::new(provider, signer).into()
+    }
+}

--- a/src/builder/sender/raw.rs
+++ b/src/builder/sender/raw.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use anyhow::Context;
+use ethers::{
+    middleware::SignerMiddleware,
+    providers::{JsonRpcClient, Middleware, PendingTransaction, Provider},
+    types::{transaction::eip2718::TypedTransaction, Address, TransactionReceipt, H256},
+};
+use ethers_signers::Signer;
+use tonic::async_trait;
+
+use super::{fill_and_sign, SentTxInfo, TransactionSender};
+use crate::common::types::ExpectedStorage;
+
+#[derive(Debug)]
+pub struct RawTransactionSender<C, S>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    // The `SignerMiddleware` specifically needs to wrap a `Provider`, and not
+    // just any `Middleware`, because `.request()` is only on `Provider` and not
+    // on `Middleware`.
+    provider: SignerMiddleware<Arc<Provider<C>>, S>,
+}
+
+#[async_trait]
+impl<C, S> TransactionSender for RawTransactionSender<C, S>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    async fn send_transaction(
+        &self,
+        tx: TypedTransaction,
+        _expected_storage: &ExpectedStorage,
+    ) -> anyhow::Result<SentTxInfo> {
+        let (raw_tx, nonce) = fill_and_sign(&self.provider, tx).await?;
+
+        let tx_hash = self
+            .provider
+            .provider()
+            .request("eth_sendRawTransaction", (raw_tx,))
+            .await
+            .context("should send raw transaction to node")?;
+        Ok(SentTxInfo { nonce, tx_hash })
+    }
+
+    async fn wait_until_mined(&self, tx_hash: H256) -> anyhow::Result<Option<TransactionReceipt>> {
+        PendingTransaction::new(tx_hash, self.provider.inner())
+            .await
+            .context("should wait for transaction to be mined or dropped")
+    }
+
+    fn address(&self) -> Address {
+        self.provider.address()
+    }
+}
+
+impl<C, S> RawTransactionSender<C, S>
+where
+    C: JsonRpcClient + 'static,
+    S: Signer + 'static,
+{
+    pub fn new(provider: Arc<Provider<C>>, signer: S) -> Self {
+        Self {
+            provider: SignerMiddleware::new(provider, signer),
+        }
+    }
+}

--- a/src/builder/server.rs
+++ b/src/builder/server.rs
@@ -13,13 +13,11 @@ use ethers::{
 };
 use tokio::{join, time};
 use tonic::{async_trait, transport::Channel, Request, Response, Status};
-use tracing::{
-    error,
-    log::{debug, info, trace, warn},
-};
+use tracing::{debug, error, info, trace, warn};
 
+use super::sender::TransactionSender;
 use crate::{
-    builder::bundle_proposer::BundleProposer,
+    builder::{bundle_proposer::BundleProposer, sender::SentTxInfo},
     common::{
         gas::GasFees,
         math,
@@ -33,7 +31,6 @@ use crate::{
                 self, op_pool_client::OpPoolClient, RemoveEntitiesRequest, RemoveOpsRequest,
             },
         },
-        transaction_sender::{SentTxInfo, TransactionSender},
         types::{Entity, EntryPointLike, ExpectedStorage, UserOperation},
     },
 };

--- a/src/cli/builder.rs
+++ b/src/cli/builder.rs
@@ -191,6 +191,7 @@ impl BuilderArgs {
             max_bundle_size: self.max_bundle_size,
             submit_url,
             use_bundle_priority_fee: common.use_bundle_priority_fee,
+            bundle_priority_fee_overhead_percent: common.bundle_priority_fee_overhead_percent,
             priority_fee_mode,
             use_conditional_send_transaction: self.use_conditional_send_transaction,
             eth_poll_interval: Duration::from_millis(self.eth_poll_interval_millis),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -157,6 +157,14 @@ pub struct CommonArgs {
     use_bundle_priority_fee: Option<bool>,
 
     #[arg(
+        long = "bundle_priority_fee_overhead_percent",
+        name = "bundle_priority_fee_overhead_percent",
+        env = "BUNDLE_PRIORITY_FEE_OVERHEAD_PERCENT",
+        default_value = "0"
+    )]
+    bundle_priority_fee_overhead_percent: u64,
+
+    #[arg(
         long = "priority_fee_mode_kind",
         name = "priority_fee_mode_kind",
         env = "PRIORITY_FEE_MODE_KIND",
@@ -228,6 +236,7 @@ impl TryFrom<&CommonArgs> for precheck::Settings {
         Ok(Self {
             max_verification_gas: value.max_verification_gas.into(),
             use_bundle_priority_fee: value.use_bundle_priority_fee,
+            bundle_priority_fee_overhead_percent: value.bundle_priority_fee_overhead_percent,
             priority_fee_mode: PriorityFeeMode::try_from(
                 value.priority_fee_mode_kind.as_str(),
                 value.priority_fee_mode_value,

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -12,5 +12,4 @@ pub mod protos;
 pub mod server;
 pub mod simulation;
 pub mod tracer;
-pub mod transaction_sender;
 pub mod types;

--- a/src/common/precheck.rs
+++ b/src/common/precheck.rs
@@ -37,6 +37,7 @@ pub struct PrecheckerImpl<P: ProviderLike, E: EntryPointLike> {
 pub struct Settings {
     pub max_verification_gas: U256,
     pub use_bundle_priority_fee: Option<bool>,
+    pub bundle_priority_fee_overhead_percent: u64,
     pub priority_fee_mode: gas::PriorityFeeMode,
 }
 
@@ -77,6 +78,7 @@ impl<P: ProviderLike, E: EntryPointLike> PrecheckerImpl<P, E> {
                 chain_id,
                 settings.priority_fee_mode,
                 settings.use_bundle_priority_fee,
+                settings.bundle_priority_fee_overhead_percent,
             ),
         }
     }


### PR DESCRIPTION
Closes #196 

## Proposed Changes

  - Use enum_dispatch since we now have a 3rd type of sender
  - Implement flashbots sender
