### PR TITLE
feat(rpc): use zero fees in no paymaster estimation case

### DIFF
--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -179,13 +179,13 @@ pub struct CommonArgs {
     max_simulate_handle_ops_gas: u64,
 
     #[arg(
-        long = "validation_estimation_gas_fee",
-        name = "validation_estimation_gas_fee",
-        env = "VALIDATION_ESTIMATION_GAS_FEE",
+        long = "verification_estimation_gas_fee",
+        name = "verification_estimation_gas_fee",
+        env = "VERIFICATION_ESTIMATION_GAS_FEE",
         default_value = "1000000000000", // 10K gwei
         global = true
     )]
-    validation_estimation_gas_fee: u64,
+    verification_estimation_gas_fee: u64,
 
     #[arg(
         long = "bundle_priority_fee_overhead_percent",
@@ -290,7 +290,7 @@ impl TryFrom<&CommonArgs> for EstimationSettings {
             max_verification_gas: value.max_verification_gas,
             max_call_gas,
             max_simulate_handle_ops_gas: value.max_simulate_handle_ops_gas,
-            validation_estimation_gas_fee: value.validation_estimation_gas_fee,
+            verification_estimation_gas_fee: value.verification_estimation_gas_fee,
         })
     }
 }

--- a/crates/rpc/src/eth/api.rs
+++ b/crates/rpc/src/eth/api.rs
@@ -871,7 +871,7 @@ mod tests {
                     max_verification_gas: 1_000_000,
                     max_call_gas: 1_000_000,
                     max_simulate_handle_ops_gas: 1_000_000,
-                    validation_estimation_gas_fee: 1_000_000_000_000,
+                    verification_estimation_gas_fee: 1_000_000_000_000,
                 },
                 FeeEstimator::new(
                     &chain_spec,

--- a/crates/sim/src/estimation/types.rs
+++ b/crates/sim/src/estimation/types.rs
@@ -27,12 +27,12 @@ pub struct Settings {
     pub max_call_gas: u64,
     /// The maximum amount of gas that can be used in a call to `simulateHandleOps`
     pub max_simulate_handle_ops_gas: u64,
-    /// The gas fee to use during validation gas estimation, required to be held by the fee-payer
+    /// The gas fee to use during verification gas estimation, required to be held by the fee-payer
     /// during estimation. If using a paymaster, the fee-payer must have 3x this value.
     /// As the gas limit is varied during estimation, the fee is held constant by varied the
     /// gas price.
     /// Clients can use state overrides to set the balance of the fee-payer to at least this value.
-    pub validation_estimation_gas_fee: u64,
+    pub verification_estimation_gas_fee: u64,
 }
 
 impl Settings {

--- a/crates/types/src/chain.rs
+++ b/crates/types/src/chain.rs
@@ -32,8 +32,12 @@ pub struct ChainSpec {
     pub id: u64,
     /// entry point address
     pub entry_point_address: Address,
-    /// cost of transferring native tokens
-    pub native_transfer_gas: U256,
+    /// Overhead when preforming gas estimation to account for the deposit storage
+    /// and transfer overhead.
+    ///
+    /// NOTE: This must take into account when the storage slot was originally 0
+    /// and is now non-zero, making the overhead slightly higher for most operations.
+    pub deposit_transfer_overhead: U256,
 
     /*
      * Gas estimation
@@ -116,7 +120,7 @@ impl Default for ChainSpec {
             name: "Unknown".to_string(),
             id: 0,
             entry_point_address: Address::from_str(ENTRY_POINT_ADDRESS_V6_0).unwrap(),
-            native_transfer_gas: U256::from(6800),
+            deposit_transfer_overhead: U256::from(30000),
             eip1559_enabled: true,
             calldata_pre_verification_gas: false,
             l1_gas_oracle_contract_type: L1GasOracleContractType::default(),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,8 +42,8 @@ See [chain spec](./architecture/chain_spec.md) for a detailed description of cha
   - env: *USER_OPERATION_EVENT_BLOCK_DISTANCE*
 - `--max_simulate_handle_ops_gas`: Maximum gas for simulating handle operations. (default: `20000000`).
   - env: *MAX_SIMULATE_HANDLE_OPS_GAS*
-- `--validation_estimation_gas_fee`: The gas fee to use during validation estimation. (default: `1000000000000` 10K gwei).
-  - env: *VALIDATION_ESTIMATION_GAS_FEE*
+- `--verification_estimation_gas_fee`: The gas fee to use during verification estimation. (default: `1000000000000` 10K gwei).
+  - env: *VERIFICATION_ESTIMATION_GAS_FEE*
   - See [RPC documentation](./architecture/rpc.md#verificationGasLimit-estimation) for details.
 - `--bundle_priority_fee_overhead_percent`: bundle transaction priority fee overhead over network value. (default: `0`).
   - env: *BUNDLE_PRIORITY_FEE_OVERHEAD_PERCENT*


### PR DESCRIPTION
## Proposed Changes

  - See the docs for a description of the proposed change.
  - TLDR: using zero fees during the no paymaster verification estimation case. In the paymaster case we use the constant.
  - Changes the name of the constant to be more consistent.
