### PR TITLE
fix(precheck): Reject ops with gas higher than bundle limit

### DIFF
--- a/src/builder/task.rs
+++ b/src/builder/task.rs
@@ -52,6 +52,7 @@ pub struct Args {
     pub redis_lock_ttl_millis: u64,
     pub chain_id: u64,
     pub max_bundle_size: u64,
+    pub max_bundle_gas: u64,
     pub submit_url: String,
     pub use_bundle_priority_fee: Option<bool>,
     pub bundle_priority_fee_overhead_percent: u64,
@@ -113,6 +114,7 @@ impl Task for BuilderTask {
         let proposer_settings = bundle_proposer::Settings {
             chain_id: self.args.chain_id,
             max_bundle_size: self.args.max_bundle_size,
+            max_bundle_gas: self.args.max_bundle_gas,
             beneficiary,
             use_bundle_priority_fee: self.args.use_bundle_priority_fee,
             priority_fee_mode: self.args.priority_fee_mode,
@@ -134,7 +136,6 @@ impl Task for BuilderTask {
             simulator,
             entry_point.clone(),
             Arc::clone(&provider),
-            self.args.chain_id,
             proposer_settings,
             self.event_sender.clone(),
         );

--- a/src/cli/builder.rs
+++ b/src/cli/builder.rs
@@ -193,6 +193,7 @@ impl BuilderArgs {
             redis_lock_ttl_millis: self.redis_lock_ttl_millis,
             chain_id: common.chain_id,
             max_bundle_size: self.max_bundle_size,
+            max_bundle_gas: common.max_bundle_gas,
             submit_url,
             use_bundle_priority_fee: common.use_bundle_priority_fee,
             bundle_priority_fee_overhead_percent: common.bundle_priority_fee_overhead_percent,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -120,6 +120,15 @@ pub struct CommonArgs {
     max_verification_gas: u64,
 
     #[arg(
+        long = "max_bundle_gas",
+        name = "max_bundle_gas",
+        default_value = "10000000",
+        env = "MAX_BUNDLE_GAS",
+        global = true
+    )]
+    max_bundle_gas: u64,
+
+    #[arg(
         long = "min_stake_value",
         name = "min_stake_value",
         env = "MIN_STAKE_VALUE",
@@ -241,7 +250,9 @@ impl TryFrom<&CommonArgs> for precheck::Settings {
 
     fn try_from(value: &CommonArgs) -> anyhow::Result<Self> {
         Ok(Self {
+            chain_id: value.chain_id,
             max_verification_gas: value.max_verification_gas.into(),
+            max_total_execution_gas: value.max_bundle_gas.into(),
             use_bundle_priority_fee: value.use_bundle_priority_fee,
             bundle_priority_fee_overhead_percent: value.bundle_priority_fee_overhead_percent,
             priority_fee_mode: PriorityFeeMode::try_from(


### PR DESCRIPTION
Ops whose total execution gas is higher than the bundle gas limit can never be added to a bundle, so we should reject them immediately.

Also, make bundle gas limit configurable, and remove a repeated `chain_id` field between the proposer and its settings.
