### PR TITLE
fix(builder): try underpriced bundle txns again

### DIFF
--- a/crates/types/src/gas.rs
+++ b/crates/types/src/gas.rs
@@ -39,8 +39,8 @@ impl GasFees {
     /// Increase the gas fees by a percentage
     pub fn increase_by_percent(self, percent: u64) -> Self {
         Self {
-            max_fee_per_gas: math::increase_by_percent(self.max_fee_per_gas, percent),
-            max_priority_fee_per_gas: math::increase_by_percent(
+            max_fee_per_gas: math::increase_by_percent_ceil(self.max_fee_per_gas, percent),
+            max_priority_fee_per_gas: math::increase_by_percent_ceil(
                 self.max_priority_fee_per_gas,
                 percent,
             ),

--- a/crates/utils/src/math.rs
+++ b/crates/utils/src/math.rs
@@ -13,7 +13,7 @@
 
 //! Math utilities
 
-use std::ops::{Div, Mul};
+use std::ops::{Add, Div, Mul};
 
 /// Increases a number by a percentage
 pub fn increase_by_percent<T>(n: T, percent: u64) -> T
@@ -23,10 +23,28 @@ where
     n * (100 + percent) / 100
 }
 
+/// Increases a number by a percentage, rounding up
+pub fn increase_by_percent_ceil<T>(n: T, percent: u64) -> T
+where
+    T: Add<u64, Output = T> + Mul<u64, Output = T> + Div<u64, Output = T>,
+{
+    (n * (100 + percent) + 99) / 100
+}
+
 /// Take a percentage of a number
 pub fn percent<T>(n: T, percent: u64) -> T
 where
     T: Mul<u64, Output = T> + Div<u64, Output = T>,
 {
     n * percent / 100
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_increase_by_percent_ceil() {
+        assert_eq!(increase_by_percent_ceil(3, 10), 4);
+    }
 }


### PR DESCRIPTION
Applies to #550 

## Proposed Changes

  - Retry bundle transactions if we receive `replacement transaction underpriced`
  
 ## TODO

- [x] This is a hotfix to unblock stuck transactions on Sepolia, we need a stronger approach for `main`. The issue here is that we require there to be a UO to unstick (see #550 for why this isn't sufficient).
