### PR TITLE
chore(ra): add helix config to git ignore for rust-analyzer optimisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ src/common/contracts/
 
 *.profraw
 .DS_Store
+.helix


### PR DESCRIPTION
## Proposed Changes

 - Adding .helix dir to gitignore for RA settings on the helix IDE
