### PR TITLE
feat: add config for fee accept percentage

### DIFF
--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -208,6 +208,14 @@ pub struct CommonArgs {
     )]
     priority_fee_mode_value: u64,
 
+    #[arg(
+        long = "fee_accept_percent",
+        name = "fee_accept_percent",
+        env = "FEE_ACCEPT_PERCENT",
+        default_value = "100"
+    )]
+    fee_accept_percent: u64,
+
     /// Interval at which the builder polls an Eth node for new blocks and
     /// mined transactions.
     #[arg(
@@ -288,6 +296,7 @@ impl TryFrom<&CommonArgs> for PrecheckSettings {
                 value.priority_fee_mode_kind.as_str(),
                 value.priority_fee_mode_value,
             )?,
+            fee_accept_percent: value.fee_accept_percent,
         })
     }
 }

--- a/crates/types/src/chain.rs
+++ b/crates/types/src/chain.rs
@@ -44,3 +44,8 @@ pub const BASE_CHAIN_IDS: &[u64] = &[
 
 /// Known chain IDs for the Polygon ecosystem
 pub const POLYGON_CHAIN_IDS: &[u64] = &[Chain::Polygon as u64, Chain::PolygonMumbai as u64];
+
+/// Return true if the chain ID has a dynamic preVerificationGas field
+pub fn is_dynamic_pvg(chain_id: u64) -> bool {
+    ARBITRUM_CHAIN_IDS.contains(&chain_id) || OP_BEDROCK_CHAIN_IDS.contains(&chain_id)
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,6 +43,8 @@ These options are common to all subcommands and can be used globally:
   - env: *PRIORITY_FEE_MODE_KIND*
 - `--priority_fee_mode_value`: Priority fee mode value. (default: `0`).
   - env: *PRIORITY_FEE_MODE_VALUE*
+- `--fee_accept_percent`: Percentage of the current network fees a user operation must have in order to be accepted into the mempool. (default: `100`).
+  - env: *FEE_ACCEPT_PERCENT*
 - `--aws_region`: AWS region. (default: `us-east-1`).
   - env: *AWS_REGION*
   - (*Only required if using other AWS features*)


### PR DESCRIPTION
Closes #405 

## Proposed Changes

  - Add and use a `fee_accept_percent` configuration to the prechecker that allows user operations into the mempool that bid a minimum of X% of the current bundle fees.
