### PR TITLE
feat(builder): add two phase UO gas limit filtering

### DIFF
--- a/crates/sim/src/gas/gas.rs
+++ b/crates/sim/src/gas/gas.rs
@@ -99,12 +99,12 @@ pub fn user_operation_gas_limit(
     uo: &UserOperation,
     chain_id: u64,
     assume_single_op_bundle: bool,
-    paymaster_post_op: Option<bool>,
+    paymaster_post_op: bool,
 ) -> U256 {
     user_operation_pre_verification_gas_limit(uo, chain_id, assume_single_op_bundle)
         + uo.call_gas_limit
         + uo.verification_gas_limit
-            * verification_gas_limit_multiplier(uo, assume_single_op_bundle, paymaster_post_op)
+            * verification_gas_limit_multiplier(assume_single_op_bundle, paymaster_post_op)
 }
 
 /// Returns the static pre-verification gas cost of a user operation
@@ -157,14 +157,13 @@ fn calc_static_pre_verification_gas(op: &UserOperation, include_fixed_gas_overhe
 }
 
 fn verification_gas_limit_multiplier(
-    uo: &UserOperation,
     assume_single_op_bundle: bool,
-    paymaster_post_op: Option<bool>,
+    paymaster_post_op: bool,
 ) -> u64 {
     // If using a paymaster that has a postOp, we need to account for potentially 2 postOp calls which can each use up to verification_gas_limit gas.
     // otherwise the entrypoint expects the gas for 1 postOp call that uses verification_gas_limit plus the actual verification call
     // we only add the additional verification_gas_limit only if we know for sure that this is a single op bundle, which what we do to get a worst-case upper bound
-    if uo.paymaster().is_some() && paymaster_post_op.unwrap_or(true) {
+    if paymaster_post_op {
         3
     } else if assume_single_op_bundle {
         2

--- a/crates/sim/src/gas/polygon.rs
+++ b/crates/sim/src/gas/polygon.rs
@@ -66,12 +66,12 @@ where
 
     /// Estimates max and priority gas and converts to U256
     pub(crate) async fn estimate_priority_fee(&self) -> anyhow::Result<U256> {
-        let (provider_estiamte, fee_history_estimate) = try_join!(
+        let (provider_estimate, fee_history_estimate) = try_join!(
             self.provider.get_max_priority_fee().map_err(|e| e.into()),
             self.calculate_fees()
         )?;
 
-        Ok(cmp::max(provider_estiamte, fee_history_estimate))
+        Ok(cmp::max(provider_estimate, fee_history_estimate))
     }
 
     /// Perform a request to the gas price API and deserialize the response.

--- a/crates/sim/src/precheck.rs
+++ b/crates/sim/src/precheck.rs
@@ -180,7 +180,10 @@ impl<P: Provider, E: EntryPoint> PrecheckerImpl<P, E> {
                 max_verification_gas,
             ));
         }
-        let total_gas_limit = gas::user_operation_gas_limit(op, chain_id, true, None);
+
+        // compute the worst case total gas limit by assuming the UO is in its own bundle and has a postOp call.
+        // This is conservative and potentially may invalidate some very large UOs that would otherwise be valid.
+        let total_gas_limit = gas::user_operation_gas_limit(op, chain_id, true, true);
         if total_gas_limit > max_total_execution_gas {
             violations.push(PrecheckViolation::TotalGasLimitTooHigh(
                 total_gas_limit,
@@ -477,7 +480,7 @@ mod tests {
             res,
             ArrayVec::<PrecheckViolation, 6>::from([
                 PrecheckViolation::VerificationGasLimitTooHigh(10_000_000.into(), 5_000_000.into(),),
-                PrecheckViolation::TotalGasLimitTooHigh(20_009_000.into(), 10_000_000.into(),),
+                PrecheckViolation::TotalGasLimitTooHigh(30_009_000.into(), 10_000_000.into(),),
                 PrecheckViolation::PreVerificationGasTooLow(0.into(), 1_000.into(),),
                 PrecheckViolation::MaxFeePerGasTooLow(5_000.into(), 8_000.into(),),
                 PrecheckViolation::MaxPriorityFeePerGasTooLow(2_000.into(), 4_000.into(),),


### PR DESCRIPTION
#349

## Proposed Changes

Add a two phase bundle gas filtering process. In the first phase, we filter the UOs in the pool down to a subset that we want to simulate. This phase intentionally includes more UOs than necessary in order to account for any UOs that might be dropped later on. The second phase of filtering happens after simulation. At this point we are able to get a better gas limit estimate for each UO because we know for sure if the UO uses a `postOp` or not, and also drop UOs that fail validation. This filtering is when we ensure that all the UOs we have selected satisfy the maximum bundle gas limit.
