### PR TITLE
feat(sim): reject UOs that don't have a buffer on verification gas limit

### DIFF
--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -558,6 +558,7 @@ message SimulationViolationError {
     AggregatorValidationFailed aggregator_validation_failed = 16;
     UnstakedPaymasterContext unstaked_paymaster_context = 17;
     UnstakedAggregator unstaked_aggregator = 18;
+    VerificationGasLimitBufferTooLow verification_gas_limit_buffer_too_low = 19;
   }
 }
 
@@ -634,3 +635,7 @@ message CodeHashChanged {}
 
 message AggregatorValidationFailed {}
 
+message VerificationGasLimitBufferTooLow {
+  bytes limit = 1;
+  bytes needed = 2;
+}

--- a/crates/sim/src/simulation/mod.rs
+++ b/crates/sim/src/simulation/mod.rs
@@ -15,6 +15,7 @@
 mod simulation;
 #[cfg(feature = "test-utils")]
 pub use simulation::MockSimulator;
+pub(crate) use simulation::REQUIRED_VERIFICATION_GAS_LIMIT_BUFFER;
 pub use simulation::{
     EntityInfo, EntityInfos, NeedsStakeInformation, Settings, SimulationError, SimulationResult,
     SimulationViolation, Simulator, SimulatorImpl, ViolationOpCode,


### PR DESCRIPTION
Closes #593 

## Proposed Changes

- Adds a simulation violation check that requires a UO to have at least a 2000 gas buffer on their `verificationGasLimit` compared to what is used during simulation. This accounts for a situation where a UO can use slightly more than their VGL onchain, causing a bundle to revert.