### PR TITLE
chore(docker): do not overide cache with COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash
 ENV PATH="/root/.foundry/bin:${PATH}"
 RUN foundryup
 
-RUN cargo install cargo-chef 
+RUN cargo install cargo-chef --locked
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && echo "d
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config protobuf-compiler nodejs yarn
+RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config protobuf-compiler nodejs yarn rsync
 
 SHELL ["/bin/bash", "-c"]
 RUN curl -L https://foundry.paradigm.xyz | bash
@@ -36,6 +36,11 @@ RUN cargo chef cook --profile $BUILD_PROFILE --recipe-path recipe.json
 
 # Build application
 COPY . .
+
+COPY --from=planner /app recipe-original
+RUN rsync --recursive --checksum --itemize-changes --verbose recipe-original/ .
+RUN rm -r recipe-original
+
 RUN cargo build --profile $BUILD_PROFILE --locked --bin rundler
 
 # Use Ubuntu as the release image

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,9 @@ ENV BUILD_PROFILE $BUILD_PROFILE
 # Builds dependencies
 RUN cargo chef cook --profile $BUILD_PROFILE --recipe-path recipe.json
 
-# Build application
-COPY . .
-
+# Undo the source file changes made by cargo-chef.
+# rsync invalidates the cargo cache for the changed files only, by updating their timestamps.
+# This makes sure the fake empty binaries created by cargo-chef are rebuilt.
 COPY --from=planner /app recipe-original
 RUN rsync --recursive --checksum --itemize-changes --verbose recipe-original/ .
 RUN rm -r recipe-original


### PR DESCRIPTION
I was looking into the cargo chef build speeds in CI and found a few interesting things that have been implemented and recommended by the chef project.

this was first proposed in https://github.com/LukeMathWalker/cargo-chef/issues/180 and eventually zcach found a workaround with rzync in the following PR https://github.com/ZcashFoundation/zebra/pull/6934
