### PR TITLE
feat(traits): update use of ethers Provider and contract binding of entrypoint to use traits 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         run: sudo apt-get install -y protobuf-compiler
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.71.0
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -35,6 +37,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+          toolchain: 1.71.0
       - name: Install toolchain (nightly)
         run: rustup toolchain add nightly --component rustfmt --profile minimal
       - uses: Swatinem/rust-cache@v2

--- a/src/builder/task.rs
+++ b/src/builder/task.rs
@@ -120,13 +120,15 @@ impl Task for BuilderTask {
         };
         let op_pool =
             Self::connect_client_with_shutdown(&self.args.pool_url, shutdown_token.clone()).await?;
+
+        let entry_point = IEntryPoint::new(self.args.entry_point_address, Arc::clone(&provider));
         let simulator = SimulatorImpl::new(
             Arc::clone(&provider),
-            self.args.entry_point_address,
+            entry_point.clone(),
             self.args.sim_settings,
             self.args.mempool_configs.clone(),
         );
-        let entry_point = IEntryPoint::new(self.args.entry_point_address, Arc::clone(&provider));
+
         let proposer = BundleProposerImpl::new(
             op_pool.clone(),
             simulator,

--- a/src/rpc/task.rs
+++ b/src/rpc/task.rs
@@ -22,6 +22,7 @@ use url::Url;
 use super::ApiNamespace;
 use crate::{
     common::{
+        contracts::i_entry_point::IEntryPoint,
         handle::Task,
         mempool::MempoolConfig,
         precheck,
@@ -114,12 +115,20 @@ impl Task for RpcTask {
             bail!("No entry points provided");
         }
 
+        let entry_point_addrs = &self.args.entry_points;
+        let mut entry_points = vec![];
+
+        for entry in entry_point_addrs {
+            let entry = IEntryPoint::new(*entry, provider.clone());
+            entry_points.push(entry);
+        }
+
         for api in &self.args.api_namespaces {
             match api {
                 ApiNamespace::Eth => module.merge(
                     EthApi::new(
                         provider.clone(),
-                        self.args.entry_points.clone(),
+                        entry_points.clone(),
                         self.args.chain_id,
                         op_pool_client.clone(),
                         self.args.precheck_settings,


### PR DESCRIPTION
[Closes] #267 

## Proposed Changes

  - update use of ethers Provider and contract binding of entrypoint to use traits
  - Did not update provider config with use of Signer yet as I will need to look further into the config
  - I did have to clone some instances of `EntrypointLike` to get around the compiler but could most likely remove memory cloning however I don't think that will much memory overhead in this case
