### PR TITLE
feat(builder): retry stuck bundles, fix maxFeePerGas

### DIFF
--- a/src/builder/server.rs
+++ b/src/builder/server.rs
@@ -6,21 +6,23 @@ use std::{
     time::Duration,
 };
 
-use anyhow::Context;
+use anyhow::{bail, Context};
 use ethers::{
     providers::{Http, Middleware, Provider, RetryClient},
-    types::{Address, TransactionReceipt, H256},
+    types::{transaction::eip2718::TypedTransaction, Address, H256, U256},
 };
 use tokio::{join, time};
 use tonic::{async_trait, transport::Channel, Request, Response, Status};
 use tracing::{
     error,
-    log::{debug, info, trace},
+    log::{debug, info, trace, warn},
 };
 
 use crate::{
     builder::bundle_proposer::BundleProposer,
     common::{
+        gas::GasFees,
+        math,
         protos::{
             builder::{
                 builder_server::Builder, BundlingMode, DebugSendBundleNowRequest,
@@ -31,10 +33,20 @@ use crate::{
                 self, op_pool_client::OpPoolClient, RemoveEntitiesRequest, RemoveOpsRequest,
             },
         },
-        transaction_sender::TransactionSender,
-        types::{Entity, EntryPointLike, UserOperation},
+        transaction_sender::{SentTxInfo, TransactionSender},
+        types::{Entity, EntryPointLike, ExpectedStorage, UserOperation},
     },
 };
+
+// Overhead on gas estimates to account for inaccuracies.
+const GAS_ESTIMATE_OVERHEAD_PERCENT: u64 = 10;
+
+#[derive(Debug)]
+pub struct Settings {
+    pub max_blocks_to_wait_for_mine: u64,
+    pub replacement_fee_percent_increase: u64,
+    pub max_fee_increases: u64,
+}
 
 #[derive(Debug)]
 pub struct BuilderImpl<P, E, T>
@@ -53,6 +65,42 @@ where
     transaction_sender: T,
     // TODO: Figure out what we really want to do for detecting new blocks.
     provider: Arc<Provider<RetryClient<Http>>>,
+    settings: Settings,
+}
+
+#[derive(Debug)]
+struct BundleTx {
+    tx: TypedTransaction,
+    expected_storage: ExpectedStorage,
+    op_count: usize,
+}
+
+#[derive(Debug)]
+enum SendBundleResult {
+    Success {
+        block_number: u64,
+        attempt_number: u64,
+        tx_hash: H256,
+    },
+    NoOperationsInitially,
+    NoOperationsAfterFeeIncreases {
+        initial_op_count: usize,
+        attempt_number: u64,
+    },
+    StalledAtMaxFeeIncreases,
+    Error(anyhow::Error),
+}
+
+#[derive(Debug)]
+enum MineResult {
+    Success {
+        block_number: u64,
+        attempt_number: u64,
+    },
+    StillPendingAfterWait,
+    Dropped,
+    NonceUsedForOtherTx,
+    Error(anyhow::Error),
 }
 
 impl<P, E, T> BuilderImpl<P, E, T>
@@ -71,6 +119,7 @@ where
         entry_point: E,
         transaction_sender: T,
         provider: Arc<Provider<RetryClient<Http>>>,
+        settings: Settings,
     ) -> Self {
         Self {
             is_manual_bundling_mode: AtomicBool::new(false),
@@ -82,6 +131,7 @@ where
             entry_point,
             transaction_sender,
             provider,
+            settings,
         }
     }
 
@@ -95,21 +145,125 @@ where
                 time::sleep(self.eth_poll_interval).await;
                 continue;
             }
-            last_block_number = self.wait_for_new_block(last_block_number).await;
-            let result = self.send_bundle_and_wait_for_mine().await;
+            last_block_number = self.wait_for_new_block_number(last_block_number).await;
+            let result = self.send_bundle_with_increasing_gas_fees().await;
             match result {
-                Ok(Some(receipt)) => info!(
-                    "Bundle with hash {:?} landed in block {}",
-                    receipt.transaction_hash,
-                    receipt.block_number.unwrap_or_default()
-                ),
-                Ok(None) => trace!("No ops to send at block {last_block_number}"),
-                Err(error) => error!("Failed to send bundle. Will retry next block: {error:?}"),
+                SendBundleResult::Success {
+                    block_number,
+                    attempt_number,
+                     tx_hash,
+                } =>
+                    if attempt_number == 0 {
+                        info!("Bundle with hash {tx_hash:?} landed in block {block_number}");
+                    } else {
+                        info!("Bundle with hash {tx_hash:?} landed in block {block_number} after increasing gas fees {attempt_number} time(s)");
+                    }
+                SendBundleResult::NoOperationsInitially => trace!("No ops to send at block {last_block_number}"),
+                SendBundleResult::NoOperationsAfterFeeIncreases {
+                    initial_op_count,
+                    attempt_number,
+                } => info!("Bundle initially had {initial_op_count} operations, but after increasing gas fees {attempt_number} time(s) it was empty"),
+                SendBundleResult::StalledAtMaxFeeIncreases => warn!("Bundle failed to mine after {} fee increases", self.settings.max_fee_increases),
+                SendBundleResult::Error(error) => error!("Failed to send bundle. Will retry next block: {error:?}"),
             }
         }
     }
 
-    async fn wait_for_new_block(&self, prev_block_number: u64) -> u64 {
+    /// Constructs a bundle and sends it to the entry point as a transaction. If
+    /// the bundle fails to be mined after
+    /// `settings.max_blocks_to_wait_for_mine` blocks, increases the gas fees by
+    /// enough to send a replacement transaction, then constructs a new bundle
+    /// using the new, higher gas requirements. Continues to retry with higher
+    /// gas costs until one of the following happens:
+    ///
+    /// 1. The transaction succeeds
+    /// 2. The gas fees are high enough that the bundle is empty because there
+    ///    are no ops that meet the fee requirements.
+    /// 3. The transaction has not succeeded after `settings.max_fee_increases`
+    ///    replacements.
+    async fn send_bundle_with_increasing_gas_fees(&self) -> SendBundleResult {
+        let result = self.send_bundle_with_increasing_gas_fees_inner().await;
+        match result {
+            Ok(result) => result,
+            Err(error) => SendBundleResult::Error(error),
+        }
+    }
+
+    /// Helper function returning `Result` to be able to use `?`.
+    async fn send_bundle_with_increasing_gas_fees_inner(&self) -> anyhow::Result<SendBundleResult> {
+        let mut nonce: Option<U256> = None;
+        let mut previous_fees: Option<GasFees> = None;
+        let mut initial_op_count: Option<usize> = None;
+        let mut tx_hashes = Vec::<H256>::new();
+        for attempt_number in 0..=self.settings.max_fee_increases {
+            let required_fees = previous_fees.map(|fees| {
+                fees.increase_by_percent(self.settings.replacement_fee_percent_increase)
+            });
+            let Some(bundle_tx) = self.get_bundle_tx(required_fees).await? else {
+                return Ok(if let Some(initial_op_count) = initial_op_count {
+                    SendBundleResult::NoOperationsAfterFeeIncreases { initial_op_count, attempt_number }
+                } else {
+                    SendBundleResult::NoOperationsInitially
+                });
+            };
+            let BundleTx {
+                mut tx,
+                expected_storage,
+                op_count,
+            } = bundle_tx;
+            if let Some(nonce) = nonce {
+                tx.set_nonce(nonce);
+            };
+            if initial_op_count.is_none() {
+                initial_op_count = Some(op_count)
+            };
+            let current_fees = GasFees::from(&tx);
+            let SentTxInfo {
+                nonce: sent_nonce,
+                tx_hash,
+            } = self
+                .transaction_sender
+                .send_transaction(tx, &expected_storage)
+                .await
+                .context("builder should send bundle transaction")?;
+            info!(
+                "Sent bundle in transaction on attempt {attempt_number} with hash: {}",
+                tx_hash
+            );
+            nonce = Some(sent_nonce);
+            previous_fees = Some(current_fees);
+            tx_hashes.push(tx_hash);
+            let wait_result = self
+                .wait_for_mine_or_max_blocks(&tx_hashes, sent_nonce)
+                .await;
+            match wait_result {
+                MineResult::Success {
+                    block_number,
+                    attempt_number,
+                } => {
+                    return Ok(SendBundleResult::Success {
+                        block_number,
+                        attempt_number,
+                        tx_hash: tx_hashes[attempt_number as usize],
+                    })
+                }
+                MineResult::StillPendingAfterWait => {
+                    info!("Transaction not mined for several blocks")
+                }
+                MineResult::Dropped => info!("Transaction dropped by provider"),
+                MineResult::NonceUsedForOtherTx => warn!("Bundle nonce used by other transaction"),
+                MineResult::Error(error) => return Ok(SendBundleResult::Error(error)),
+            };
+            info!(
+                "Bundle transaction failed to mine on attempt {attempt_number} (maxFeePerGas: {}, maxPriorityFeePerGas: {}).",
+                current_fees.max_fee_per_gas,
+                current_fees.max_priority_fee_per_gas,
+            );
+        }
+        Ok(SendBundleResult::StalledAtMaxFeeIncreases)
+    }
+
+    async fn wait_for_new_block_number(&self, prev_block_number: u64) -> u64 {
         loop {
             let block_number = self.provider.get_block_number().await;
             match block_number {
@@ -129,29 +283,102 @@ where
         }
     }
 
-    /// Returns `None` if no bundle was sent because it would contain no ops.
-    async fn send_bundle_and_wait_for_mine(&self) -> anyhow::Result<Option<TransactionReceipt>> {
-        let tx_hash = self.send_bundle().await?;
-        let Some(tx_hash) = tx_hash else {
-            return Ok(None);
-        };
-        let receipt = self
-            .transaction_sender
-            .wait_until_mined(tx_hash)
-            .await
-            .context("builder should wait for bundle to mine")?
-            .context("bundle transaction should not be dropped")?;
-        Ok(Some(receipt))
+    /// Waits for any of a group of transaction hashes with the same sender and
+    /// nonce to mine. Returns once one of the following occurs:
+    ///
+    /// 1. A transaction with one of the provided hashes mines.
+    /// 2. The transaction associated with the most recent hash is dropped.
+    /// 3. `MAX_BLOCKS_TO_WAIT_FOR_MINE` blocks pass without any of the
+    ///    transations mining.
+    /// 4. The sender's nonce increases, invalidating these transactions.
+    ///
+    /// We need to wait on all the transaction hashes, and not just the latest
+    /// one, because it's possible that one of the earlier transactions
+    /// successfully mines even after we've submitted later ones.
+    async fn wait_for_mine_or_max_blocks(&self, tx_hashes: &[H256], nonce: U256) -> MineResult {
+        let result = self
+            .wait_for_mine_or_max_blocks_inner(tx_hashes, nonce)
+            .await;
+        match result {
+            Ok(result) => result,
+            Err(error) => MineResult::Error(error),
+        }
     }
 
-    /// Returns `None` if no bundle was sent because it would contain no ops.
-    async fn send_bundle(&self) -> anyhow::Result<Option<H256>> {
+    /// Helper function to allow use of `?` operator.
+    async fn wait_for_mine_or_max_blocks_inner(
+        &self,
+        tx_hashes: &[H256],
+        nonce: U256,
+    ) -> anyhow::Result<MineResult> {
+        if tx_hashes.is_empty() {
+            bail!("tx hashes to wait for should not be empty");
+        }
+        let last_index = tx_hashes.len() - 1;
+        let latest_tx_hash = tx_hashes[last_index];
+        let mut block_number = self
+            .provider
+            .get_block_number()
+            .await
+            .context("should get block number while waiting for transaction to mine")?
+            .as_u64();
+        let max_block_number = block_number + self.settings.max_blocks_to_wait_for_mine;
+        while block_number < max_block_number {
+            // Wait for either the latest transaction's status to change or for
+            // a new block to show up.
+            block_number = tokio::select! {
+                maybe_receipt = self.transaction_sender.wait_until_mined(latest_tx_hash) => {
+                    let maybe_receipt = maybe_receipt
+                        .context("should wait for latest transaction to mine or drop")?;
+                    return Ok(match maybe_receipt {
+                        Some(receipt) => MineResult::Success {
+                            block_number: receipt
+                                .block_number
+                                .context("receipt should have block number")?
+                                .as_u64(),
+                            attempt_number: last_index as u64,
+                        },
+                        None => MineResult::Dropped,
+                    });
+                },
+                new_block_number = self.wait_for_new_block_number(block_number) => new_block_number,
+            };
+            // A new block has appeared.
+            let tx_count = self
+                .provider
+                .get_transaction_count(self.transaction_sender.address(), None)
+                .await?;
+            if tx_count > nonce {
+                // A new transaction has been mined for this account. Check each
+                // of the provided hashes to see which one it is, if any.
+                for (attempt_number, &tx_hash) in tx_hashes.iter().enumerate().rev() {
+                    let tx = self.provider.get_transaction(tx_hash).await?;
+                    if let Some(tx) = tx {
+                        if let Some(block_number) = tx.block_number {
+                            return Ok(MineResult::Success {
+                                block_number: block_number.as_u64(),
+                                attempt_number: attempt_number as u64,
+                            });
+                        }
+                    }
+                }
+                return Ok(MineResult::NonceUsedForOtherTx);
+            }
+        }
+        Ok(MineResult::StillPendingAfterWait)
+    }
+
+    /// Builds a bundle and returns some metadata and the transaction to send
+    /// it, or `None` if there are no valid operations available.
+    async fn get_bundle_tx(
+        &self,
+        required_fees: Option<GasFees>,
+    ) -> anyhow::Result<Option<BundleTx>> {
         let bundle = self
             .proposer
-            .make_bundle()
+            .make_bundle(required_fees)
             .await
             .context("proposer should create bundle for builder")?;
-
         let remove_ops_future = async {
             let result = self.remove_ops_from_pool(&bundle.rejected_ops).await;
             if let Err(error) = result {
@@ -166,41 +393,36 @@ where
                 error!("Failed to remove rejected entities from pool: {error}");
             }
         };
-
+        join!(remove_ops_future, remove_entities_future);
         if bundle.is_empty() {
             if !bundle.rejected_ops.is_empty() || !bundle.rejected_entities.is_empty() {
                 info!(
-                    "Empty bundle with {} rejected ops and {} rejected entities. Removing them from pool.",
-                    bundle.rejected_ops.len(),
-                    bundle.rejected_entities.len()
-                );
-                join!(remove_ops_future, remove_entities_future);
+                "Empty bundle with {} rejected ops and {} rejected entities. Removing them from pool.",
+                bundle.rejected_ops.len(),
+                bundle.rejected_entities.len()
+            );
             }
             return Ok(None);
         }
-
         info!(
             "Selected bundle with {} op(s), with {} rejected op(s) and {} rejected entities",
             bundle.len(),
             bundle.rejected_ops.len(),
             bundle.rejected_entities.len()
         );
-        // Give the estimated gas a 10% overhead to account for inaccuracies.
-        let gas = bundle.gas_estimate * 11 / 10;
+        let gas = math::increase_by_percent(bundle.gas_estimate, GAS_ESTIMATE_OVERHEAD_PERCENT);
+        let op_count = bundle.len();
         let tx = self.entry_point.get_send_bundle_transaction(
             bundle.ops_per_aggregator,
             self.beneficiary,
             gas,
-            bundle.max_priority_fee_per_gas,
+            bundle.gas_fees,
         );
-        let send_future = self
-            .transaction_sender
-            .send_transaction(tx, &bundle.expected_storage);
-        let (_, _, send_bundle_result) =
-            join!(remove_ops_future, remove_entities_future, send_future);
-        let tx_hash = send_bundle_result.context("builder should send bundle transaction")?;
-        info!("Sent bundle in transaction with hash: {}", tx_hash);
-        Ok(Some(tx_hash))
+        Ok(Some(BundleTx {
+            tx,
+            expected_storage: bundle.expected_storage,
+            op_count,
+        }))
     }
 
     async fn remove_ops_from_pool(&self, ops: &[UserOperation]) -> anyhow::Result<()> {
@@ -247,11 +469,19 @@ where
         _request: Request<DebugSendBundleNowRequest>,
     ) -> tonic::Result<Response<DebugSendBundleNowResponse>> {
         debug!("Send bundle now called");
-        let result = self.send_bundle().await;
+        let result = self.send_bundle_with_increasing_gas_fees().await;
         let tx_hash = match result {
-            Ok(Some(tx_hash)) => tx_hash,
-            Ok(None) => return Err(Status::internal("no ops to send")),
-            Err(error) => return Err(Status::internal(error.to_string())),
+            SendBundleResult::Success { tx_hash, .. } => tx_hash,
+            SendBundleResult::NoOperationsInitially => {
+                return Err(Status::internal("no ops to send"))
+            }
+            SendBundleResult::NoOperationsAfterFeeIncreases { .. } => {
+                return Err(Status::internal(
+                    "bundle initially had operations, but after increasing gas fees it was empty",
+                ))
+            }
+            SendBundleResult::StalledAtMaxFeeIncreases => return Err(Status::internal("")),
+            SendBundleResult::Error(error) => return Err(Status::internal(error.to_string())),
         };
         Ok(Response::new(DebugSendBundleNowResponse {
             transaction_hash: tx_hash.as_bytes().to_vec(),

--- a/src/builder/task.rs
+++ b/src/builder/task.rs
@@ -18,6 +18,7 @@ use url::Url;
 
 use crate::{
     builder::{
+        self,
         bundle_proposer::{self, BundleProposerImpl},
         server::{BuilderImpl, DummyBuilder},
         signer::{BundlerSigner, KmsSigner, LocalSigner},
@@ -57,6 +58,9 @@ pub struct Args {
     pub eth_poll_interval: Duration,
     pub sim_settings: simulation::Settings,
     pub mempool_configs: HashMap<H256, MempoolConfig>,
+    pub max_blocks_to_wait_for_mine: u64,
+    pub replacement_fee_percent_increase: u64,
+    pub max_fee_increases: u64,
 }
 
 #[derive(Debug)]
@@ -131,6 +135,11 @@ impl Task for BuilderTask {
             signer,
             self.args.use_conditional_send_transaction,
         );
+        let builder_settings = builder::server::Settings {
+            max_blocks_to_wait_for_mine: self.args.max_blocks_to_wait_for_mine,
+            replacement_fee_percent_increase: self.args.replacement_fee_percent_increase,
+            max_fee_increases: self.args.max_fee_increases,
+        };
         let builder = Arc::new(BuilderImpl::new(
             self.args.chain_id,
             beneficiary,
@@ -140,6 +149,7 @@ impl Task for BuilderTask {
             entry_point,
             transaction_sender,
             provider,
+            builder_settings,
         ));
 
         let _builder_loop_guard = {

--- a/src/cli/builder.rs
+++ b/src/cli/builder.rs
@@ -134,6 +134,37 @@ pub struct BuilderArgs {
         default_value = "false"
     )]
     use_conditional_send_transaction: bool,
+
+    /// After submitting a bundle transaction, the maximum number of blocks to
+    /// wait for that transaction to mine before we try resending with higher
+    /// gas fees.
+    #[arg(
+        long = "builder.max_blocks_to_wait_for_mine",
+        name = "builder.max_blocks_to_wait_for_mine",
+        env = "BUILDER_MAX_BLOCKS_TO_WAIT_FOR_MINE",
+        default_value = "2"
+    )]
+    max_blocks_to_wait_for_mine: u64,
+
+    /// Percentage amount to increase gas fees when retrying a transaction after
+    /// it failed to mine.
+    #[arg(
+        long = "builder.replacement_fee_percent_increase",
+        name = "builder.replacement_fee_percent_increase",
+        env = "BUILDER_REPLACEMENT_FEE_PERCENT_INCREASE",
+        default_value = "10"
+    )]
+    replacement_fee_percent_increase: u64,
+
+    ///
+    #[arg(
+        long = "builder.max_fee_increases",
+        name = "builder.max_fee_increases",
+        env = "BUILDER_MAX_FEE_INCREASES",
+        // Seven increases of 10% is roughly 2x the initial fees.
+        default_value = "7"
+    )]
+    max_fee_increases: u64,
 }
 
 impl BuilderArgs {
@@ -188,6 +219,9 @@ impl BuilderArgs {
             eth_poll_interval: Duration::from_millis(self.eth_poll_interval_millis),
             sim_settings: common.try_into()?,
             mempool_configs,
+            max_blocks_to_wait_for_mine: self.max_blocks_to_wait_for_mine,
+            replacement_fee_percent_increase: self.replacement_fee_percent_increase,
+            max_fee_increases: self.max_fee_increases,
         })
     }
 

--- a/src/cli/pool.rs
+++ b/src/cli/pool.rs
@@ -54,7 +54,7 @@ pub struct PoolArgs {
         env = "POOL_MIN_REPLACEMENT_FEE_INCREASE_PERCENTAGE",
         default_value = "10"
     )]
-    pub min_replacement_fee_increase_percentage: usize,
+    pub min_replacement_fee_increase_percentage: u64,
 
     /// ETH Node HTTP polling interval in milliseconds
     /// (only used if node_http is set)

--- a/src/common/math.rs
+++ b/src/common/math.rs
@@ -1,0 +1,8 @@
+use std::ops::{Div, Mul};
+
+pub fn increase_by_percent<T>(n: T, percent: u64) -> T
+where
+    T: Mul<u64, Output = T> + Div<u64, Output = T>,
+{
+    n * (100 + percent) / 100
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -5,6 +5,7 @@ pub mod eth;
 pub mod gas;
 pub mod grpc;
 pub mod handle;
+pub mod math;
 pub mod mempool;
 pub mod precheck;
 pub mod protos;

--- a/src/common/precheck.rs
+++ b/src/common/precheck.rs
@@ -129,8 +129,9 @@ impl<P: ProviderLike, E: EntryPointLike> PrecheckerImpl<P, E> {
         // The entry point calculates the user's fee per gas as
         // min(maxFeePerGas, maxPriorityFeePerGas + block.basefee), so we need
         // each term to be at least the current base fee plus the amount we want
-        // as tip.
-        let min_max_fee_per_gas = base_fee + min_priority_fee_per_gas;
+        // as tip. Give enough leeway for the base fee to increase by the
+        // maximum amount for a single block (12.5%).
+        let min_max_fee_per_gas = base_fee * 9 / 8 + min_priority_fee_per_gas;
         if op.max_fee_per_gas < min_max_fee_per_gas {
             violations.push(PrecheckViolation::MaxFeePerGasTooLow(
                 op.max_fee_per_gas,

--- a/src/common/types/entry_point_like.rs
+++ b/src/common/types/entry_point_like.rs
@@ -20,6 +20,7 @@ use crate::common::{
         shared_types::UserOpsPerAggregator,
     },
     eth,
+    gas::GasFees,
     types::UserOperation,
 };
 
@@ -54,7 +55,7 @@ pub trait EntryPointLike: Send + Sync + 'static {
         ops_per_aggregator: Vec<UserOpsPerAggregator>,
         beneficiary: Address,
         gas: U256,
-        max_priority_fee_per_gas: U256,
+        gas_fees: GasFees,
     ) -> TypedTransaction;
 }
 
@@ -152,13 +153,15 @@ where
         ops_per_aggregator: Vec<UserOpsPerAggregator>,
         beneficiary: Address,
         gas: U256,
-        max_priority_fee_per_gas: U256,
+        gas_fees: GasFees,
     ) -> TypedTransaction {
         let tx: Eip1559TransactionRequest =
             get_handle_ops_call(self, ops_per_aggregator, beneficiary, gas)
                 .tx
                 .into();
-        tx.max_priority_fee_per_gas(max_priority_fee_per_gas).into()
+        tx.max_fee_per_gas(gas_fees.max_fee_per_gas)
+            .max_priority_fee_per_gas(gas_fees.max_priority_fee_per_gas)
+            .into()
     }
 }
 

--- a/src/common/types/provider_like.rs
+++ b/src/common/types/provider_like.rs
@@ -33,6 +33,8 @@ pub trait ProviderLike: Send + Sync + 'static {
 
     async fn get_latest_block_hash(&self) -> anyhow::Result<H256>;
 
+    async fn get_base_fee(&self) -> anyhow::Result<U256>;
+
     async fn get_max_priority_fee(&self) -> anyhow::Result<U256>;
 
     async fn get_code(&self, address: Address, block_hash: Option<H256>) -> anyhow::Result<Bytes>;
@@ -78,6 +80,15 @@ impl<C: JsonRpcClient + 'static> ProviderLike for Provider<C> {
             .context("block should exist to get latest hash")?
             .hash
             .context("hash should be present on block")
+    }
+
+    async fn get_base_fee(&self) -> anyhow::Result<U256> {
+        Middleware::get_block(self, BlockNumber::Latest)
+            .await
+            .context("should load latest block to get base fee")?
+            .context("latest block should exist")?
+            .base_fee_per_gas
+            .context("latest block should have a nonempty base fee")
     }
 
     async fn get_max_priority_fee(&self) -> anyhow::Result<U256> {

--- a/src/op_pool/event/mod.rs
+++ b/src/op_pool/event/mod.rs
@@ -41,7 +41,7 @@ pub struct EntryPointEvent {
     pub txn_index: U64,
 }
 
-/// A trait that provides a stream of new blocks with thier events by entrypoint
+/// A trait that provides a stream of new blocks with their events by entrypoint
 pub trait EventProvider: Send + Sync {
     /// Subscribe to new blocks by entrypoint
     fn subscribe_by_entrypoint(

--- a/src/op_pool/mempool/mod.rs
+++ b/src/op_pool/mempool/mod.rs
@@ -80,7 +80,7 @@ pub struct PoolConfig {
     pub max_userops_per_sender: usize,
     /// The minimum fee bump required to replace an operation in the mempool
     /// Applies to both priority fee and fee. Expressed as an integer percentage value
-    pub min_replacement_fee_increase_percentage: usize,
+    pub min_replacement_fee_increase_percentage: u64,
     /// After this threshold is met, we will start to drop the worst userops from the mempool
     pub max_size_of_pool_bytes: usize,
     /// Operations that are always banned from the mempool

--- a/src/op_pool/mempool/pool.rs
+++ b/src/op_pool/mempool/pool.rs
@@ -15,7 +15,10 @@ use super::{
     size::SizeTracker,
     PoolConfig, PoolOperation,
 };
-use crate::common::types::{Entity, UserOperation, UserOperationId};
+use crate::common::{
+    math,
+    types::{Entity, UserOperation, UserOperationId},
+};
 
 /// Pool of user operations
 #[derive(Debug)]
@@ -219,19 +222,15 @@ impl PoolInner {
     }
 
     fn get_min_replacement_fees(&self, op: &UserOperation) -> (U256, U256) {
-        let replacement_priority_fee = Self::fee_multiply_percent(
+        let replacement_priority_fee = math::increase_by_percent(
             op.max_priority_fee_per_gas,
             self.config.min_replacement_fee_increase_percentage,
         );
-        let replacement_fee = Self::fee_multiply_percent(
+        let replacement_fee = math::increase_by_percent(
             op.max_fee_per_gas,
             self.config.min_replacement_fee_increase_percentage,
         );
         (replacement_priority_fee, replacement_fee)
-    }
-
-    fn fee_multiply_percent(fee: U256, percent: usize) -> U256 {
-        fee * (100 + percent) / 100
     }
 }
 

--- a/src/rpc/eth/estimation.rs
+++ b/src/rpc/eth/estimation.rs
@@ -20,7 +20,7 @@ use crate::{
             EstimateCallGasResult, EstimateCallGasRevertAtMax,
             CALLGASESTIMATIONPROXY_DEPLOYED_BYTECODE,
         },
-        eth, gas,
+        eth, gas, math,
         precheck::MIN_CALL_GAS_LIMIT,
         types::{EntryPointLike, ProviderLike, UserOperation},
     },
@@ -113,10 +113,11 @@ impl<P: ProviderLike, E: EntryPointLike> GasEstimator for GasEstimatorImpl<P, E>
         let call_gas_limit = call_gas_limit?;
         Ok(GasEstimate {
             pre_verification_gas,
-            verification_gas_limit: (verification_gas_limit
-                * (100 + VERIFICATION_GAS_BUFFER_PERCENT)
-                / 100)
-                .min(settings.max_verification_gas.into()),
+            verification_gas_limit: math::increase_by_percent(
+                verification_gas_limit,
+                VERIFICATION_GAS_BUFFER_PERCENT,
+            )
+            .min(settings.max_verification_gas.into()),
             call_gas_limit: call_gas_limit.clamp(MIN_CALL_GAS_LIMIT, settings.max_call_gas.into()),
         })
     }


### PR DESCRIPTION
If a bundle goes for two blocks without being mined, send a replacement transaction with the same nonce but higher gas fees to replace it. The replacement transaction is a newly generated bundle with stricter gas fee requirements to account for the new higher fees.

There are a few edge cases to watch out for in the implementation:

* We submit a replacement transaction, but the earlier one ends up getting mined.
* Our account's nonce increases from a separate transaction not related to the bundle transactions, invalidating any outstanding transactions.
* While we initially have ops to send, after increasing the gas fees there are no longer any ops that meet the fee requirements.

Introduce several new enums to represent the various failure cases.

Further, fix handling of `maxFeePerGas` on bundle transactions, as well as the requirement for `maxFeePerGas` on user ops, checked in both the prechecker and the proposer. We now send our transactions using a `maxFeePerGas` calculated from the current base fee increased by 12.5%, and place equivalent requirements on user ops.

As part of the new focus on making sure that `maxFeePerGas` is correct, introduce a new struct, `GasFees`, containing the two fee fields, and refactor code throughout the codebase to use it.

This is a breaking change, as previously accepted user ops will now be rejected because their `maxFeePerGas` is too low.

Closes https://github.com/OMGWINNING/rundler/issues/221