### PR TITLE
feat(rpc): include pending UOs in eth_getUserOperationByHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,6 +4069,7 @@ dependencies = [
  "futures-util",
  "jsonrpsee",
  "metrics",
+ "mockall",
  "rundler-builder",
  "rundler-pool",
  "rundler-provider",

--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -110,6 +110,8 @@ message MempoolOp {
   // multiple UserOperations in the mempool, otherwise just one UserOperation is
   // permitted
   bool account_is_staked = 8;
+  // The entry point address of this operation
+  bytes entry_point = 9;
 }
 
 // Defines the gRPC endpoints for a UserOperation mempool service
@@ -125,6 +127,9 @@ service OpPool {
   // Get up to `max_ops` from the mempool.
   rpc GetOps (GetOpsRequest) returns (GetOpsResponse);
 
+  // Get a UserOperation by its hash
+  rpc GetOpByHash (GetOpByHashRequest) returns (GetOpByHashResponse);
+
   // Removes UserOperations from the mempool
   rpc RemoveOps(RemoveOpsRequest) returns (RemoveOpsResponse);
 
@@ -133,10 +138,13 @@ service OpPool {
 
   // Clears the bundler mempool and reputation data of paymasters/accounts/factories/aggregators
   rpc DebugClearState (DebugClearStateRequest) returns (DebugClearStateResponse);
+
   // Dumps the current UserOperations mempool
   rpc DebugDumpMempool (DebugDumpMempoolRequest) returns (DebugDumpMempoolResponse);
+
   // Sets reputation of given addresses.
   rpc DebugSetReputation (DebugSetReputationRequest) returns (DebugSetReputationResponse);
+
   // Returns the reputation data of all observed addresses. Returns an array of
   // reputation objects, each with the fields described above in
   // debug_bundler_setReputation
@@ -195,6 +203,20 @@ message GetOpsResponse {
 }
 message GetOpsSuccess {
   repeated MempoolOp ops = 1;
+}
+
+message GetOpByHashRequest {
+  // The serialized UserOperation hash
+  bytes hash = 1;
+}
+message GetOpByHashResponse {
+  oneof result {
+    GetOpByHashSuccess success = 1;
+    MempoolError failure = 2;
+  }
+}
+message GetOpByHashSuccess {
+  MempoolOp op = 1;
 }
 
 message GetReputationStatusResponse {

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -80,6 +80,9 @@ pub trait Mempool: Send + Sync + 'static {
     /// Returns the all operations from the pool up to a max size
     fn all_operations(&self, max: usize) -> Vec<Arc<PoolOperation>>;
 
+    /// Looks up a user operation by hash, returns None if not found
+    fn get_user_operation_by_hash(&self, hash: H256) -> Option<Arc<PoolOperation>>;
+
     /// Debug methods
 
     /// Clears the mempool
@@ -168,6 +171,8 @@ pub enum OperationOrigin {
 pub struct PoolOperation {
     /// The user operation stored in the pool
     pub uo: UserOperation,
+    /// The entry point address for this operation
+    pub entry_point: Address,
     /// The aggregator address for this operation, if any.
     pub aggregator: Option<Address>,
     /// The valid time range for this operation.
@@ -264,6 +269,7 @@ mod tests {
                 init_code: factory.as_fixed_bytes().into(),
                 ..Default::default()
             },
+            entry_point: Address::random(),
             aggregator: Some(aggregator),
             valid_time_range: ValidTimeRange::all_time(),
             expected_code_hash: H256::random(),

--- a/crates/pool/src/server/mod.rs
+++ b/crates/pool/src/server/mod.rs
@@ -69,6 +69,11 @@ pub trait PoolServer: Send + Sync + 'static {
         shard_index: u64,
     ) -> PoolResult<Vec<PoolOperation>>;
 
+    /// Get an operation from the pool by hash
+    /// Checks each entry point in order until the operation is found
+    /// Returns None if the operation is not found
+    async fn get_op_by_hash(&self, hash: H256) -> PoolResult<Option<PoolOperation>>;
+
     /// Remove operations from the pool by hash
     async fn remove_ops(&self, entry_point: Address, ops: Vec<H256>) -> PoolResult<()>;
 

--- a/crates/pool/src/server/remote/mod.rs
+++ b/crates/pool/src/server/remote/mod.rs
@@ -13,7 +13,7 @@
 
 mod client;
 mod error;
-#[allow(non_snake_case, unreachable_pub)]
+#[allow(non_snake_case, unreachable_pub, clippy::large_enum_variant)]
 mod protos;
 mod server;
 

--- a/crates/pool/src/server/remote/protos.rs
+++ b/crates/pool/src/server/remote/protos.rs
@@ -234,6 +234,7 @@ impl From<&PoolOperation> for MempoolOp {
     fn from(op: &PoolOperation) -> Self {
         MempoolOp {
             uo: Some(UserOperation::from(&op.uo)),
+            entry_point: op.entry_point.as_bytes().to_vec(),
             aggregator: op.aggregator.map_or(vec![], |a| a.as_bytes().to_vec()),
             valid_after: op.valid_time_range.valid_after.seconds_since_epoch(),
             valid_until: op.valid_time_range.valid_until.seconds_since_epoch(),
@@ -255,6 +256,8 @@ impl TryFrom<MempoolOp> for PoolOperation {
 
     fn try_from(op: MempoolOp) -> Result<Self, Self::Error> {
         let uo = op.uo.context(MISSING_USER_OP_ERR_STR)?.try_into()?;
+
+        let entry_point = from_bytes(&op.entry_point)?;
 
         let aggregator: Option<Address> = if op.aggregator.is_empty() {
             None
@@ -278,6 +281,7 @@ impl TryFrom<MempoolOp> for PoolOperation {
 
         Ok(PoolOperation {
             uo,
+            entry_point,
             aggregator,
             valid_time_range,
             expected_code_hash,

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -30,3 +30,8 @@ serde.workspace = true
 strum.workspace = true
 url.workspace = true
 futures-util.workspace = true
+
+[dev-dependencies]
+mockall.workspace = true
+rundler-provider = { path = "../provider", features = ["test-utils"]}
+rundler-pool = { path = "../pool", features = ["test-utils"] }

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -79,7 +79,7 @@ pub struct RpcStakeInfo {
 }
 
 /// User operation definition for RPC
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcUserOperation {
     sender: RpcAddress,
@@ -132,7 +132,7 @@ impl From<RpcUserOperation> for UserOperation {
 }
 
 /// User operation with additional metadata
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RichUserOperation {
     /// The full user operation
@@ -140,11 +140,11 @@ pub struct RichUserOperation {
     /// The entry point address this operation was sent to
     pub entry_point: RpcAddress,
     /// The number of the block this operation was included in
-    pub block_number: U256,
+    pub block_number: Option<U256>,
     /// The hash of the block this operation was included in
-    pub block_hash: H256,
+    pub block_hash: Option<H256>,
     /// The hash of the transaction this operation was included in
-    pub transaction_hash: H256,
+    pub transaction_hash: Option<H256>,
 }
 
 /// User operation receipt


### PR DESCRIPTION
Closes #529 

## Proposed Changes

  - Add endpoint to pool to get a pending user operation by hash
  - Use that endpoint in `eth_getUserOperationByHash` to return pending UOs
  
## TODO

- [x] Add unit tests to pool
- [x] Add unit tests to RPC
- [x] Integration test
