### PR TITLE
feat(simulation): Allow associated storage access if factory staked

### DIFF
--- a/src/builder/server.rs
+++ b/src/builder/server.rs
@@ -227,8 +227,11 @@ where
                 return Ok(match initial_op_count {
                     Some(initial_op_count) => {
                         BuilderMetrics::increment_bundle_txns_abandoned();
-                        SendBundleResult::NoOperationsAfterFeeIncreases { initial_op_count, attempt_number: num_increases }
-                    },
+                        SendBundleResult::NoOperationsAfterFeeIncreases {
+                            initial_op_count,
+                            attempt_number: num_increases,
+                        }
+                    }
                     None => SendBundleResult::NoOperationsInitially,
                 });
             };

--- a/src/common/eth.rs
+++ b/src/common/eth.rs
@@ -138,7 +138,7 @@ fn get_revert_data<D: AbiDecode>(mut error: ProviderError) -> Result<D, Provider
         return Err(error);
     };
     let Some(jsonrpc_error) = dyn_error.as_error_response() else {
-        return Err(error)
+        return Err(error);
     };
     if !jsonrpc_error.is_revert() {
         return Err(error);

--- a/src/common/precheck.rs
+++ b/src/common/precheck.rs
@@ -177,7 +177,9 @@ impl<P: ProviderLike, E: EntryPointLike> PrecheckerImpl<P, E> {
         } = async_data;
         if !op.paymaster_and_data.is_empty() {
             let Some(paymaster) = op.paymaster() else {
-                return Some(PrecheckViolation::PaymasterTooShort(op.paymaster_and_data.len()));
+                return Some(PrecheckViolation::PaymasterTooShort(
+                    op.paymaster_and_data.len(),
+                ));
             };
             if !paymaster_exists {
                 return Some(PrecheckViolation::PaymasterIsNotContract(paymaster));
@@ -228,7 +230,7 @@ impl<P: ProviderLike, E: EntryPointLike> PrecheckerImpl<P, E> {
 
     async fn is_contract(&self, address: Option<Address>) -> anyhow::Result<bool> {
         let Some(address) = address else {
-            return Ok(false)
+            return Ok(false);
         };
         let bytecode = self
             .provider

--- a/src/rpc/eth/mod.rs
+++ b/src/rpc/eth/mod.rs
@@ -428,9 +428,7 @@ where
             .await
             .context("should have successfully queried for user op events by hash")?;
 
-        let Some(event) = event else {
-            return Ok(None)
-        };
+        let Some(event) = event else { return Ok(None) };
 
         // 2. If the event is found, get the TX
         let transaction_hash = event
@@ -498,9 +496,7 @@ where
             .await
             .context("should have fetched user ops by hash")?;
 
-        let Some(log) = log else {
-            return Ok(None)
-        };
+        let Some(log) = log else { return Ok(None) };
 
         // 2. If the event is found, get the TX receipt
         let tx_hash = log.transaction_hash.context("tx_hash should be present")?;
@@ -582,11 +578,11 @@ impl From<SimulationError> for EthRpcError {
         debug!("Simulation error: {value:?}");
 
         let SimulationError::Violations(violations) = &mut value else {
-            return Self::Internal(value.into())
+            return Self::Internal(value.into());
         };
 
         let Some(violation) = violations.iter().min() else {
-            return Self::Internal(value.into())
+            return Self::Internal(value.into());
         };
 
         match violation {
@@ -655,10 +651,10 @@ impl From<ErrorInfo> for EthRpcError {
         if reason == ErrorReason::EntityThrottled.as_str_name() {
             let (entity, address) = metadata.iter().next().unwrap();
             let Some(address) = Address::from_str(address).ok() else {
-                return anyhow!("should have valid address in ErrorInfo metadata").into()
+                return anyhow!("should have valid address in ErrorInfo metadata").into();
             };
             let Some(entity) = EntityType::from_str(entity).ok() else {
-                return anyhow!("should be a valid Entity type in ErrorInfo metadata").into()
+                return anyhow!("should be a valid Entity type in ErrorInfo metadata").into();
             };
             return EthRpcError::ThrottledOrBanned(Entity::new(entity, address));
         } else if reason == ErrorReason::ReplacementUnderpriced.as_str_name() {
@@ -686,7 +682,7 @@ impl From<Status> for EthRpcError {
     fn from(status: Status) -> Self {
         let status_details: anyhow::Result<ErrorInfo> = status.try_into();
         let Ok(error_info) = status_details else {
-            return EthRpcError::Internal(status_details.unwrap_err())
+            return EthRpcError::Internal(status_details.unwrap_err());
         };
 
         EthRpcError::from(error_info)


### PR DESCRIPTION
As per https://github.com/ethereum/EIPs/pull/7250, allow entities to access the sender's associated storage if the factory is staked.