### PR TITLE
fix(mempool): fix configuration deserialization

### DIFF
--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -191,7 +191,9 @@ impl BuilderArgs {
         let submit_url = self.submit_url.clone().unwrap_or_else(|| rpc_url.clone());
 
         let mempool_configs = match &common.mempool_config_path {
-            Some(path) => get_json_config::<MempoolConfigs>(path, &common.aws_region).await?,
+            Some(path) => get_json_config::<MempoolConfigs>(path, &common.aws_region)
+                .await
+                .with_context(|| format!("should load mempool configurations from {path}"))?,
             None => MempoolConfigs::default(),
         };
 

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -173,7 +173,9 @@ impl PoolArgs {
         tracing::info!("allowlist: {:?}", allowlist);
 
         let mempool_channel_configs = match &common.mempool_config_path {
-            Some(path) => get_json_config::<MempoolConfigs>(path, &common.aws_region).await?,
+            Some(path) => get_json_config::<MempoolConfigs>(path, &common.aws_region)
+                .await
+                .with_context(|| format!("should load mempool configurations from {path}"))?,
             None => MempoolConfigs::default(),
         };
         tracing::info!("Mempool channel configs: {:?}", mempool_channel_configs);

--- a/crates/sim/src/simulation/mempool.rs
+++ b/crates/sim/src/simulation/mempool.rs
@@ -24,9 +24,9 @@ use crate::simulation::SimulationViolation;
 ///
 /// Typically read from a JSON file using the `Deserialize` trait.
 #[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct MempoolConfig {
     /// Entry point address this mempool is associated with.
-    #[serde(rename = "camelCase")]
     pub(crate) entry_point: Address,
     /// Allowlist to match violations against.
     pub(crate) allowlist: Vec<AllowlistEntry>,


### PR DESCRIPTION
Correctly deserialize the `entryPoint` field, and display a more descriptive error when deserialization fails.