### PR TITLE
refactor(entrypoint): replace get_deposit calls with balance_of

### DIFF
--- a/crates/provider/src/traits/entry_point.rs
+++ b/crates/provider/src/traits/entry_point.rs
@@ -1,4 +1,6 @@
-use ethers::types::{spoof, transaction::eip2718::TypedTransaction, Address, Bytes, H256, U256};
+use ethers::types::{
+    spoof, transaction::eip2718::TypedTransaction, Address, BlockId, Bytes, H256, U256,
+};
 #[cfg(feature = "test-utils")]
 use mockall::automock;
 use rundler_types::{
@@ -35,10 +37,8 @@ pub trait EntryPoint: Send + Sync + 'static {
     ) -> anyhow::Result<HandleOpsOut>;
 
     /// Get the balance of an address
-    async fn balance_of(&self, address: Address) -> anyhow::Result<U256>;
-
-    /// Get the deposit value of an address on the entry point contract
-    async fn get_deposit(&self, address: Address, block_hash: H256) -> anyhow::Result<U256>;
+    async fn balance_of(&self, address: Address, block_id: Option<BlockId>)
+        -> anyhow::Result<U256>;
 
     /// Call the entry point contract's `simulateValidation` function
     async fn simulate_validation(

--- a/crates/rundler/src/common/precheck.rs
+++ b/crates/rundler/src/common/precheck.rs
@@ -274,7 +274,7 @@ impl<P: Provider, E: EntryPoint> PrecheckerImpl<P, E> {
             None => op.sender,
         };
         self.entry_point
-            .balance_of(payer)
+            .balance_of(payer, None)
             .await
             .context("precheck should get payer balance")
     }


### PR DESCRIPTION
Closes #378

## Proposed Changes

  - remove `get_deposit` and add `block_id` parameter to `balance_of`