### PR TITLE
chore(compiler): upgrade rust to 1.71.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Adapted from https://github.com/paradigmxyz/reth/blob/main/Dockerfile
 # syntax=docker/dockerfile:1.4
 
-FROM rust:1.69.0 AS chef-builder
+FROM rust:1.71.0 AS chef-builder
 
 # Install system dependencies
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list


### PR DESCRIPTION
[Closes/Fixes] #

Upgrade Rust to 1.71. Fixes Docker build issue:

```
427.5 Caused by:
427.5   package `foundry-cli v0.2.0 (/usr/local/cargo/git/checkouts/foundry-f7cca724e93059b0/dea5405/crates/cli)` cannot be built because it requires rustc 1.71 or newer, while the currently active rustc version is 1.69.0
```

## Proposed Changes

  -
  -
  -
