### PR TITLE
feat(rpc): add state overrides to estimate gas, fix error msg

### DIFF
--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -177,6 +177,15 @@ pub struct CommonArgs {
     max_simulate_handle_ops_gas: u64,
 
     #[arg(
+        long = "validation_estimation_gas_fee",
+        name = "validation_estimation_gas_fee",
+        env = "VALIDATION_ESTIMATION_GAS_FEE",
+        default_value = "1000000000000", // 10K gwei
+        global = true
+    )]
+    validation_estimation_gas_fee: u64,
+
+    #[arg(
         long = "bundle_priority_fee_overhead_percent",
         name = "bundle_priority_fee_overhead_percent",
         env = "BUNDLE_PRIORITY_FEE_OVERHEAD_PERCENT",
@@ -279,6 +288,7 @@ impl TryFrom<&CommonArgs> for EstimationSettings {
             max_verification_gas: value.max_verification_gas,
             max_call_gas,
             max_simulate_handle_ops_gas: value.max_simulate_handle_ops_gas,
+            validation_estimation_gas_fee: value.validation_estimation_gas_fee,
         })
     }
 }

--- a/crates/provider/src/traits/provider.rs
+++ b/crates/provider/src/traits/provider.rs
@@ -16,7 +16,7 @@
 use std::{fmt::Debug, sync::Arc};
 
 use ethers::types::{
-    transaction::eip2718::TypedTransaction, Address, Block, BlockId, BlockNumber, Bytes,
+    spoof, transaction::eip2718::TypedTransaction, Address, Block, BlockId, BlockNumber, Bytes,
     FeeHistory, Filter, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, Log,
     Transaction, TransactionReceipt, TxHash, H256, U256, U64,
 };
@@ -69,7 +69,12 @@ pub trait Provider: Send + Sync + Debug + 'static {
     ) -> Result<FeeHistory, ProviderError>;
 
     /// Simulate a transaction via an eth_call
-    async fn call(&self, tx: &TypedTransaction, block: Option<BlockId>) -> ProviderResult<Bytes>;
+    async fn call(
+        &self,
+        tx: &TypedTransaction,
+        block: Option<BlockId>,
+        state_overrides: &spoof::State,
+    ) -> ProviderResult<Bytes>;
 
     /// Get the current block number
     async fn get_block_number(&self) -> ProviderResult<u64>;

--- a/crates/rpc/src/eth/mod.rs
+++ b/crates/rpc/src/eth/mod.rs
@@ -18,7 +18,7 @@ pub use api::Settings as EthApiSettings;
 mod error;
 mod server;
 
-use ethers::types::{Address, H256, U64};
+use ethers::types::{spoof, Address, H256, U64};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use rundler_sim::{GasEstimate, UserOperationOptionalGas};
 
@@ -42,6 +42,7 @@ pub trait EthApi {
         &self,
         op: UserOperationOptionalGas,
         entry_point: Address,
+        state_override: Option<spoof::State>,
     ) -> RpcResult<GasEstimate>;
 
     /// Returns the user operation with the given hash.

--- a/crates/rpc/src/eth/server.rs
+++ b/crates/rpc/src/eth/server.rs
@@ -12,7 +12,7 @@
 // If not, see https://www.gnu.org/licenses/.
 
 use async_trait::async_trait;
-use ethers::types::{Address, H256, U64};
+use ethers::types::{spoof, Address, H256, U64};
 use jsonrpsee::core::RpcResult;
 use rundler_pool::PoolServer;
 use rundler_provider::{EntryPoint, Provider};
@@ -40,8 +40,9 @@ where
         &self,
         op: UserOperationOptionalGas,
         entry_point: Address,
+        state_override: Option<spoof::State>,
     ) -> RpcResult<GasEstimate> {
-        Ok(EthApi::estimate_user_operation_gas(self, op, entry_point).await?)
+        Ok(EthApi::estimate_user_operation_gas(self, op, entry_point, state_override).await?)
     }
 
     async fn get_user_operation_by_hash(&self, hash: H256) -> RpcResult<Option<RichUserOperation>> {

--- a/crates/sim/src/estimation/types.rs
+++ b/crates/sim/src/estimation/types.rs
@@ -27,6 +27,12 @@ pub struct Settings {
     pub max_call_gas: u64,
     /// The maximum amount of gas that can be used in a call to `simulateHandleOps`
     pub max_simulate_handle_ops_gas: u64,
+    /// The gas fee to use during validation gas estimation, required to be held by the fee-payer
+    /// during estimation. If using a paymaster, the fee-payer must have 3x this value.
+    /// As the gas limit is varied during estimation, the fee is held constant by varied the
+    /// gas price.
+    /// Clients can use state overrides to set the balance of the fee-payer to at least this value.
+    pub validation_estimation_gas_fee: u64,
 }
 
 impl Settings {

--- a/crates/sim/src/simulation/simulation.rs
+++ b/crates/sim/src/simulation/simulation.rs
@@ -1119,7 +1119,7 @@ mod tests {
             .returning(move |_, _, _| Ok(get_test_tracer_output()));
 
         // The underlying eth_call when getting the code hash in check_contracts
-        provider.expect_call().returning(|_, _| {
+        provider.expect_call().returning(|_, _, _| {
             let json_rpc_error = JsonRpcError {
                 code: -32000,
                 message: "execution reverted".to_string(),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,6 +34,9 @@ These options are common to all subcommands and can be used globally:
   - env: *USER_OPERATION_EVENT_BLOCK_DISTANCE*
 - `--max_simulate_handle_ops_gas`: Maximum gas for simulating handle operations. (default: `20000000`).
   - env: *MAX_SIMULATE_HANDLE_OPS_GAS*
+- `--validation_estimation_gas_fee`: The gas fee to use during validation estimation. (default: `1000000000000` 10K gwei).
+  - env: *VALIDATION_ESTIMATION_GAS_FEE*
+  - See [RPC documentation](./architecture/rpc.md#verificationGasLimit-estimation) for details.
 - `--bundle_priority_fee_overhead_percent`: bundle transaction priority fee overhead over network value. (default: `0`).
   - env: *BUNDLE_PRIORITY_FEE_OVERHEAD_PERCENT*
 - `--priority_fee_mode_kind`: Priority fee mode kind. Possible values are `base_fee_percent` and `priority_fee_increase_percent`. (default: `priority_fee_increase_percent`).


### PR DESCRIPTION
Closes #525
Closes #530

## Proposed Changes

  - Add state overrides to `eth_estimateUserOperationGas`
  - Move revert bytes to `revert_bytes` in the data field of the `eth_estimateUserOperationGas` error response
 
## TODO

- [x] Test state overrides using a USDC paymaster
- [x] Test revert bytes using a contract that returns a non-string error
