### PR TITLE
feat(pool): remove expired UOs from pool each block

### DIFF
--- a/crates/pool/src/emit.rs
+++ b/crates/pool/src/emit.rs
@@ -113,6 +113,11 @@ pub enum OpRemovalReason {
         /// The removed entity
         entity: Entity,
     },
+    /// Op was removed because it expired
+    Expired {
+        /// Op was valid until this timestamp
+        valid_until: Timestamp,
+    },
 }
 
 impl EntitySummary {


### PR DESCRIPTION
Closes #502 

## Proposed Changes

  - Evict UOs once the last mined block's timestamp has passed their `valid_until` field
  
 ## TODO

- [x] This needs to merge to `main` first
- [x] Integration test this, submit a UO with a short expiry and fees that are too low
