### PR TITLE
[WIP] feat(network): initial gossip implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.10",
  "once_cell",
  "version_check",
 ]
@@ -507,9 +507,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "base64ct"
@@ -938,7 +938,7 @@ dependencies = [
  "bs58 0.4.0",
  "coins-core",
  "digest 0.10.7",
- "getrandom 0.2.8",
+ "getrandom 0.2.10",
  "hmac 0.12.1",
  "k256",
  "lazy_static",
@@ -955,7 +955,7 @@ checksum = "84f4d04ee18e58356accd644896aeb2094ddeafb6a713e056cef0c0a8e468c15"
 dependencies = [
  "bitvec 0.17.4",
  "coins-bip32",
- "getrandom 0.2.8",
+ "getrandom 0.2.10",
  "hmac 0.12.1",
  "once_cell",
  "pbkdf2 0.12.1",
@@ -970,7 +970,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b949a1c63fb7eb591eb7ba438746326aedf0ae843e51ec92ba6bec5bb382c4f"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.4",
  "bech32",
  "bs58 0.4.0",
  "digest 0.10.7",
@@ -1718,7 +1718,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe81b5c06ecfdbc71dd845216f225f53b62a10cb8a16c946836a3467f701d05b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.4",
  "bytes",
  "ed25519-dalek",
  "hex",
@@ -2092,7 +2092,7 @@ checksum = "b411b119f1cf0efb69e2190883dee731251882bb21270f893ee9513b3a697c48"
 dependencies = [
  "async-trait",
  "auto_impl",
- "base64 0.21.0",
+ "base64 0.21.4",
  "bytes",
  "enr 0.8.1",
  "ethers-core",
@@ -2396,6 +2396,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
+name = "futures-ticker"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9763058047f713632a52e916cc7f6a4b3fc6e9fc1ff8c5b1dc49e5a89041682e"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "instant",
+]
+
+[[package]]
 name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2651,6 +2662,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hkdf"
@@ -3343,12 +3360,13 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "getrandom 0.2.8",
+ "getrandom 0.2.10",
  "instant",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-dns",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-mdns",
@@ -3431,6 +3449,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-gossipsub"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d157562dba6017193e5285acf6b1054759e83540bfd79f75b69d6ce774c88da"
+dependencies = [
+ "asynchronous-codec",
+ "base64 0.21.4",
+ "byteorder",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-ticker",
+ "getrandom 0.2.10",
+ "hex_fmt",
+ "instant",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "log",
+ "prometheus-client",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand",
+ "regex",
+ "sha2 0.10.8",
+ "smallvec",
+ "unsigned-varint",
+ "void",
+]
+
+[[package]]
 name = "libp2p-identify"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3500,6 +3550,7 @@ checksum = "239ba7d28f8d0b5d77760dc6619c05c7e88e74ec8fbbe97f856f20a56745e620"
 dependencies = [
  "instant",
  "libp2p-core",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-ping",
@@ -3898,7 +3949,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.4",
  "hyper",
  "indexmap 1.9.3",
  "ipnet",
@@ -5082,7 +5133,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -5173,7 +5224,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.10",
  "redox_syscall 0.2.16",
  "thiserror",
 ]
@@ -5228,7 +5279,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -5462,11 +5513,13 @@ dependencies = [
  "ethereum_ssz_derive",
  "ethers",
  "futures",
+ "getrandom 0.2.10",
  "hex",
  "libp2p",
  "libp2p-mplex",
  "rand",
  "rundler-types",
+ "sha2 0.10.8",
  "snap",
  "ssz_types",
  "thiserror",
@@ -5854,7 +5907,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.4",
 ]
 
 [[package]]
@@ -6101,7 +6154,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.4",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -6876,7 +6929,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.0",
+ "base64 0.21.4",
  "bytes",
  "h2",
  "http",
@@ -7282,7 +7335,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.10",
  "serde",
 ]
 

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -12,12 +12,13 @@ rundler-types = { path = "../types" }
 ethereum_ssz = "0.5.3"
 ethereum_ssz_derive = "0.5.3"
 ethers.workspace = true
-snap = "1.1.0"
-ssz_types = "0.5.4"
 discv5 = { version = "0.3.1", features = ["libp2p"] }
 futures.workspace = true
 hex = "0.4.3"
 libp2p-mplex = "0.40.0"
+sha2 = "0.10.8"
+snap = "1.1.0"
+ssz_types = "0.5.4"
 tokio.workspace = true
 tokio-io-timeout = "1.2.0"
 tokio-util = { workspace = true, features = ["codec", "compat"] }
@@ -25,10 +26,13 @@ thiserror.workspace = true
 tracing.workspace = true
 unsigned-varint = { version = "0.7.2", features = ["codec"] }
 
+# required version by gossipsub
+getrandom = "0.2.10"
+
 [dependencies.libp2p]
 version = "0.52.3"
 default-features = false
-features = ["tokio", "noise", "macros", "tcp", "identify", "yamux", "secp256k1"]
+features = ["tokio", "noise", "macros", "tcp", "identify", "yamux", "secp256k1", "gossipsub"]
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/network/src/gossip/message.rs
+++ b/crates/network/src/gossip/message.rs
@@ -1,0 +1,130 @@
+// This file is part of Rundler.
+//
+// Rundler is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Rundler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Rundler.
+// If not, see https://www.gnu.org/licenses/.
+
+use ethers::types::{Address, H256, U256};
+use libp2p::gossipsub;
+use rundler_types::UserOperation;
+use sha2::{Digest, Sha256};
+use ssz::{Decode, Encode};
+use ssz_derive::{Decode, Encode};
+
+use super::topic::{Topic, TopicKind};
+use crate::types::{Encoding, UserOperationSsz};
+
+const MESSAGE_DOMAIN_VALID_SNAPPY: [u8; 4] = [1, 0, 0, 0];
+//const MESSAGE_DOMAIN_INVALID_SNAPPY: [u8; 4] = [0, 0, 0, 0];
+
+/// Gossipsub messages
+#[derive(Clone, Debug)]
+pub enum Message {
+    /// User operations with entrypoint gossip message
+    UserOperationsWithEntryPoint(UserOperationsWithEntryPoint),
+}
+
+impl Message {
+    pub(crate) fn encode(self) -> Vec<u8> {
+        match self {
+            Message::UserOperationsWithEntryPoint(m) => {
+                UserOperationsWithEntryPointSsz::from(m).as_ssz_bytes()
+            }
+        }
+    }
+
+    // TODO error handling
+    pub(crate) fn decode(topic: &Topic, data: Vec<u8>) -> Result<Self, &'static str> {
+        if topic.encoding() != Encoding::SSZSnappy {
+            return Err("invalid encoding");
+        }
+
+        match topic.kind() {
+            TopicKind::UserOperationsWithEntryPoint => {
+                let uo_ssz = UserOperationsWithEntryPointSsz::from_ssz_bytes(&data).unwrap();
+                let uo = UserOperationsWithEntryPoint::try_from(uo_ssz).unwrap();
+                Ok(Self::UserOperationsWithEntryPoint(uo))
+            }
+        }
+    }
+
+    pub(crate) fn topic(&self, mempool_id: H256) -> Topic {
+        match self {
+            Message::UserOperationsWithEntryPoint(_) => Topic::new(
+                mempool_id,
+                TopicKind::UserOperationsWithEntryPoint,
+                Encoding::SSZSnappy,
+            ),
+        }
+    }
+}
+
+/// User operations with entrypoint gossip message
+#[derive(Clone, Debug)]
+pub struct UserOperationsWithEntryPoint {
+    /// The entry point contract this message targets
+    pub entry_point_contract: Address,
+    /// The block hash at which these user operations were verified
+    pub verified_at_block_hash: H256,
+    /// The chain ID of the chain these user operations are for
+    pub chain_id: U256,
+    /// The user operations
+    pub user_operations: Vec<UserOperation>,
+}
+
+pub(crate) fn message_id(message: &gossipsub::Message) -> gossipsub::MessageId {
+    // NOTE: this message has already gone through the DataTransform layer,
+    // so its data is already decompressed, and is valid.
+    // this means that MESSAGE_DOMAIN_INVALID_SNAPPY is never used.
+    // TODO: check on this.
+
+    // TODO: these message IDs are not scoped to topics. This may be a problem.
+
+    let mut vec = Vec::with_capacity(MESSAGE_DOMAIN_VALID_SNAPPY.len() + message.data.len());
+    vec.extend_from_slice(&MESSAGE_DOMAIN_VALID_SNAPPY);
+    vec.extend_from_slice(&message.data);
+    Sha256::digest(&vec)[..20].into()
+}
+
+#[derive(Clone, Debug, Encode, Decode)]
+struct UserOperationsWithEntryPointSsz {
+    entry_point_contract: Address,
+    verified_at_block_hash: H256,
+    chain_id: U256,
+    user_operations: Vec<UserOperationSsz>,
+}
+
+impl From<UserOperationsWithEntryPoint> for UserOperationsWithEntryPointSsz {
+    fn from(uo: UserOperationsWithEntryPoint) -> Self {
+        Self {
+            entry_point_contract: uo.entry_point_contract,
+            verified_at_block_hash: uo.verified_at_block_hash,
+            chain_id: uo.chain_id,
+            user_operations: uo.user_operations.into_iter().map(|uo| uo.into()).collect(),
+        }
+    }
+}
+
+impl TryFrom<UserOperationsWithEntryPointSsz> for UserOperationsWithEntryPoint {
+    type Error = &'static str;
+
+    fn try_from(uo_ssz: UserOperationsWithEntryPointSsz) -> Result<Self, Self::Error> {
+        Ok(Self {
+            entry_point_contract: uo_ssz.entry_point_contract,
+            verified_at_block_hash: uo_ssz.verified_at_block_hash,
+            chain_id: uo_ssz.chain_id,
+            user_operations: uo_ssz
+                .user_operations
+                .into_iter()
+                .map(|uo| uo.try_into())
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+}

--- a/crates/network/src/gossip/snappy.rs
+++ b/crates/network/src/gossip/snappy.rs
@@ -1,0 +1,62 @@
+// This file is part of Rundler.
+//
+// Rundler is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Rundler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Rundler.
+// If not, see https://www.gnu.org/licenses/.
+
+// adapted from https://github.com/sigp/lighthouse/blob/stable/beacon_node/lighthouse_network/src/types/pubsub.rs
+
+use std::io;
+
+use libp2p::gossipsub::{DataTransform, Message, RawMessage, TopicHash};
+use snap::raw::{Decoder, Encoder};
+
+pub(crate) struct SnappyTransform {
+    gossip_max_size: usize,
+}
+
+impl SnappyTransform {
+    pub(crate) fn new(gossip_max_size: usize) -> Self {
+        Self { gossip_max_size }
+    }
+}
+
+impl DataTransform for SnappyTransform {
+    fn inbound_transform(&self, raw_message: RawMessage) -> Result<Message, io::Error> {
+        let len = snap::raw::decompress_len(&raw_message.data)?;
+        if len > self.gossip_max_size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "ssz_snappy decoded data > GOSSIP_MAX_SIZE",
+            ));
+        }
+
+        let mut decoder = Decoder::new();
+        let decompressed_data = decoder.decompress_vec(&raw_message.data)?;
+
+        Ok(Message {
+            source: raw_message.source,
+            data: decompressed_data,
+            sequence_number: raw_message.sequence_number,
+            topic: raw_message.topic,
+        })
+    }
+
+    fn outbound_transform(&self, _topic: &TopicHash, data: Vec<u8>) -> Result<Vec<u8>, io::Error> {
+        if data.len() > self.gossip_max_size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "ssz_snappy Encoded data > GOSSIP_MAX_SIZE",
+            ));
+        }
+        let mut encoder = Encoder::new();
+        encoder.compress_vec(&data).map_err(Into::into)
+    }
+}

--- a/crates/network/src/gossip/topic.rs
+++ b/crates/network/src/gossip/topic.rs
@@ -1,0 +1,131 @@
+// This file is part of Rundler.
+//
+// Rundler is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Rundler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Rundler.
+// If not, see https://www.gnu.org/licenses/.
+
+use ethers::types::H256;
+use libp2p::gossipsub::{self, TopicHash};
+
+use crate::types::Encoding;
+
+const TOPIC_PREFIX: &str = "account_abstraction";
+
+pub(crate) fn mempool_to_topics(mempool_id: H256) -> Vec<Topic> {
+    vec![Topic::new(
+        mempool_id,
+        TopicKind::UserOperationsWithEntryPoint,
+        Encoding::SSZSnappy,
+    )]
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum TopicKind {
+    UserOperationsWithEntryPoint,
+}
+
+impl AsRef<str> for TopicKind {
+    fn as_ref(&self) -> &str {
+        match self {
+            TopicKind::UserOperationsWithEntryPoint => "user_operations_with_entry_point",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct Topic {
+    mempool_id: H256,
+    kind: TopicKind,
+    encoding: Encoding,
+    id: String,
+}
+
+impl Topic {
+    pub(crate) fn new(mempool_id: H256, kind: TopicKind, encoding: Encoding) -> Self {
+        let id = format!(
+            "/{}/{:?}/{}/{}",
+            TOPIC_PREFIX,
+            mempool_id,
+            kind.as_ref(),
+            encoding.as_ref()
+        );
+        Self {
+            mempool_id,
+            kind,
+            encoding,
+            id,
+        }
+    }
+
+    pub(crate) fn mempool_id(&self) -> H256 {
+        self.mempool_id
+    }
+
+    pub(crate) fn kind(&self) -> &TopicKind {
+        &self.kind
+    }
+
+    pub(crate) fn encoding(&self) -> Encoding {
+        self.encoding
+    }
+}
+
+impl AsRef<str> for Topic {
+    fn as_ref(&self) -> &str {
+        self.id.as_ref()
+    }
+}
+
+impl From<Topic> for TopicHash {
+    fn from(topic: Topic) -> Self {
+        TopicHash::from_raw(topic.as_ref())
+    }
+}
+
+impl From<Topic> for gossipsub::IdentTopic {
+    fn from(topic: Topic) -> Self {
+        gossipsub::IdentTopic::new(topic.as_ref())
+    }
+}
+
+impl TryFrom<TopicHash> for Topic {
+    type Error = &'static str;
+
+    fn try_from(topic: TopicHash) -> Result<Self, Self::Error> {
+        let mut parts = topic.as_str().split('/');
+        let _ = parts.next();
+
+        if parts.next() != Some(TOPIC_PREFIX) {
+            return Err("invalid topic: invalid prefix");
+        }
+
+        let mempool_id = parts
+            .next()
+            .ok_or("invalid topic: missing mempool id")?
+            .parse::<H256>()
+            .map_err(|_| "invalid topic: invalid mempool id")?;
+
+        let kind = match parts.next() {
+            Some("user_operations_with_entry_point") => TopicKind::UserOperationsWithEntryPoint,
+            _ => return Err("invalid topic: invalid kind"),
+        };
+
+        let encoding = match parts.next() {
+            Some("ssz_snappy") => Encoding::SSZSnappy,
+            _ => return Err("invalid topic: invalid encoding"),
+        };
+
+        if parts.next().is_some() {
+            return Err("invalid topic: too many parts");
+        }
+
+        Ok(Self::new(mempool_id, kind, encoding))
+    }
+}

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -36,6 +36,9 @@ pub use network::{
 mod error;
 pub use error::{Error, Result};
 
+mod gossip;
+pub use gossip::message::{Message as GossipMessage, UserOperationsWithEntryPoint};
+
 mod rpc;
 pub use rpc::{
     message::{
@@ -44,3 +47,5 @@ pub use rpc::{
     },
     ConnectionConfig,
 };
+
+mod types;

--- a/crates/network/src/rpc/handler/codec.rs
+++ b/crates/network/src/rpc/handler/codec.rs
@@ -218,13 +218,15 @@ mod test {
     use rundler_types::UserOperation;
 
     use super::*;
-    use crate::rpc::{
-        handler::serde::{CodedError, PooledUserOpsByHashChunkSsz, SszChunk, UserOperationSsz},
-        message::{
-            ErrorKind, Goodbye, GoodbyeReason, Metadata, Ping, Pong, PooledUserOpHashesRequest,
-            PooledUserOpHashesResponse, PooledUserOpsByHashRequest, ResponseError, Status,
+    use crate::{
+        rpc::{
+            handler::serde::{CodedError, PooledUserOpsByHashChunkSsz, SszChunk},
+            message::{
+                ErrorKind, Goodbye, GoodbyeReason, Metadata, Ping, Pong, PooledUserOpHashesRequest,
+                PooledUserOpHashesResponse, PooledUserOpsByHashRequest, ResponseError, Status,
+            },
         },
-        protocol::Encoding,
+        types::{Encoding, UserOperationSsz},
     };
 
     const MAX_CHUNK_SIZE: usize = 1048576;

--- a/crates/network/src/rpc/handler/inbound.rs
+++ b/crates/network/src/rpc/handler/inbound.rs
@@ -23,8 +23,9 @@ use crate::{
     network::PeerRequestId,
     rpc::{
         message::{Request, ResponseResult},
-        protocol::{self, Encoding, Protocol, ProtocolError},
+        protocol::{self, Protocol, ProtocolError},
     },
+    types::Encoding,
 };
 
 #[derive(Debug)]

--- a/crates/network/src/rpc/handler/outbound.rs
+++ b/crates/network/src/rpc/handler/outbound.rs
@@ -17,9 +17,12 @@ use tokio_io_timeout::TimeoutStream;
 use tokio_util::{codec::Framed, compat::FuturesAsyncReadCompatExt};
 
 use super::{codec, serde, ConnectionConfig};
-use crate::rpc::{
-    message::{Request, ResponseResult},
-    protocol::{self, Encoding, Protocol, ProtocolError, ProtocolSchema},
+use crate::{
+    rpc::{
+        message::{Request, ResponseResult},
+        protocol::{self, Protocol, ProtocolError, ProtocolSchema},
+    },
+    types::Encoding,
 };
 
 #[derive(Debug)]

--- a/crates/network/src/rpc/handler/serde.rs
+++ b/crates/network/src/rpc/handler/serde.rs
@@ -11,21 +11,22 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use ethers::types::{Address, U256};
-use rundler_types::UserOperation;
 use ssz::{Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
 use tracing::warn;
 
-use crate::rpc::{
-    handler::CodecError,
-    message::{
-        ErrorKind, Goodbye, Metadata, Ping, Pong, PooledUserOpHashesRequest,
-        PooledUserOpHashesResponse, PooledUserOpsByHashRequest, PooledUserOpsByHashResponse,
-        Request, Response, ResponseError, ResponseResult, Status, MAX_ERROR_MESSAGE_LEN,
-        MAX_OPS_PER_REQUEST,
+use crate::{
+    rpc::{
+        handler::CodecError,
+        message::{
+            ErrorKind, Goodbye, Metadata, Ping, Pong, PooledUserOpHashesRequest,
+            PooledUserOpHashesResponse, PooledUserOpsByHashRequest, PooledUserOpsByHashResponse,
+            Request, Response, ResponseError, ResponseResult, Status, MAX_ERROR_MESSAGE_LEN,
+            MAX_OPS_PER_REQUEST,
+        },
+        protocol::ProtocolSchema,
     },
-    protocol::ProtocolSchema,
+    types::UserOperationSsz,
 };
 
 // TODO: determine what this actually should be
@@ -301,63 +302,6 @@ pub(crate) struct PooledUserOpsByHashChunkSsz {
     pub(crate) user_op: UserOperationSsz,
 }
 
-#[derive(Debug, Clone, PartialEq, Encode, Decode)]
-pub(crate) struct UserOperationSsz {
-    sender: Vec<u8>,
-    nonce: U256,
-    init_code: Vec<u8>,
-    call_data: Vec<u8>,
-    call_gas_limit: U256,
-    verification_gas_limit: U256,
-    pre_verification_gas: U256,
-    max_fee_per_gas: U256,
-    max_priority_fee_per_gas: U256,
-    paymaster_and_data: Vec<u8>,
-    signature: Vec<u8>,
-}
-
-impl From<UserOperation> for UserOperationSsz {
-    fn from(uo: UserOperation) -> Self {
-        Self {
-            sender: uo.sender.as_bytes().to_vec(),
-            nonce: uo.nonce,
-            init_code: uo.init_code.to_vec(),
-            call_data: uo.call_data.to_vec(),
-            call_gas_limit: uo.call_gas_limit,
-            verification_gas_limit: uo.verification_gas_limit,
-            pre_verification_gas: uo.pre_verification_gas,
-            max_fee_per_gas: uo.max_fee_per_gas,
-            max_priority_fee_per_gas: uo.max_priority_fee_per_gas,
-            paymaster_and_data: uo.paymaster_and_data.to_vec(),
-            signature: uo.signature.to_vec(),
-        }
-    }
-}
-
-impl TryFrom<UserOperationSsz> for UserOperation {
-    type Error = CodecError;
-
-    fn try_from(uo_ssz: UserOperationSsz) -> Result<Self, Self::Error> {
-        if uo_ssz.sender.len() != 20 {
-            return Err(CodecError::InvalidData("invalid sender bytes".into()));
-        }
-
-        Ok(Self {
-            sender: Address::from_slice(&uo_ssz.sender),
-            nonce: uo_ssz.nonce,
-            init_code: uo_ssz.init_code.into(),
-            call_data: uo_ssz.call_data.into(),
-            call_gas_limit: uo_ssz.call_gas_limit,
-            verification_gas_limit: uo_ssz.verification_gas_limit,
-            pre_verification_gas: uo_ssz.pre_verification_gas,
-            max_fee_per_gas: uo_ssz.max_fee_per_gas,
-            max_priority_fee_per_gas: uo_ssz.max_priority_fee_per_gas,
-            paymaster_and_data: uo_ssz.paymaster_and_data.into(),
-            signature: uo_ssz.signature.into(),
-        })
-    }
-}
-
 impl ProtocolSchema {
     pub(crate) fn ssz_request_limits(&self) -> (usize, usize) {
         match self {
@@ -414,6 +358,7 @@ impl From<DecodeError> for CodecError {
 #[cfg(test)]
 mod test {
     use ethers::types::H256;
+    use rundler_types::UserOperation;
 
     use super::*;
 

--- a/crates/network/src/rpc/protocol.rs
+++ b/crates/network/src/rpc/protocol.rs
@@ -12,7 +12,7 @@
 // If not, see https://www.gnu.org/licenses/.
 
 use super::handler::CodecError;
-use crate::rpc::message::Request;
+use crate::{rpc::message::Request, types::Encoding};
 
 const PROTOCOL_PREFIX: &str = "/account_abstraction/req";
 
@@ -51,14 +51,6 @@ impl Protocol {
             id,
         }
     }
-}
-
-/// The encoding of a protocol.
-///
-/// Currently only SSZSnappy is supported.
-#[derive(Clone, Debug)]
-pub(crate) enum Encoding {
-    SSZSnappy,
 }
 
 impl AsRef<str> for Encoding {

--- a/crates/network/src/types.rs
+++ b/crates/network/src/types.rs
@@ -1,0 +1,81 @@
+// This file is part of Rundler.
+//
+// Rundler is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Rundler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Rundler.
+// If not, see https://www.gnu.org/licenses/.
+
+use ethers::types::{Address, U256};
+use rundler_types::UserOperation;
+use ssz_derive::{Decode, Encode};
+
+#[derive(Debug, Clone, PartialEq, Encode, Decode)]
+pub(crate) struct UserOperationSsz {
+    sender: Vec<u8>,
+    nonce: U256,
+    init_code: Vec<u8>,
+    call_data: Vec<u8>,
+    call_gas_limit: U256,
+    verification_gas_limit: U256,
+    pre_verification_gas: U256,
+    max_fee_per_gas: U256,
+    max_priority_fee_per_gas: U256,
+    paymaster_and_data: Vec<u8>,
+    signature: Vec<u8>,
+}
+
+impl From<UserOperation> for UserOperationSsz {
+    fn from(uo: UserOperation) -> Self {
+        Self {
+            sender: uo.sender.as_bytes().to_vec(),
+            nonce: uo.nonce,
+            init_code: uo.init_code.to_vec(),
+            call_data: uo.call_data.to_vec(),
+            call_gas_limit: uo.call_gas_limit,
+            verification_gas_limit: uo.verification_gas_limit,
+            pre_verification_gas: uo.pre_verification_gas,
+            max_fee_per_gas: uo.max_fee_per_gas,
+            max_priority_fee_per_gas: uo.max_priority_fee_per_gas,
+            paymaster_and_data: uo.paymaster_and_data.to_vec(),
+            signature: uo.signature.to_vec(),
+        }
+    }
+}
+
+impl TryFrom<UserOperationSsz> for UserOperation {
+    type Error = &'static str;
+
+    fn try_from(uo_ssz: UserOperationSsz) -> Result<Self, Self::Error> {
+        if uo_ssz.sender.len() != 20 {
+            return Err("invalid sender bytes");
+        }
+
+        Ok(Self {
+            sender: Address::from_slice(&uo_ssz.sender),
+            nonce: uo_ssz.nonce,
+            init_code: uo_ssz.init_code.into(),
+            call_data: uo_ssz.call_data.into(),
+            call_gas_limit: uo_ssz.call_gas_limit,
+            verification_gas_limit: uo_ssz.verification_gas_limit,
+            pre_verification_gas: uo_ssz.pre_verification_gas,
+            max_fee_per_gas: uo_ssz.max_fee_per_gas,
+            max_priority_fee_per_gas: uo_ssz.max_priority_fee_per_gas,
+            paymaster_and_data: uo_ssz.paymaster_and_data.into(),
+            signature: uo_ssz.signature.into(),
+        })
+    }
+}
+
+/// The encoding of a protocol.
+///
+/// Currently only SSZSnappy is supported.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum Encoding {
+    SSZSnappy,
+}


### PR DESCRIPTION
#248 

## Proposed Changes

  - Add an MVP for the p2p gossip protocol. Mostly to learn about issues with the protocol specification.
  - Lots of TODOs in the code that need to be addressed.

3 big spec issues currently:

1. The discovery definition doesn't explain how to find other peers that support a particular mempool. The mempool id should somehow be added to the ENR. This can either happen by somehow mapping mempool id to mempool subnet, or by adding the mempool id list directly to the ENR.
2. The definition for `message_id` doesn't allow the message to be sent across multiple topics. It currently gets deduplicated before being forwarded on the 2nd topic. There are 2 solutions here both with downsides.
a. Include the topic in the `message_id`. This is how the latest consensus spec defines them. The downside is that the messages will get sent/received across all topics.
b. Somehow get the libp2p spec changed to allow the same message_id to be propagated across multiple topics. 

Relevant section: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md#message-cache

3. [user_ops_with_entry_point](https://github.com/eth-infinitism/bundler-spec/blob/main/p2p-specs/p2p-interface.md#-useroperationswithentrypoint-) is a completely invalid message type for the gossip protocol. It should be a single user operation. Else each gossiped message that has a different list will have different message IDs, each peer will then have to get each list and deduplicate the contents. Massive waste.

Going to write these things up and propose changes to the p2p spec.
