### PR TITLE
refactor(provider): crate provider error enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4062,6 +4062,7 @@ dependencies = [
  "rundler-types",
  "rundler-utils",
  "serde",
+ "thiserror",
  "tokio",
 ]
 
@@ -4100,6 +4101,7 @@ dependencies = [
  "arrayvec",
  "async-trait",
  "ethers",
+ "futures-util",
  "indexmap 2.0.0",
  "mockall",
  "parse-display",

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -15,6 +15,7 @@ async-trait.workspace = true
 ethers.workspace = true
 serde.workspace = true
 tokio.workspace = true
+thiserror.workspace = true
 
 mockall = {workspace = true, optional = true }
 

--- a/crates/provider/src/ethers/provider.rs
+++ b/crates/provider/src/ethers/provider.rs
@@ -3,7 +3,10 @@ use std::{fmt::Debug, sync::Arc};
 use anyhow::Context;
 use ethers::{
     contract::ContractError,
-    providers::{JsonRpcClient, Middleware, Provider as EthersProvider, ProviderError},
+    prelude::ContractError as EthersContractError,
+    providers::{
+        JsonRpcClient, Middleware, Provider as EthersProvider, ProviderError as EthersProviderError,
+    },
     types::{
         transaction::eip2718::TypedTransaction, Address, Block, BlockId, BlockNumber, Bytes,
         Eip1559TransactionRequest, FeeHistory, Filter, GethDebugTracingCallOptions,
@@ -20,7 +23,7 @@ use rundler_types::{
 };
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::{AggregatorOut, AggregatorSimOut, Provider};
+use crate::{AggregatorOut, AggregatorSimOut, Provider, ProviderError, ProviderResult};
 
 const ARBITRUM_NITRO_NODE_INTERFACE_ADDRESS: Address = H160([
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xc8,
@@ -36,20 +39,16 @@ impl<C: JsonRpcClient + 'static> Provider for EthersProvider<C> {
     // `Middleware` because forming a `PendingTransaction` specifically requires
     // a `Provider`.
 
-    async fn request<T, R>(&self, method: &str, params: T) -> Result<R, ProviderError>
+    async fn request<T, R>(&self, method: &str, params: T) -> ProviderResult<R>
     where
         T: Debug + Serialize + Send + Sync + 'static,
         R: Serialize + DeserializeOwned + Debug + Send + 'static,
     {
-        EthersProvider::request(self, method, params).await
+        Ok(EthersProvider::request(self, method, params).await?)
     }
 
-    async fn call(
-        &self,
-        tx: &TypedTransaction,
-        block: Option<BlockId>,
-    ) -> Result<Bytes, ProviderError> {
-        Middleware::call(self, tx, block).await
+    async fn call(&self, tx: &TypedTransaction, block: Option<BlockId>) -> ProviderResult<Bytes> {
+        Ok(Middleware::call(self, tx, block).await?)
     }
 
     async fn fee_history<T: Into<U256> + Send + Sync + Serialize + 'static>(
@@ -57,11 +56,11 @@ impl<C: JsonRpcClient + 'static> Provider for EthersProvider<C> {
         t: T,
         block_number: BlockNumber,
         reward_percentiles: &[f64],
-    ) -> Result<FeeHistory, ProviderError> {
-        Middleware::fee_history(self, t, block_number, reward_percentiles).await
+    ) -> ProviderResult<FeeHistory> {
+        Ok(Middleware::fee_history(self, t, block_number, reward_percentiles).await?)
     }
 
-    async fn get_block_number(&self) -> anyhow::Result<u64> {
+    async fn get_block_number(&self) -> ProviderResult<u64> {
         Ok(Middleware::get_block_number(self)
             .await
             .context("should get block number from provider")?
@@ -71,32 +70,30 @@ impl<C: JsonRpcClient + 'static> Provider for EthersProvider<C> {
     async fn get_block<T: Into<BlockId> + Send + Sync + 'static>(
         &self,
         block_hash_or_number: T,
-    ) -> anyhow::Result<Option<Block<H256>>> {
-        Middleware::get_block(self, block_hash_or_number)
-            .await
-            .context("should get block from provider")
+    ) -> ProviderResult<Option<Block<H256>>> {
+        Ok(Middleware::get_block(self, block_hash_or_number).await?)
     }
 
     async fn get_transaction<T: Send + Sync + Into<TxHash>>(
         &self,
         transaction_hash: T,
-    ) -> Result<Option<Transaction>, ProviderError> {
-        Middleware::get_transaction(self, transaction_hash).await
+    ) -> ProviderResult<Option<Transaction>> {
+        Ok(Middleware::get_transaction(self, transaction_hash).await?)
     }
 
     async fn get_transaction_receipt<T: Send + Sync + Into<TxHash> + 'static>(
         &self,
         transaction_hash: T,
-    ) -> Result<Option<TransactionReceipt>, ProviderError> {
-        Middleware::get_transaction_receipt(self, transaction_hash).await
+    ) -> ProviderResult<Option<TransactionReceipt>> {
+        Ok(Middleware::get_transaction_receipt(self, transaction_hash).await?)
     }
 
     async fn debug_trace_transaction(
         &self,
         tx_hash: TxHash,
         trace_options: GethDebugTracingOptions,
-    ) -> Result<GethTrace, ProviderError> {
-        Middleware::debug_trace_transaction(self, tx_hash, trace_options).await
+    ) -> ProviderResult<GethTrace> {
+        Ok(Middleware::debug_trace_transaction(self, tx_hash, trace_options).await?)
     }
 
     async fn debug_trace_call(
@@ -104,51 +101,47 @@ impl<C: JsonRpcClient + 'static> Provider for EthersProvider<C> {
         tx: TypedTransaction,
         block_id: Option<BlockId>,
         trace_options: GethDebugTracingCallOptions,
-    ) -> Result<GethTrace, ProviderError> {
-        Middleware::debug_trace_call(self, tx, block_id, trace_options).await
+    ) -> ProviderResult<GethTrace> {
+        Ok(Middleware::debug_trace_call(self, tx, block_id, trace_options).await?)
     }
 
-    async fn get_balance(&self, address: Address, block: Option<BlockId>) -> anyhow::Result<U256> {
-        Middleware::get_balance(self, address, block)
-            .await
-            .context("should get balance from provider")
+    async fn get_balance(&self, address: Address, block: Option<BlockId>) -> ProviderResult<U256> {
+        Ok(Middleware::get_balance(self, address, block).await?)
     }
 
-    async fn get_latest_block_hash(&self) -> anyhow::Result<H256> {
-        Middleware::get_block(self, BlockId::Number(BlockNumber::Latest))
-            .await
-            .context("should load block to get hash")?
-            .context("block should exist to get latest hash")?
-            .hash
-            .context("hash should be present on block")
+    async fn get_latest_block_hash(&self) -> ProviderResult<H256> {
+        Ok(
+            Middleware::get_block(self, BlockId::Number(BlockNumber::Latest))
+                .await
+                .context("should load block to get hash")?
+                .context("block should exist to get latest hash")?
+                .hash
+                .context("hash should be present on block")?,
+        )
     }
 
-    async fn get_base_fee(&self) -> anyhow::Result<U256> {
-        Middleware::get_block(self, BlockNumber::Pending)
+    async fn get_base_fee(&self) -> ProviderResult<U256> {
+        Ok(Middleware::get_block(self, BlockNumber::Pending)
             .await
             .context("should load pending block to get base fee")?
             .context("pending block should exist")?
             .base_fee_per_gas
-            .context("pending block should have a nonempty base fee")
+            .context("pending block should have a nonempty base fee")?)
     }
 
-    async fn get_max_priority_fee(&self) -> anyhow::Result<U256> {
-        self.request("eth_maxPriorityFeePerGas", ())
-            .await
-            .context("should get max priority fee from provider")
+    async fn get_max_priority_fee(&self) -> ProviderResult<U256> {
+        Ok(self.request("eth_maxPriorityFeePerGas", ()).await?)
     }
 
-    async fn get_logs(&self, filter: &Filter) -> anyhow::Result<Vec<Log>> {
-        Middleware::get_logs(self, filter)
-            .await
-            .context("provider should get logs")
+    async fn get_logs(&self, filter: &Filter) -> ProviderResult<Vec<Log>> {
+        Ok(Middleware::get_logs(self, filter).await?)
     }
 
     async fn aggregate_signatures(
         self: Arc<Self>,
         aggregator_address: Address,
         ops: Vec<UserOperation>,
-    ) -> anyhow::Result<Option<Bytes>> {
+    ) -> ProviderResult<Option<Bytes>> {
         let aggregator = IAggregator::new(aggregator_address, self);
         // TODO: Cap the gas here.
         let result = aggregator.aggregate_signatures(ops).call().await;
@@ -164,7 +157,7 @@ impl<C: JsonRpcClient + 'static> Provider for EthersProvider<C> {
         aggregator_address: Address,
         user_op: UserOperation,
         gas_cap: u64,
-    ) -> anyhow::Result<AggregatorOut> {
+    ) -> ProviderResult<AggregatorOut> {
         let aggregator = IAggregator::new(aggregator_address, self);
         let result = aggregator
             .validate_user_op_signature(user_op)
@@ -182,23 +175,19 @@ impl<C: JsonRpcClient + 'static> Provider for EthersProvider<C> {
         }
     }
 
-    async fn get_code(&self, address: Address, block_hash: Option<H256>) -> anyhow::Result<Bytes> {
-        Middleware::get_code(self, address, block_hash.map(|b| b.into()))
-            .await
-            .context("provider should get contract code")
+    async fn get_code(&self, address: Address, block_hash: Option<H256>) -> ProviderResult<Bytes> {
+        Ok(Middleware::get_code(self, address, block_hash.map(|b| b.into())).await?)
     }
 
-    async fn get_transaction_count(&self, address: Address) -> anyhow::Result<U256> {
-        Middleware::get_transaction_count(self, address, None)
-            .await
-            .context("provider should get transaction count")
+    async fn get_transaction_count(&self, address: Address) -> ProviderResult<U256> {
+        Ok(Middleware::get_transaction_count(self, address, None).await?)
     }
 
     async fn calc_arbitrum_l1_gas(
         self: Arc<Self>,
         entry_point_address: Address,
         op: UserOperation,
-    ) -> anyhow::Result<U256> {
+    ) -> ProviderResult<U256> {
         let entry_point = IEntryPoint::new(entry_point_address, Arc::clone(&self));
         let data = entry_point
             .handle_ops(vec![op], Address::random())
@@ -217,7 +206,7 @@ impl<C: JsonRpcClient + 'static> Provider for EthersProvider<C> {
         self: Arc<Self>,
         entry_point_address: Address,
         op: UserOperation,
-    ) -> anyhow::Result<U256> {
+    ) -> ProviderResult<U256> {
         let entry_point = IEntryPoint::new(entry_point_address, Arc::clone(&self));
         let data = entry_point
             .handle_ops(vec![op], Address::random())
@@ -250,5 +239,26 @@ impl<C: JsonRpcClient + 'static> Provider for EthersProvider<C> {
         )?;
 
         Ok(l1_fee / (l2_base_fee + l2_priority_fee))
+    }
+}
+
+impl From<EthersProviderError> for ProviderError {
+    fn from(e: EthersProviderError) -> Self {
+        match e {
+            EthersProviderError::JsonRpcClientError(e) => {
+                if let Some(jsonrpc_error) = e.as_error_response() {
+                    ProviderError::JsonRpcError(jsonrpc_error.clone())
+                } else {
+                    ProviderError::Other(anyhow::anyhow!(e.to_string()))
+                }
+            }
+            _ => ProviderError::Other(anyhow::anyhow!(e.to_string())),
+        }
+    }
+}
+
+impl<M: Middleware> From<EthersContractError<M>> for ProviderError {
+    fn from(e: EthersContractError<M>) -> Self {
+        ProviderError::ContractError(e.to_string())
     }
 }

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -11,6 +11,9 @@
 mod ethers;
 
 mod traits;
-pub use traits::{AggregatorOut, AggregatorSimOut, EntryPoint, HandleOpsOut, Provider};
+pub use traits::{
+    AggregatorOut, AggregatorSimOut, EntryPoint, HandleOpsOut, Provider, ProviderError,
+    ProviderResult,
+};
 #[cfg(any(test, feature = "test-utils"))]
 pub use traits::{MockEntryPoint, MockProvider};

--- a/crates/provider/src/traits/error.rs
+++ b/crates/provider/src/traits/error.rs
@@ -1,0 +1,15 @@
+use ethers::providers::JsonRpcError;
+
+/// Error enumeration for the Provider trait
+#[derive(Debug, thiserror::Error)]
+pub enum ProviderError {
+    /// JSON-RPC error
+    #[error(transparent)]
+    JsonRpcError(#[from] JsonRpcError),
+    /// Contract Error
+    #[error("Contract Error: {0}")]
+    ContractError(String),
+    /// Internal errors
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}

--- a/crates/provider/src/traits/mod.rs
+++ b/crates/provider/src/traits/mod.rs
@@ -1,5 +1,8 @@
 //! Traits for the provider module.
 
+mod error;
+pub use error::ProviderError;
+
 mod entry_point;
 #[cfg(feature = "test-utils")]
 pub use entry_point::MockEntryPoint;
@@ -8,4 +11,4 @@ pub use entry_point::{EntryPoint, HandleOpsOut};
 mod provider;
 #[cfg(feature = "test-utils")]
 pub use provider::MockProvider;
-pub use provider::{AggregatorOut, AggregatorSimOut, Provider};
+pub use provider::{AggregatorOut, AggregatorSimOut, Provider, ProviderResult};

--- a/crates/rpc/src/eth/error.rs
+++ b/crates/rpc/src/eth/error.rs
@@ -4,6 +4,7 @@ use jsonrpsee::types::{
     ErrorObjectOwned,
 };
 use rundler_pool::{MempoolError, PoolServerError};
+use rundler_provider::ProviderError;
 use rundler_sim::{PrecheckViolation, SimulationViolation};
 use rundler_types::{Entity, EntityType, Timestamp};
 use serde::Serialize;
@@ -263,10 +264,16 @@ impl From<EthRpcError> for ErrorObjectOwned {
 
 impl From<tonic::Status> for EthRpcError {
     fn from(status: tonic::Status) -> Self {
-        EthRpcError::Internal(anyhow::anyhow!(format!(
+        EthRpcError::Internal(anyhow::anyhow!(
             "internal server error code: {} message: {}",
             status.code(),
             status.message()
-        )))
+        ))
+    }
+}
+
+impl From<ProviderError> for EthRpcError {
+    fn from(e: ProviderError) -> Self {
+        EthRpcError::Internal(anyhow::anyhow!("provider error: {e:?}"))
     }
 }

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -15,6 +15,7 @@ anyhow.workspace = true
 arrayvec = "0.7.2"
 async-trait.workspace = true
 ethers.workspace = true
+futures-util.workspace = true
 indexmap = "2.0.0"
 parse-display.workspace = true
 thiserror.workspace = true

--- a/crates/sim/src/estimation/estimation.rs
+++ b/crates/sim/src/estimation/estimation.rs
@@ -100,7 +100,10 @@ impl<P: Provider, E: EntryPoint> GasEstimator for GasEstimatorImpl<P, E> {
             provider, settings, ..
         } = self;
 
-        let block_hash = provider.get_latest_block_hash().await?;
+        let block_hash = provider
+            .get_latest_block_hash()
+            .await
+            .map_err(anyhow::Error::from)?;
 
         // Estimate pre verification gas
         let pre_verification_gas = self.calc_pre_verification_gas(&op).await?;
@@ -263,7 +266,8 @@ impl<P: Provider, E: EntryPoint> GasEstimatorImpl<P, E> {
         let entry_point_code = self
             .provider
             .get_code(self.entry_point.address(), Some(block_hash))
-            .await?;
+            .await
+            .map_err(anyhow::Error::from)?;
         // Use a random address for the moved entry point so that users can't
         // intentionally get bad estimates by interacting with the hardcoded
         // address.
@@ -376,11 +380,11 @@ fn estimation_proxy_bytecode_with_target(target: Address) -> Bytes {
 mod tests {
     use ethers::{
         abi::{AbiEncode, Address},
-        providers::{JsonRpcError, MockError, ProviderError},
+        providers::JsonRpcError,
         types::Chain,
         utils::hex,
     };
-    use rundler_provider::{MockEntryPoint, MockProvider};
+    use rundler_provider::{MockEntryPoint, MockProvider, ProviderError};
     use rundler_types::contracts::{get_gas_used::GasUsedResult, i_entry_point::ExecutionResult};
 
     use super::*;
@@ -621,10 +625,7 @@ mod tests {
                 message: "execution reverted".to_string(),
                 data: Some(serde_json::Value::String(result_data.to_string())),
             };
-
-            Err(ProviderError::JsonRpcClientError(Box::new(
-                MockError::JsonRpcError(json_rpc_error),
-            )))
+            Err(ProviderError::JsonRpcError(json_rpc_error))
         });
 
         let (estimator, _) = create_estimator(entry, provider);
@@ -690,10 +691,7 @@ mod tests {
                 message: "execution reverted".to_string(),
                 data: Some(serde_json::Value::String(result_data.to_string())),
             };
-
-            Err(ProviderError::JsonRpcClientError(Box::new(
-                MockError::JsonRpcError(json_rpc_error),
-            )))
+            Err(ProviderError::JsonRpcError(json_rpc_error))
         });
 
         let (estimator, _) = create_estimator(entry, provider);
@@ -757,10 +755,7 @@ mod tests {
                 message: "execution reverted".to_string(),
                 data: Some(serde_json::Value::String(result_data.to_string())),
             };
-
-            Err(ProviderError::JsonRpcClientError(Box::new(
-                MockError::JsonRpcError(json_rpc_error),
-            )))
+            Err(ProviderError::JsonRpcError(json_rpc_error))
         });
 
         let (estimator, _) = create_estimator(entry, provider);
@@ -810,10 +805,7 @@ mod tests {
                 message: "execution reverted".to_string(),
                 data: Some(serde_json::Value::String(result_data.to_string())),
             };
-
-            Err(ProviderError::JsonRpcClientError(Box::new(
-                MockError::JsonRpcError(json_rpc_error),
-            )))
+            Err(ProviderError::JsonRpcError(json_rpc_error))
         });
 
         let (estimator, _) = create_estimator(entry, provider);
@@ -862,10 +854,7 @@ mod tests {
                 message: "execution reverted".to_string(),
                 data: Some(serde_json::Value::String(result_data.to_string())),
             };
-
-            Err(ProviderError::JsonRpcClientError(Box::new(
-                MockError::JsonRpcError(json_rpc_error),
-            )))
+            Err(ProviderError::JsonRpcError(json_rpc_error))
         });
 
         let (estimator, _) = create_estimator(entry, provider);
@@ -1104,10 +1093,7 @@ mod tests {
                 message: "execution reverted".to_string(),
                 data: Some(serde_json::Value::String(result_data.to_string())),
             };
-
-            Err(ProviderError::JsonRpcClientError(Box::new(
-                MockError::JsonRpcError(json_rpc_error),
-            )))
+            Err(ProviderError::JsonRpcError(json_rpc_error))
         });
 
         let (estimator, _) = create_estimator(entry, provider);
@@ -1178,10 +1164,7 @@ mod tests {
                 message: "execution reverted".to_string(),
                 data: Some(serde_json::Value::String(result_data.to_string())),
             };
-
-            Err(ProviderError::JsonRpcClientError(Box::new(
-                MockError::JsonRpcError(json_rpc_error),
-            )))
+            Err(ProviderError::JsonRpcError(json_rpc_error))
         });
 
         //max_call_gas is less than MIN_CALL_GAS_LIMIT

--- a/crates/sim/src/gas/gas.rs
+++ b/crates/sim/src/gas/gas.rs
@@ -267,17 +267,16 @@ impl<P: Provider> FeeEstimator<P> {
     }
 
     async fn get_base_fee(&self) -> anyhow::Result<U256> {
-        self.provider.get_base_fee().await
+        Ok(self.provider.get_base_fee().await?)
     }
 
     async fn get_priority_fee(&self) -> anyhow::Result<U256> {
         if POLYGON_CHAIN_IDS.contains(&self.chain_id) {
             let gas_oracle =
                 Polygon::new(Arc::clone(&self.provider), self.chain_id).category(GasCategory::Fast);
-            let fees = gas_oracle.estimate_eip1559_fees().await?;
-            Ok(fees.1)
+            Ok(gas_oracle.estimate_priority_fee().await?)
         } else if self.use_bundle_priority_fee {
-            self.provider.get_max_priority_fee().await
+            Ok(self.provider.get_max_priority_fee().await?)
         } else {
             Ok(U256::zero())
         }

--- a/crates/sim/src/utils.rs
+++ b/crates/sim/src/utils.rs
@@ -1,10 +1,9 @@
 use anyhow::Context;
 use ethers::{
     abi::{AbiDecode, AbiEncode},
-    providers::ProviderError,
     types::{Address, BlockId, Bytes, Eip1559TransactionRequest, Selector, H256, U256},
 };
-use rundler_provider::Provider;
+use rundler_provider::{Provider, ProviderError};
 use rundler_types::contracts::{
     get_code_hashes::{CodeHashesResult, GETCODEHASHES_BYTECODE},
     get_gas_used::{GasUsedResult, GETGASUSED_BYTECODE},
@@ -67,11 +66,8 @@ async fn call_constructor<P: Provider, Args: AbiEncode, Ret: AbiDecode>(
 }
 
 // Gets and decodes the revert data from a provider error, if it is a revert error.
-fn get_revert_data<D: AbiDecode>(mut error: ProviderError) -> Result<D, ProviderError> {
-    let ProviderError::JsonRpcClientError(dyn_error) = &mut error else {
-        return Err(error);
-    };
-    let Some(jsonrpc_error) = dyn_error.as_error_response() else {
+fn get_revert_data<D: AbiDecode>(error: ProviderError) -> Result<D, ProviderError> {
+    let ProviderError::JsonRpcError(jsonrpc_error) = &error else {
         return Err(error);
     };
     if !jsonrpc_error.is_revert() {


### PR DESCRIPTION
Closes #409 

Add a provider error enum to consolidate error types on the provider interface.

Also sunk in fixes to the `polygon` priority fee estimation that we put in release directly to handle an on-call event.
