### PR TITLE
fix(docs): add missing command to full node docker-compose.yaml example

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -18,6 +18,7 @@ version: "3.8"
 services:
   rundler:
     image: rundler
+    command: node
     ports:
       # RPC port
       - "3000:3000"


### PR DESCRIPTION
This adds the missing command parameter to the example docker-compose config, without this `docker-compose up` will not run as rundler needs a command specified 