### PR TITLE
chore(test): add unit tests for gas estimation logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ src/common/contracts/
 
 .env
 *.log
+
+*.profraw
+.DS_Store

--- a/src/common/gas.rs
+++ b/src/common/gas.rs
@@ -77,6 +77,7 @@ fn calc_static_pre_verification_gas(op: &UserOperation) -> U256 {
         })
         .reduce(|a, b| a + b)
         .unwrap_or_default();
+
     ov.fixed / ov.bundle_size
         + call_data_cost
         + ov.per_user_op


### PR DESCRIPTION
[Closes/Fixes] #300

This particular module is difficult to write tests without having a lot of boilerplate code duplicated. I could always separate re-used code blocks into variables within the test module but I dont think it is needed that much as the test code is not compiled into the release binary 

## Proposed Changes
  - 88% test coverage for estimation code
  - Added multiple usecases to test errors and correct outputs
 
## TODO

- Add a check for settings max_call_gas to insure that the thread does not panic by comparing the field to the MIN_CALL_GAS_LIMIT constant.
- Check for integer overflow when converting U256 to u64