### PR TITLE
fix(gas): improve bundle gas estimation calculation

### DIFF
--- a/crates/sim/src/gas/gas.rs
+++ b/crates/sim/src/gas/gas.rs
@@ -336,34 +336,29 @@ mod tests {
 
     use super::*;
 
+    fn create_test_op_with_gas(
+        pre_verification_gas: U256,
+        call_gas_limit: U256,
+        verification_gas_limit: U256,
+        with_paymaster: bool,
+    ) -> UserOperation {
+        UserOperation {
+            pre_verification_gas,
+            call_gas_limit,
+            verification_gas_limit,
+            paymaster_and_data: if with_paymaster {
+                Bytes::from(vec![0; 20])
+            } else {
+                Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
     #[tokio::test]
     async fn test_bundle_gas_limit() {
-        let op1 = UserOperation {
-            pre_verification_gas: 100_000.into(),
-            call_gas_limit: 100_000.into(),
-            verification_gas_limit: 1_000_000.into(),
-            max_fee_per_gas: Default::default(),
-            sender: Default::default(),
-            nonce: Default::default(),
-            init_code: Default::default(),
-            call_data: Default::default(),
-            max_priority_fee_per_gas: Default::default(),
-            paymaster_and_data: Default::default(),
-            signature: Default::default(),
-        };
-        let op2 = UserOperation {
-            pre_verification_gas: 100_000.into(),
-            call_gas_limit: 100_000.into(),
-            verification_gas_limit: 200_000.into(),
-            max_fee_per_gas: Default::default(),
-            sender: Default::default(),
-            nonce: Default::default(),
-            init_code: Default::default(),
-            call_data: Default::default(),
-            max_priority_fee_per_gas: Default::default(),
-            paymaster_and_data: Default::default(),
-            signature: Default::default(),
-        };
+        let op1 = create_test_op_with_gas(100_000.into(), 100_000.into(), 1_000_000.into(), false);
+        let op2 = create_test_op_with_gas(100_000.into(), 100_000.into(), 200_000.into(), false);
         let ops = vec![op1.clone(), op2.clone()];
         let chain_id = 1;
         let gas_limit = bundle_gas_limit(ops.iter(), chain_id);
@@ -380,32 +375,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_bundle_gas_limit_with_paymaster_op() {
-        let op1 = UserOperation {
-            pre_verification_gas: 100_000.into(),
-            call_gas_limit: 100_000.into(),
-            verification_gas_limit: 1_000_000.into(),
-            max_fee_per_gas: Default::default(),
-            sender: Default::default(),
-            nonce: Default::default(),
-            init_code: Default::default(),
-            call_data: Default::default(),
-            max_priority_fee_per_gas: Default::default(),
-            paymaster_and_data: Bytes::from(vec![0; 20]), // has paymaster
-            signature: Default::default(),
-        };
-        let op2 = UserOperation {
-            pre_verification_gas: 100_000.into(),
-            call_gas_limit: 100_000.into(),
-            verification_gas_limit: 200_000.into(),
-            max_fee_per_gas: Default::default(),
-            sender: Default::default(),
-            nonce: Default::default(),
-            init_code: Default::default(),
-            call_data: Default::default(),
-            max_priority_fee_per_gas: Default::default(),
-            paymaster_and_data: Default::default(),
-            signature: Default::default(),
-        };
+        let op1 = create_test_op_with_gas(100_000.into(), 100_000.into(), 1_000_000.into(), true); // has paymaster
+        let op2 = create_test_op_with_gas(100_000.into(), 100_000.into(), 200_000.into(), false);
         let ops = vec![op1.clone(), op2.clone()];
         let chain_id = 1;
         let gas_limit = bundle_gas_limit(ops.iter(), chain_id);


### PR DESCRIPTION
Contributes to #349

## Proposed Changes

Improve the bundle gas limit calculation. The bundle gas limit we now use is based off the following observation:
 
In the Entrypoint contract, the `innerHandleOp` call has [this check](https://github.com/eth-infinitism/account-abstraction/blob/da5d2d50853b8dca47bdca49337d26d1333a08a3/contracts/core/EntryPoint.sol#L264) that the bundle would need to pass for every single user op that it executes. 

Within a bundle, let $p_i$, $v_i$, and $c_i$ be the static pre-verification gas, verification gas limit, and call gas limit of user operation $i$. Also let $m_i$ be $1$ if user op $i$ uses a paymaster, and $0$ if not. Suppose we start with initial gas $g$. When processing user op $i$, at the point of the the `innerHandleOp` check we have yet to execute the call for user op $i$, and the check requires that at that point the remaining gas be greater than $c_i+v_i+5000$. If user op $i$ uses a paymaster, because of the `postOp` calls, we would also need the remaining gas to also be greater than $c_i+2v_i$, since the up to two `postOp` calls can each use up $v_i$ gas. 

We can express this condition as:

$$remaining\\_gas_i\geq c_i+v_i+5000+m_i \max(v_i-5000,0)$$

The worst case remaining gas at this check for user operation $i$, since we have already processed user ops $1$ through $i-1$ and both the pre-verification gas and up to the verification gas limit of user op $i$, is:
$$g-\sum_{j=1}^{i-1}\big(p_j+(1+2m_j)v_j+c_j\big)-p_i-v_i$$

In order to not run out of gas and pass all the checks, we would therefore need that for all $i$:
$$g\geq \sum_{j=1}^{i-1}\big(p_j+(1+2m_j)v_j+c_j\big)+p_i+2v_i+c_i+5000+m_i \max(v_i-5000,0)$$

so the smallest initial gas limit we can assign the bundle would be the max over all $i$ of the right hand side of the inequality.
