### PR TITLE
chore(stale): add allowlist for long running issues/PRs

### DIFF
--- a/.github/workflows/scheduled_jobs.yaml
+++ b/.github/workflows/scheduled_jobs.yaml
@@ -12,6 +12,7 @@ jobs:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           days-before-stale: 30
           days-before-close: 5
+          exempt-assignees: dancoombs,dphilipson,0xfourzerofour,alex-miao 
   todo:
     runs-on: "ubuntu-latest"
     steps:


### PR DESCRIPTION
## Proposed Changes

  - Allow long running issues to stay active without being set to stale if it includes members of the Rundler Team
