### PR TITLE
feat(kms): do not require distributed locking when only using one kms key

### DIFF
--- a/crates/builder/src/signer/aws.rs
+++ b/crates/builder/src/signer/aws.rs
@@ -55,9 +55,15 @@ impl KmsSigner {
                 .await
                 .context("should create signer")?
         } else {
-            AwsSigner::new(client, key_ids.first().unwrap(), chain_id)
-                .await
-                .context("should create signer")?
+            AwsSigner::new(
+                client,
+                key_ids
+                    .first()
+                    .expect("There should be at least one kms key"),
+                chain_id,
+            )
+            .await
+            .context("should create signer")?
         };
 
         let monitor_guard = SpawnGuard::spawn_with_guard(monitor_account_balance(


### PR DESCRIPTION
Closes #361

## Proposed Changes 

- Change create conditional signer based on length of kms keys so that the kms_guard can be turned into an optional field and not created with only one key id
