### PR TITLE
feat(builder): add a timer based trigger to bundle building

### DIFF
--- a/bin/rundler/chain_specs/dev.toml
+++ b/bin/rundler/chain_specs/dev.toml
@@ -2,3 +2,5 @@ base = "ethereum"
 
 name = "Ethereum Devnet"
 id = 1337
+
+bundle_max_send_interval_millis = 250

--- a/crates/builder/src/server/local.rs
+++ b/crates/builder/src/server/local.rs
@@ -11,11 +11,6 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
-
 use async_trait::async_trait;
 use ethers::types::{Address, H256};
 use rundler_task::server::{HealthCheck, ServerStatus};
@@ -26,7 +21,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    bundle_sender::{SendBundleRequest, SendBundleResult},
+    bundle_sender::{BundleSenderAction, SendBundleRequest, SendBundleResult},
     server::{BuilderResult, BuilderServer, BuilderServerError, BundlingMode},
 };
 
@@ -57,17 +52,12 @@ impl LocalBuilderBuilder {
     /// Run the local builder server, consuming the builder
     pub fn run(
         self,
-        manual_bundling_mode: Arc<AtomicBool>,
-        send_bundle_requesters: Vec<mpsc::Sender<SendBundleRequest>>,
+        bundle_sender_actions: Vec<mpsc::Sender<BundleSenderAction>>,
         entry_points: Vec<Address>,
         shutdown_token: CancellationToken,
     ) -> JoinHandle<anyhow::Result<()>> {
-        let mut runner = LocalBuilderServerRunner::new(
-            self.req_receiver,
-            manual_bundling_mode,
-            send_bundle_requesters,
-            entry_points,
-        );
+        let mut runner =
+            LocalBuilderServerRunner::new(self.req_receiver, bundle_sender_actions, entry_points);
         tokio::spawn(async move { runner.run(shutdown_token).await })
     }
 }
@@ -80,8 +70,7 @@ pub struct LocalBuilderHandle {
 
 struct LocalBuilderServerRunner {
     req_receiver: mpsc::Receiver<ServerRequest>,
-    send_bundle_requesters: Vec<mpsc::Sender<SendBundleRequest>>,
-    manual_bundling_mode: Arc<AtomicBool>,
+    bundle_sender_actions: Vec<mpsc::Sender<BundleSenderAction>>,
     entry_points: Vec<Address>,
 }
 
@@ -150,14 +139,12 @@ impl HealthCheck for LocalBuilderHandle {
 impl LocalBuilderServerRunner {
     fn new(
         req_receiver: mpsc::Receiver<ServerRequest>,
-        manual_bundling_mode: Arc<AtomicBool>,
-        send_bundle_requesters: Vec<mpsc::Sender<SendBundleRequest>>,
+        bundle_sender_actions: Vec<mpsc::Sender<BundleSenderAction>>,
         entry_points: Vec<Address>,
     ) -> Self {
         Self {
             req_receiver,
-            manual_bundling_mode,
-            send_bundle_requesters,
+            bundle_sender_actions,
             entry_points,
         }
     }
@@ -177,16 +164,14 @@ impl LocalBuilderServerRunner {
                                 })
                             },
                             ServerRequestKind::DebugSendBundleNow => {
-                                if !self.manual_bundling_mode.load(Ordering::Relaxed) {
-                                    break 'a Err(anyhow::anyhow!("bundling mode is not manual").into())
-                                } else if self.send_bundle_requesters.len() != 1 {
+                                if self.bundle_sender_actions.len() != 1 {
                                     break 'a Err(anyhow::anyhow!("more than 1 bundle builder not supported in debug mode").into())
                                 }
 
                                 let (tx, rx) = oneshot::channel();
-                                match self.send_bundle_requesters[0].send(SendBundleRequest{
+                                match self.bundle_sender_actions[0].send(BundleSenderAction::SendBundle(SendBundleRequest{
                                     responder: tx
-                                }).await {
+                                })).await {
                                     Ok(()) => {},
                                     Err(e) => break 'a Err(anyhow::anyhow!("failed to send send bundle request: {}", e.to_string()).into())
                                 }
@@ -211,7 +196,15 @@ impl LocalBuilderServerRunner {
                                 }
                             },
                             ServerRequestKind::DebugSetBundlingMode { mode } => {
-                                self.manual_bundling_mode.store(mode == BundlingMode::Manual, Ordering::Relaxed);
+                                if self.bundle_sender_actions.len() != 1 {
+                                    break 'a Err(anyhow::anyhow!("more than 1 bundle builder not supported in debug mode").into())
+                                }
+
+                                match self.bundle_sender_actions[0].send(BundleSenderAction::ChangeMode(mode)).await {
+                                    Ok(()) => {},
+                                    Err(e) => break 'a Err(anyhow::anyhow!("failed to change bundler mode: {}", e.to_string()).into())
+                                }
+
                                 Ok(ServerResponse::DebugSetBundlingMode)
                             },
                         }

--- a/crates/types/src/chain.rs
+++ b/crates/types/src/chain.rs
@@ -60,6 +60,16 @@ pub struct ChainSpec {
     pub max_max_priority_fee_per_gas: U256,
 
     /*
+     * Bundle building
+     */
+    /// The maximum amount of time to wait before sending a bundle.
+    ///
+    /// The bundle builder will always try to send a bundle when a new block is received.
+    /// This parameter is used to trigger the builder to send a bundle after a specified
+    /// amount of time, before a new block is not received.
+    pub bundle_max_send_interval_millis: u64,
+
+    /*
      * Senders
      */
     /// True if the flashbots sender is enabled on this chain
@@ -112,6 +122,7 @@ impl Default for ChainSpec {
             priority_fee_oracle_type: PriorityFeeOracleType::default(),
             min_max_priority_fee_per_gas: U256::zero(),
             max_max_priority_fee_per_gas: U256::MAX,
+            bundle_max_send_interval_millis: u64::MAX,
             flashbots_enabled: false,
             bloxroute_enabled: false,
             chain_history_size: 64,


### PR DESCRIPTION
Closes #598

## Proposed Changes

  - Adds a timer based trigger to the bundle sender. The bundle sender will send a bundle if the timer elapses before it receives the next block. Currently this is set to maximum time for all networks except for dev where it is set to 250ms. This allows bundles to be sent on dev Geth where blocks are only triggered when transactions arrive.
  - Its possible there will be other networks that have unpredictable block times where this chain spec rule could be useful.
  - Fixes switching between bundling modes. Previously if we transition to manual mode we'd never be able to exit unless the tests switch the mode while bundling building is in flight. Once we looped back around we'd be stuck in manual mode until a new bundle was triggered. Doing this required a refactor of how the server interacts with the bundle senders.
