### PR TITLE
feat(log): capture logs from the log crate to tracing subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3961,6 +3961,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-appender",
+ "tracing-log",
  "tracing-subscriber",
 ]
 

--- a/bin/rundler/Cargo.toml
+++ b/bin/rundler/Cargo.toml
@@ -39,4 +39,5 @@ tokio-rustls = "0.24.1"
 tokio-util = "0.7.8"
 tracing.workspace = true
 tracing-appender = "0.2.2"
+tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "fmt", "json"] }

--- a/bin/rundler/src/cli/tracing.rs
+++ b/bin/rundler/src/cli/tracing.rs
@@ -16,6 +16,7 @@ use std::io;
 pub use tracing::*;
 use tracing::{subscriber, subscriber::Interest, Metadata, Subscriber};
 use tracing_appender::non_blocking::WorkerGuard;
+use tracing_log::LogTracer;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, FmtSubscriber, Layer};
 
 use super::LogsArgs;
@@ -45,6 +46,9 @@ pub fn configure_logging(config: &LogsArgs) -> anyhow::Result<WorkerGuard> {
                 .with(TargetBlacklistLayer),
         )?;
     }
+
+    // Redirect logs from external crates using `log` to the tracing subscriber
+    LogTracer::init()?;
 
     Ok(guard)
 }


### PR DESCRIPTION
## Proposed Changes

  - Some dependencies we rely on use the `log` create, we should capture those logs to our tracing subscriber

