### PR TITLE
Revert "chore(build): update git submodules before generating ABIs"

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     println!("cargo:rerun-if-changed=proto");
     println!("cargo:rerun-if-changed=tracer/package.json");
     println!("cargo:rerun-if-changed=tracer/src/validationTracer.ts");
-    update_submodules()?;
     generate_contract_bindings()?;
     generate_protos()?;
     compile_tracer()?;
@@ -52,14 +51,6 @@ fn generate_abis() -> Result<(), Box<dyn error::Error>> {
             .arg("./contracts"),
         "https://getfoundry.sh/",
         "generate ABIs",
-    )
-}
-
-fn update_submodules() -> Result<(), Box<dyn error::Error>> {
-    run_command(
-        Command::new("git").arg("submodule").arg("update"),
-        "https://github.com/git-guides/install-git",
-        "update submodules",
     )
 }
 


### PR DESCRIPTION
Reverts OMGWINNING/rundler#320

Did not fix the submodule problem for `cargo semver-checks check-release --baseline-rev main`. Reverting for now.