### PR TITLE
feat(mempool): check for same nonce and sender 

### DIFF
--- a/crates/pool/src/chain.rs
+++ b/crates/pool/src/chain.rs
@@ -26,7 +26,7 @@ use ethers::{
 use futures::future;
 use rundler_provider::Provider;
 use rundler_task::block_watcher;
-use rundler_types::contracts::i_entry_point::UserOperationEventFilter;
+use rundler_types::{contracts::i_entry_point::UserOperationEventFilter, UserOperationId};
 use tokio::{
     select,
     sync::{broadcast, Semaphore},
@@ -71,6 +71,15 @@ pub struct MinedOp {
     pub entry_point: Address,
     pub sender: Address,
     pub nonce: U256,
+}
+
+impl MinedOp {
+    pub fn id(&self) -> UserOperationId {
+        UserOperationId {
+            sender: self.sender,
+            nonce: self.nonce,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/pool/src/mempool/uo_pool.rs
+++ b/crates/pool/src/mempool/uo_pool.rs
@@ -119,10 +119,8 @@ where
 
             // Remove throttled ops that were included in the block
             state.throttled_ops.remove(&op.hash);
-            if let Some(op) = state
-                .pool
-                .mine_operation(op.hash, update.latest_block_number)
-            {
+
+            if let Some(op) = state.pool.mine_operation(op, update.latest_block_number) {
                 // Only account for a staked entity once
                 for entity_addr in op.staked_entities().map(|e| e.address).unique() {
                     self.reputation.add_included(entity_addr);

--- a/crates/types/src/user_operation.rs
+++ b/crates/types/src/user_operation.rs
@@ -29,8 +29,10 @@ const PACKED_USER_OPERATION_FIXED_LEN: usize = 480;
 /// Unique identifier for a user operation from a given sender
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct UserOperationId {
-    sender: Address,
-    nonce: U256,
+    /// sender of user operation
+    pub sender: Address,
+    /// nonce of user operation
+    pub nonce: U256,
 }
 
 impl UserOperation {


### PR DESCRIPTION
Closes #278 

## Proposed Changes

  - Use the useroperation id to get the hash instead so we can make sure we are removing the correct item from the hashmap


