### PR TITLE
feat(rpc): add debug_bundler_clearMempool endpoint

### DIFF
--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -139,9 +139,6 @@ service OpPool {
   // Clears the bundler mempool and reputation data of paymasters/accounts/factories/aggregators
   rpc DebugClearState (DebugClearStateRequest) returns (DebugClearStateResponse);
 
-  // Clears the bundler mempool but not reputation data
-  rpc DebugClearMempool (DebugClearMempoolRequest) returns (DebugClearMempoolResponse);
-
   // Dumps the current UserOperations mempool
   rpc DebugDumpMempool (DebugDumpMempoolRequest) returns (DebugDumpMempoolResponse);
 
@@ -293,7 +290,10 @@ message UpdateEntitiesResponse {
 }
 message UpdateEntitiesSuccess {}
 
-message DebugClearStateRequest {}
+message DebugClearStateRequest {
+  bool clear_mempool = 1;
+  bool clear_reputation = 2;
+}
 message DebugClearStateResponse {
   oneof result {
     DebugClearStateSuccess success = 1;
@@ -301,15 +301,6 @@ message DebugClearStateResponse {
   }
 }
 message DebugClearStateSuccess {}
-
-message DebugClearMempoolRequest {}
-message DebugClearMempoolResponse {
-  oneof result {
-    DebugClearMempoolSuccess success = 1;
-    MempoolError failure = 2;
-  }
-}
-message DebugClearMempoolSuccess {}
 
 message DebugDumpMempoolRequest {
   bytes entry_point = 1;

--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -139,6 +139,9 @@ service OpPool {
   // Clears the bundler mempool and reputation data of paymasters/accounts/factories/aggregators
   rpc DebugClearState (DebugClearStateRequest) returns (DebugClearStateResponse);
 
+  // Clears the bundler mempool but not reputation data
+  rpc DebugClearMempool (DebugClearMempoolRequest) returns (DebugClearMempoolResponse);
+
   // Dumps the current UserOperations mempool
   rpc DebugDumpMempool (DebugDumpMempoolRequest) returns (DebugDumpMempoolResponse);
 
@@ -298,6 +301,15 @@ message DebugClearStateResponse {
   }
 }
 message DebugClearStateSuccess {}
+
+message DebugClearMempoolRequest {}
+message DebugClearMempoolResponse {
+  oneof result {
+    DebugClearMempoolSuccess success = 1;
+    MempoolError failure = 2;
+  }
+}
+message DebugClearMempoolSuccess {}
 
 message DebugDumpMempoolRequest {
   bytes entry_point = 1;

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -91,14 +91,8 @@ pub trait Mempool: Send + Sync + 'static {
 
     /// Debug methods
 
-    /// Clears both the mempool and reputation
-    fn clear(&self);
-
-    // Clears the reputation system
-    fn clear_reputation(&self);
-
-    /// Clears the mempool
-    fn clear_mempool(&self);
+    /// Clears the mempool of UOs or reputation of all addresses
+    fn clear_state(&self, clear_mempool: bool, clear_reputation: bool);
 
     /// Dumps the mempool's reputation tracking
     fn dump_reputation(&self) -> Vec<Reputation>;

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -91,8 +91,14 @@ pub trait Mempool: Send + Sync + 'static {
 
     /// Debug methods
 
-    /// Clears the mempool
+    /// Clears both the mempool and reputation
     fn clear(&self);
+
+    // Clears the reputation system
+    fn clear_reputation(&self);
+
+    /// Clears the mempool
+    fn clear_mempool(&self);
 
     /// Dumps the mempool's reputation tracking
     fn dump_reputation(&self) -> Vec<Reputation>;

--- a/crates/pool/src/mempool/reputation.rs
+++ b/crates/pool/src/mempool/reputation.rs
@@ -108,6 +108,9 @@ pub(crate) trait ReputationManager: Send + Sync + 'static {
 
     /// Get the ops allowed for an unstaked entity
     fn get_ops_allowed(&self, address: Address) -> u64;
+
+    /// Clear all reputation values
+    fn clear(&self);
 }
 
 #[derive(Debug)]
@@ -186,6 +189,10 @@ impl ReputationManager for HourlyMovingAverageReputation {
 
     fn get_ops_allowed(&self, address: Address) -> u64 {
         self.reputation.read().get_ops_allowed(address)
+    }
+
+    fn clear(&self) {
+        self.reputation.write().clear()
     }
 }
 
@@ -334,6 +341,10 @@ impl AddressReputation {
         }
         self.counts
             .retain(|_, count| count.ops_seen > 0 || count.ops_included > 0);
+    }
+
+    fn clear(&mut self) {
+        self.counts.clear();
     }
 }
 

--- a/crates/pool/src/mempool/uo_pool.rs
+++ b/crates/pool/src/mempool/uo_pool.rs
@@ -581,17 +581,13 @@ where
         self.state.read().pool.get_operation_by_hash(hash)
     }
 
-    fn clear(&self) {
-        self.clear_mempool();
-        self.clear_reputation();
-    }
-
-    fn clear_reputation(&self) {
-        self.reputation.clear()
-    }
-
-    fn clear_mempool(&self) {
-        self.state.write().pool.clear()
+    fn clear_state(&self, clear_mempool: bool, clear_reputation: bool) {
+        if clear_mempool {
+            self.state.write().pool.clear()
+        }
+        if clear_reputation {
+            self.reputation.clear()
+        }
     }
 
     fn dump_reputation(&self) -> Vec<Reputation> {
@@ -736,7 +732,7 @@ mod tests {
                 .unwrap();
         }
         check_ops(pool.best_operations(3, 0).unwrap(), uos);
-        pool.clear();
+        pool.clear_state(true, true);
         assert_eq!(pool.best_operations(3, 0).unwrap(), vec![]);
     }
 

--- a/crates/pool/src/mempool/uo_pool.rs
+++ b/crates/pool/src/mempool/uo_pool.rs
@@ -582,6 +582,15 @@ where
     }
 
     fn clear(&self) {
+        self.clear_mempool();
+        self.clear_reputation();
+    }
+
+    fn clear_reputation(&self) {
+        self.reputation.clear()
+    }
+
+    fn clear_mempool(&self) {
         self.state.write().pool.clear()
     }
 
@@ -1562,6 +1571,11 @@ mod tests {
 
             // return ops allowed, as defined by UREP-020
             self.same_unstaked_entity_mempool_count + inclusion_based_count
+        }
+
+        fn clear(&self) {
+            self.counts.write().seen.clear();
+            self.counts.write().included.clear();
         }
     }
 }

--- a/crates/pool/src/server/mod.rs
+++ b/crates/pool/src/server/mod.rs
@@ -91,10 +91,11 @@ pub trait PoolServer: Send + Sync + 'static {
     async fn subscribe_new_heads(&self) -> PoolResult<Pin<Box<dyn Stream<Item = NewHead> + Send>>>;
 
     /// Clear the pool state, used for debug methods
-    async fn debug_clear_state(&self) -> PoolResult<()>;
-
-    /// Clear the mempool state, used for debug methods
-    async fn debug_clear_mempool(&self) -> PoolResult<()>;
+    async fn debug_clear_state(
+        &self,
+        clear_mempool: bool,
+        clear_reputation: bool,
+    ) -> PoolResult<()>;
 
     /// Dump all operations in the pool, used for debug methods
     async fn debug_dump_mempool(&self, entry_point: Address) -> PoolResult<Vec<PoolOperation>>;

--- a/crates/pool/src/server/mod.rs
+++ b/crates/pool/src/server/mod.rs
@@ -93,6 +93,9 @@ pub trait PoolServer: Send + Sync + 'static {
     /// Clear the pool state, used for debug methods
     async fn debug_clear_state(&self) -> PoolResult<()>;
 
+    /// Clear the mempool state, used for debug methods
+    async fn debug_clear_mempool(&self) -> PoolResult<()>;
+
     /// Dump all operations in the pool, used for debug methods
     async fn debug_dump_mempool(&self, entry_point: Address) -> PoolResult<Vec<PoolOperation>>;
 

--- a/crates/pool/src/server/remote/client.rs
+++ b/crates/pool/src/server/remote/client.rs
@@ -33,14 +33,13 @@ use tonic_health::{
 };
 
 use super::protos::{
-    self, add_op_response, debug_clear_mempool_response, debug_clear_state_response,
-    debug_dump_mempool_response, debug_dump_reputation_response, debug_set_reputation_response,
-    get_op_by_hash_response, get_ops_response, get_reputation_status_response,
-    get_stake_status_response, op_pool_client::OpPoolClient, remove_ops_response,
-    update_entities_response, AddOpRequest, DebugClearMempoolRequest, DebugClearStateRequest,
-    DebugDumpMempoolRequest, DebugDumpReputationRequest, DebugSetReputationRequest, GetOpsRequest,
-    GetReputationStatusRequest, GetStakeStatusRequest, RemoveOpsRequest, SubscribeNewHeadsRequest,
-    SubscribeNewHeadsResponse, UpdateEntitiesRequest,
+    self, add_op_response, debug_clear_state_response, debug_dump_mempool_response,
+    debug_dump_reputation_response, debug_set_reputation_response, get_op_by_hash_response,
+    get_ops_response, get_reputation_status_response, get_stake_status_response,
+    op_pool_client::OpPoolClient, remove_ops_response, update_entities_response, AddOpRequest,
+    DebugClearStateRequest, DebugDumpMempoolRequest, DebugDumpReputationRequest,
+    DebugSetReputationRequest, GetOpsRequest, GetReputationStatusRequest, GetStakeStatusRequest,
+    RemoveOpsRequest, SubscribeNewHeadsRequest, SubscribeNewHeadsResponse, UpdateEntitiesRequest,
 };
 use crate::{
     mempool::{PoolOperation, Reputation, StakeStatus},
@@ -265,11 +264,18 @@ impl PoolServer for RemotePoolClient {
         }
     }
 
-    async fn debug_clear_state(&self) -> PoolResult<()> {
+    async fn debug_clear_state(
+        &self,
+        clear_mempool: bool,
+        clear_reputation: bool,
+    ) -> PoolResult<()> {
         let res = self
             .op_pool_client
             .clone()
-            .debug_clear_state(DebugClearStateRequest {})
+            .debug_clear_state(DebugClearStateRequest {
+                clear_mempool,
+                clear_reputation,
+            })
             .await?
             .into_inner()
             .result;
@@ -277,24 +283,6 @@ impl PoolServer for RemotePoolClient {
         match res {
             Some(debug_clear_state_response::Result::Success(_)) => Ok(()),
             Some(debug_clear_state_response::Result::Failure(f)) => Err(f.try_into()?),
-            None => Err(PoolServerError::Other(anyhow::anyhow!(
-                "should have received result from op pool"
-            )))?,
-        }
-    }
-
-    async fn debug_clear_mempool(&self) -> PoolResult<()> {
-        let res = self
-            .op_pool_client
-            .clone()
-            .debug_clear_mempool(DebugClearMempoolRequest {})
-            .await?
-            .into_inner()
-            .result;
-
-        match res {
-            Some(debug_clear_mempool_response::Result::Success(_)) => Ok(()),
-            Some(debug_clear_mempool_response::Result::Failure(f)) => Err(f.try_into()?),
             None => Err(PoolServerError::Other(anyhow::anyhow!(
                 "should have received result from op pool"
             )))?,

--- a/crates/pool/src/server/remote/client.rs
+++ b/crates/pool/src/server/remote/client.rs
@@ -33,13 +33,14 @@ use tonic_health::{
 };
 
 use super::protos::{
-    self, add_op_response, debug_clear_state_response, debug_dump_mempool_response,
-    debug_dump_reputation_response, debug_set_reputation_response, get_op_by_hash_response,
-    get_ops_response, get_reputation_status_response, get_stake_status_response,
-    op_pool_client::OpPoolClient, remove_ops_response, update_entities_response, AddOpRequest,
-    DebugClearStateRequest, DebugDumpMempoolRequest, DebugDumpReputationRequest,
-    DebugSetReputationRequest, GetOpsRequest, GetReputationStatusRequest, GetStakeStatusRequest,
-    RemoveOpsRequest, SubscribeNewHeadsRequest, SubscribeNewHeadsResponse, UpdateEntitiesRequest,
+    self, add_op_response, debug_clear_mempool_response, debug_clear_state_response,
+    debug_dump_mempool_response, debug_dump_reputation_response, debug_set_reputation_response,
+    get_op_by_hash_response, get_ops_response, get_reputation_status_response,
+    get_stake_status_response, op_pool_client::OpPoolClient, remove_ops_response,
+    update_entities_response, AddOpRequest, DebugClearMempoolRequest, DebugClearStateRequest,
+    DebugDumpMempoolRequest, DebugDumpReputationRequest, DebugSetReputationRequest, GetOpsRequest,
+    GetReputationStatusRequest, GetStakeStatusRequest, RemoveOpsRequest, SubscribeNewHeadsRequest,
+    SubscribeNewHeadsResponse, UpdateEntitiesRequest,
 };
 use crate::{
     mempool::{PoolOperation, Reputation, StakeStatus},
@@ -276,6 +277,24 @@ impl PoolServer for RemotePoolClient {
         match res {
             Some(debug_clear_state_response::Result::Success(_)) => Ok(()),
             Some(debug_clear_state_response::Result::Failure(f)) => Err(f.try_into()?),
+            None => Err(PoolServerError::Other(anyhow::anyhow!(
+                "should have received result from op pool"
+            )))?,
+        }
+    }
+
+    async fn debug_clear_mempool(&self) -> PoolResult<()> {
+        let res = self
+            .op_pool_client
+            .clone()
+            .debug_clear_mempool(DebugClearMempoolRequest {})
+            .await?
+            .into_inner()
+            .result;
+
+        match res {
+            Some(debug_clear_mempool_response::Result::Success(_)) => Ok(()),
+            Some(debug_clear_mempool_response::Result::Failure(f)) => Err(f.try_into()?),
             None => Err(PoolServerError::Other(anyhow::anyhow!(
                 "should have received result from op pool"
             )))?,

--- a/crates/pool/src/server/remote/server.rs
+++ b/crates/pool/src/server/remote/server.rs
@@ -30,11 +30,13 @@ use tokio_util::sync::CancellationToken;
 use tonic::{transport::Server, Request, Response, Result, Status};
 
 use super::protos::{
-    add_op_response, debug_clear_state_response, debug_dump_mempool_response,
-    debug_dump_reputation_response, debug_set_reputation_response, get_op_by_hash_response,
-    get_ops_response, get_reputation_status_response, get_stake_status_response,
+    add_op_response, debug_clear_mempool_response, debug_clear_state_response,
+    debug_dump_mempool_response, debug_dump_reputation_response, debug_set_reputation_response,
+    get_op_by_hash_response, get_ops_response, get_reputation_status_response,
+    get_stake_status_response,
     op_pool_server::{OpPool, OpPoolServer},
     remove_ops_response, update_entities_response, AddOpRequest, AddOpResponse, AddOpSuccess,
+    DebugClearMempoolRequest, DebugClearMempoolResponse, DebugClearMempoolSuccess,
     DebugClearStateRequest, DebugClearStateResponse, DebugClearStateSuccess,
     DebugDumpMempoolRequest, DebugDumpMempoolResponse, DebugDumpMempoolSuccess,
     DebugDumpReputationRequest, DebugDumpReputationResponse, DebugDumpReputationSuccess,
@@ -279,6 +281,24 @@ impl OpPool for OpPoolImpl {
             },
             Err(error) => DebugClearStateResponse {
                 result: Some(debug_clear_state_response::Result::Failure(error.into())),
+            },
+        };
+
+        Ok(Response::new(resp))
+    }
+
+    async fn debug_clear_mempool(
+        &self,
+        _request: Request<DebugClearMempoolRequest>,
+    ) -> Result<Response<DebugClearMempoolResponse>> {
+        let resp = match self.local_pool.debug_clear_mempool().await {
+            Ok(_) => DebugClearMempoolResponse {
+                result: Some(debug_clear_mempool_response::Result::Success(
+                    DebugClearMempoolSuccess {},
+                )),
+            },
+            Err(error) => DebugClearMempoolResponse {
+                result: Some(debug_clear_mempool_response::Result::Failure(error.into())),
             },
         };
 

--- a/crates/pool/src/server/remote/server.rs
+++ b/crates/pool/src/server/remote/server.rs
@@ -30,13 +30,11 @@ use tokio_util::sync::CancellationToken;
 use tonic::{transport::Server, Request, Response, Result, Status};
 
 use super::protos::{
-    add_op_response, debug_clear_mempool_response, debug_clear_state_response,
-    debug_dump_mempool_response, debug_dump_reputation_response, debug_set_reputation_response,
-    get_op_by_hash_response, get_ops_response, get_reputation_status_response,
-    get_stake_status_response,
+    add_op_response, debug_clear_state_response, debug_dump_mempool_response,
+    debug_dump_reputation_response, debug_set_reputation_response, get_op_by_hash_response,
+    get_ops_response, get_reputation_status_response, get_stake_status_response,
     op_pool_server::{OpPool, OpPoolServer},
     remove_ops_response, update_entities_response, AddOpRequest, AddOpResponse, AddOpSuccess,
-    DebugClearMempoolRequest, DebugClearMempoolResponse, DebugClearMempoolSuccess,
     DebugClearStateRequest, DebugClearStateResponse, DebugClearStateSuccess,
     DebugDumpMempoolRequest, DebugDumpMempoolResponse, DebugDumpMempoolSuccess,
     DebugDumpReputationRequest, DebugDumpReputationResponse, DebugDumpReputationSuccess,
@@ -271,9 +269,14 @@ impl OpPool for OpPoolImpl {
 
     async fn debug_clear_state(
         &self,
-        _request: Request<DebugClearStateRequest>,
+        request: Request<DebugClearStateRequest>,
     ) -> Result<Response<DebugClearStateResponse>> {
-        let resp = match self.local_pool.debug_clear_state().await {
+        let req = request.into_inner();
+        let resp = match self
+            .local_pool
+            .debug_clear_state(req.clear_mempool, req.clear_reputation)
+            .await
+        {
             Ok(_) => DebugClearStateResponse {
                 result: Some(debug_clear_state_response::Result::Success(
                     DebugClearStateSuccess {},
@@ -281,24 +284,6 @@ impl OpPool for OpPoolImpl {
             },
             Err(error) => DebugClearStateResponse {
                 result: Some(debug_clear_state_response::Result::Failure(error.into())),
-            },
-        };
-
-        Ok(Response::new(resp))
-    }
-
-    async fn debug_clear_mempool(
-        &self,
-        _request: Request<DebugClearMempoolRequest>,
-    ) -> Result<Response<DebugClearMempoolResponse>> {
-        let resp = match self.local_pool.debug_clear_mempool().await {
-            Ok(_) => DebugClearMempoolResponse {
-                result: Some(debug_clear_mempool_response::Result::Success(
-                    DebugClearMempoolSuccess {},
-                )),
-            },
-            Err(error) => DebugClearMempoolResponse {
-                result: Some(debug_clear_mempool_response::Result::Failure(error.into())),
             },
         };
 

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -94,7 +94,7 @@ where
     async fn bundler_clear_state(&self) -> RpcResult<String> {
         let _ = self
             .pool
-            .debug_clear_state()
+            .debug_clear_state(true, true)
             .await
             .map_err(|e| rpc_err(INTERNAL_ERROR_CODE, e.to_string()))?;
 
@@ -104,7 +104,7 @@ where
     async fn bundler_clear_mempool(&self) -> RpcResult<String> {
         let _ = self
             .pool
-            .debug_clear_mempool()
+            .debug_clear_state(true, false)
             .await
             .map_err(|e| rpc_err(INTERNAL_ERROR_CODE, e.to_string()))?;
 

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -32,6 +32,10 @@ pub trait DebugApi {
     #[method(name = "bundler_clearState")]
     async fn bundler_clear_state(&self) -> RpcResult<String>;
 
+    /// Clears the state of the mempool without affect reputations.
+    #[method(name = "bundler_clearMempool")]
+    async fn bundler_clear_mempool(&self) -> RpcResult<String>;
+
     /// Dumps the mempool.
     #[method(name = "bundler_dumpMempool")]
     async fn bundler_dump_mempool(&self, entry_point: Address) -> RpcResult<Vec<RpcUserOperation>>;
@@ -91,6 +95,16 @@ where
         let _ = self
             .pool
             .debug_clear_state()
+            .await
+            .map_err(|e| rpc_err(INTERNAL_ERROR_CODE, e.to_string()))?;
+
+        Ok("ok".to_string())
+    }
+
+    async fn bundler_clear_mempool(&self) -> RpcResult<String> {
+        let _ = self
+            .pool
+            .debug_clear_mempool()
             .await
             .map_err(|e| rpc_err(INTERNAL_ERROR_CODE, e.to_string()))?;
 


### PR DESCRIPTION
## Proposed Changes

  - Add the `debug_bundler_clearMempool` RPC method which is used in the spec test: https://github.com/alchemyplatform/bundler-spec-tests/blob/12bf62752d4af78ed383e6ec4c1a610ebaea1787/tests/utils.py#L184. The spec test uses the method to clear the mempool but not the reputations, which is why we need a different endpoint than `debug_bundler_clearState`
  
