### PR TITLE
fix(clippy): allow panic for DummyBuilder for rust v1.72.0

### DIFF
--- a/src/builder/server.rs
+++ b/src/builder/server.rs
@@ -549,6 +549,7 @@ pub enum DummyBuilder {}
 
 #[async_trait]
 impl Builder for DummyBuilder {
+    #[allow(clippy::diverging_sub_expression)]
     async fn debug_send_bundle_now(
         &self,
         _request: Request<DebugSendBundleNowRequest>,
@@ -556,6 +557,7 @@ impl Builder for DummyBuilder {
         panic!()
     }
 
+    #[allow(clippy::diverging_sub_expression)]
     async fn debug_set_bundling_mode(
         &self,
         _request: Request<DebugSetBundlingModeRequest>,


### PR DESCRIPTION
## Proposed Changes
- add clippy allow declaration for DummyBuilder which is used for health reporting. We could return a dummy success or error response however I just kept it as the initial panic implementation.
