### PR TITLE
refactor: create context interface for simulation

### DIFF
--- a/crates/builder/src/task.rs
+++ b/crates/builder/src/task.rs
@@ -22,15 +22,9 @@ use ethers::{
 use ethers_signers::Signer;
 use futures::future;
 use futures_util::TryFutureExt;
-use rundler_provider::{EntryPointProvider, EthersEntryPointV0_6, EthersEntryPointV0_7, Provider};
+use rundler_provider::{EntryPointProvider, EthersEntryPointV0_6, EthersEntryPointV0_7};
 use rundler_sim::{
-    simulation::{
-        v0_6::{
-            SimulateValidationTracerImpl as SimulateValidationTracerImplV0_6,
-            Simulator as SimulatorV0_6,
-        },
-        UnsafeSimulator,
-    },
+    simulation::{self, UnsafeSimulator},
     MempoolConfig, PriorityFeeMode, SimulationSettings, Simulator,
 };
 use rundler_task::Task;
@@ -288,9 +282,10 @@ where
                     i + ep.bundle_builder_index_offset,
                     Arc::clone(&provider),
                     ep_v0_6.clone(),
-                    self.create_simulator_v0_6(
+                    simulation::new_v0_6_simulator(
                         Arc::clone(&provider),
                         ep_v0_6.clone(),
+                        self.args.sim_settings,
                         ep.mempool_configs.clone(),
                     ),
                 )
@@ -458,26 +453,5 @@ where
 
         // Spawn each sender as its own independent task
         Ok((tokio::spawn(builder.send_bundles_in_loop()), send_bundle_tx))
-    }
-
-    fn create_simulator_v0_6<C, E>(
-        &self,
-        provider: Arc<C>,
-        ep: E,
-        mempool_configs: HashMap<H256, MempoolConfig>,
-    ) -> SimulatorV0_6<C, E, SimulateValidationTracerImplV0_6<C, E>>
-    where
-        C: Provider,
-        E: EntryPointProvider<v0_6::UserOperation> + Clone,
-    {
-        let simulate_validation_tracer =
-            SimulateValidationTracerImplV0_6::new(Arc::clone(&provider), ep.clone());
-        SimulatorV0_6::new(
-            Arc::clone(&provider),
-            ep,
-            simulate_validation_tracer,
-            self.args.sim_settings,
-            mempool_configs,
-        )
     }
 }

--- a/crates/pool/src/task.rs
+++ b/crates/pool/src/task.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use ethers::providers::Middleware;
 use rundler_provider::{EntryPointProvider, EthersEntryPointV0_6, EthersEntryPointV0_7, Provider};
 use rundler_sim::{
-    simulation::{v0_6 as sim_v0_6, UnsafeSimulator},
+    simulation::{self, UnsafeSimulator},
     PrecheckerImpl, Simulator,
 };
 use rundler_task::Task;
@@ -208,12 +208,9 @@ impl PoolTask {
                 simulator,
             )
         } else {
-            let simulate_validation_tracer =
-                sim_v0_6::SimulateValidationTracerImpl::new(Arc::clone(&provider), ep.clone());
-            let simulator = sim_v0_6::Simulator::new(
+            let simulator = simulation::new_v0_6_simulator(
                 Arc::clone(&provider),
                 ep.clone(),
-                simulate_validation_tracer,
                 pool_config.sim_settings,
                 pool_config.mempool_channel_configs.clone(),
             );

--- a/crates/sim/src/simulation/context.rs
+++ b/crates/sim/src/simulation/context.rs
@@ -1,0 +1,176 @@
+// This file is part of Rundler.
+//
+// Rundler is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Rundler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Rundler.
+// If not, see https://www.gnu.org/licenses/.
+
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+use anyhow::Context;
+use ethers::types::{Address, BlockId, Opcode, U256};
+use rundler_types::{
+    pool::SimulationViolation, EntityInfo, EntityInfos, EntityType, StakeInfo, UserOperation,
+    ValidationOutput,
+};
+use serde::{Deserialize, Serialize};
+
+use super::Settings;
+use crate::{ExpectedStorage, ViolationError};
+
+#[derive(Clone, Debug)]
+pub struct ValidationContext<UO> {
+    pub(crate) op: UO,
+    pub(crate) block_id: BlockId,
+    pub(crate) entity_infos: EntityInfos,
+    pub(crate) tracer_out: TracerOutput,
+    pub(crate) entry_point_out: ValidationOutput,
+    pub(crate) entities_needing_stake: Vec<EntityType>,
+    pub(crate) accessed_addresses: HashSet<Address>,
+    pub(crate) has_factory: bool,
+    pub(crate) associated_addresses: HashSet<Address>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TracerOutput {
+    pub(crate) phases: Vec<Phase>,
+    pub(crate) revert_data: Option<String>,
+    pub(crate) accessed_contract_addresses: Vec<Address>,
+    pub(crate) associated_slots_by_address: AssociatedSlotsByAddress,
+    pub(crate) factory_called_create2_twice: bool,
+    pub(crate) expected_storage: ExpectedStorage,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Phase {
+    pub(crate) forbidden_opcodes_used: Vec<String>,
+    pub(crate) forbidden_precompiles_used: Vec<String>,
+    pub(crate) storage_accesses: HashMap<Address, AccessInfo>,
+    pub(crate) called_banned_entry_point_method: bool,
+    pub(crate) addresses_calling_with_value: Vec<Address>,
+    pub(crate) called_non_entry_point_with_value: bool,
+    pub(crate) ran_out_of_gas: bool,
+    pub(crate) undeployed_contract_accesses: Vec<Address>,
+    pub(crate) ext_code_access_info: HashMap<Address, Opcode>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct AccessInfo {
+    // slot value, just prior this current operation
+    pub(crate) reads: HashMap<U256, String>,
+    // count of writes.
+    pub(crate) writes: HashMap<U256, u32>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct AssociatedSlotsByAddress(HashMap<Address, BTreeSet<U256>>);
+
+impl AssociatedSlotsByAddress {
+    pub(crate) fn is_associated_slot(&self, address: Address, slot: U256) -> bool {
+        if slot == address.as_bytes().into() {
+            return true;
+        }
+        let Some(associated_slots) = self.0.get(&address) else {
+            return false;
+        };
+        let Some(&next_smallest_slot) = associated_slots.range(..(slot + 1)).next_back() else {
+            return false;
+        };
+        slot - next_smallest_slot < 128.into()
+    }
+
+    pub(crate) fn addresses(&self) -> HashSet<Address> {
+        self.0.clone().into_keys().collect()
+    }
+}
+
+/// Trait for providing the validation context for a user operation.
+#[async_trait::async_trait]
+pub trait ValidationContextProvider: Send + Sync + 'static {
+    /// The user operation type this provider targets.
+    type UO: UserOperation;
+
+    /// Get the validation context for a user operation.
+    async fn get_context(
+        &self,
+        op: Self::UO,
+        block_id: BlockId,
+    ) -> Result<ValidationContext<Self::UO>, ViolationError<SimulationViolation>>;
+
+    /// Get the violations specific to the particular entry point this provider targets.
+    fn get_specific_violations(
+        &self,
+        _context: &ValidationContext<Self::UO>,
+    ) -> Vec<SimulationViolation> {
+        vec![]
+    }
+}
+
+pub(crate) fn entity_type_from_simulation_phase(i: usize) -> Option<EntityType> {
+    match i {
+        0 => Some(EntityType::Factory),
+        1 => Some(EntityType::Account),
+        2 => Some(EntityType::Paymaster),
+        _ => None,
+    }
+}
+
+pub(crate) fn infos_from_validation_output(
+    factory_address: Option<Address>,
+    sender_address: Address,
+    paymaster_address: Option<Address>,
+    entry_point_out: &ValidationOutput,
+    sim_settings: Settings,
+) -> EntityInfos {
+    let factory = factory_address.map(|address| EntityInfo {
+        address,
+        is_staked: is_staked(entry_point_out.factory_info, sim_settings),
+    });
+    let sender = EntityInfo {
+        address: sender_address,
+        is_staked: is_staked(entry_point_out.sender_info, sim_settings),
+    };
+    let paymaster = paymaster_address.map(|address| EntityInfo {
+        address,
+        is_staked: is_staked(entry_point_out.paymaster_info, sim_settings),
+    });
+    let aggregator = entry_point_out
+        .aggregator_info
+        .map(|aggregator_info| EntityInfo {
+            address: aggregator_info.address,
+            is_staked: is_staked(aggregator_info.stake_info, sim_settings),
+        });
+
+    EntityInfos {
+        factory,
+        sender,
+        paymaster,
+        aggregator,
+    }
+}
+
+pub(crate) fn is_staked(info: StakeInfo, sim_settings: Settings) -> bool {
+    info.stake >= sim_settings.min_stake_value.into()
+        && info.unstake_delay_sec >= sim_settings.min_unstake_delay.into()
+}
+
+pub(crate) fn parse_combined_context_str<A, B>(combined: &str) -> anyhow::Result<(A, B)>
+where
+    A: std::str::FromStr,
+    B: std::str::FromStr,
+    <A as std::str::FromStr>::Err: std::error::Error + Send + Sync + 'static,
+    <B as std::str::FromStr>::Err: std::error::Error + Send + Sync + 'static,
+{
+    let (a, b) = combined
+        .split_once(':')
+        .context("tracer combined should contain two parts")?;
+    Ok((a.parse()?, b.parse()?))
+}

--- a/crates/sim/src/simulation/mod.rs
+++ b/crates/sim/src/simulation/mod.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::HashSet;
 
 use anyhow::Error;
 use ethers::types::{Address, H256, U256};
@@ -20,19 +20,23 @@ use mockall::automock;
 use rundler_provider::AggregatorSimOut;
 use rundler_types::{
     pool::{MempoolError, SimulationViolation},
-    Entity, EntityInfo, EntityInfos, EntityType, StakeInfo, UserOperation, ValidTimeRange,
-    ValidationOutput,
+    EntityInfos, EntityType, UserOperation, ValidTimeRange,
 };
-use serde::{Deserialize, Serialize};
 
-/// Simulation module for Entry Point v0.6
-pub mod v0_6;
+mod context;
+pub use context::ValidationContextProvider;
 
 mod mempool;
 pub use mempool::{MempoolConfig, MempoolConfigs};
 
+mod simulator;
+pub use simulator::{new_v0_6_simulator, SimulatorImpl};
+
 mod unsafe_sim;
 pub use unsafe_sim::UnsafeSimulator;
+
+/// Entry Point v0.6 Tracing
+pub mod v0_6;
 
 use crate::{ExpectedStorage, ViolationError};
 
@@ -99,6 +103,15 @@ impl From<Error> for SimulationError {
     }
 }
 
+impl From<ViolationError<SimulationViolation>> for SimulationError {
+    fn from(violation_error: ViolationError<SimulationViolation>) -> Self {
+        SimulationError {
+            violation_error,
+            entity_infos: None,
+        }
+    }
+}
+
 impl From<SimulationError> for MempoolError {
     fn from(mut error: SimulationError) -> Self {
         let SimulationError {
@@ -135,152 +148,6 @@ pub trait Simulator: Send + Sync + 'static {
         block_hash: Option<H256>,
         expected_code_hash: Option<H256>,
     ) -> Result<SimulationResult, SimulationError>;
-}
-
-fn entity_type_from_simulation_phase(i: usize) -> Option<EntityType> {
-    match i {
-        0 => Some(EntityType::Factory),
-        1 => Some(EntityType::Account),
-        2 => Some(EntityType::Paymaster),
-        _ => None,
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum StorageRestriction {
-    /// (Entity needing stake, accessing entity type, accessed entity type, accessed address, accessed slot)
-    NeedsStake(EntityType, EntityType, Option<EntityType>, Address, U256),
-    Banned(U256),
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct AccessInfo {
-    // slot value, just prior this current operation
-    pub(crate) reads: HashMap<U256, String>,
-    // count of writes.
-    pub(crate) writes: HashMap<U256, u32>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub(crate) struct AssociatedSlotsByAddress(HashMap<Address, BTreeSet<U256>>);
-
-impl AssociatedSlotsByAddress {
-    pub(crate) fn is_associated_slot(&self, address: Address, slot: U256) -> bool {
-        if slot == address.as_bytes().into() {
-            return true;
-        }
-        let Some(associated_slots) = self.0.get(&address) else {
-            return false;
-        };
-        let Some(&next_smallest_slot) = associated_slots.range(..(slot + 1)).next_back() else {
-            return false;
-        };
-        slot - next_smallest_slot < 128.into()
-    }
-
-    pub(crate) fn addresses(&self) -> HashSet<Address> {
-        self.0.clone().into_keys().collect()
-    }
-}
-
-#[derive(Clone, Debug)]
-struct ParseStorageAccess<'a> {
-    access_info: &'a AccessInfo,
-    slots_by_address: &'a AssociatedSlotsByAddress,
-    address: Address,
-    sender: Address,
-    entrypoint: Address,
-    has_factory: bool,
-    entity: &'a Entity,
-}
-
-fn parse_storage_accesses(args: ParseStorageAccess<'_>) -> Result<Vec<StorageRestriction>, Error> {
-    let ParseStorageAccess {
-        access_info,
-        address,
-        sender,
-        entrypoint,
-        entity,
-        slots_by_address,
-        has_factory,
-        ..
-    } = args;
-
-    let mut restrictions = vec![];
-
-    // STO-010 - always allowed to access storage on the account
-    // [OP-051, OP-054] - block access to the entrypoint, except for depositTo and fallback
-    //   - this is handled at another level, so we don't need to check for it here
-    //   - at this level we can allow any entry point access through
-    if address.eq(&sender) || address.eq(&entrypoint) {
-        return Ok(restrictions);
-    }
-
-    let slots: Vec<&U256> = access_info
-        .reads
-        .keys()
-        .chain(access_info.writes.keys())
-        .collect();
-
-    for slot in slots {
-        let is_sender_associated = slots_by_address.is_associated_slot(sender, *slot);
-        // [STO-032]
-        let is_entity_associated = slots_by_address.is_associated_slot(entity.address, *slot);
-        // [STO-031]
-        let is_same_address = address.eq(&entity.address);
-        // [STO-033]
-        let is_read_permission = !access_info.writes.contains_key(slot);
-
-        // STO-021 - Associated storage on external contracts is allowed
-        if is_sender_associated && !is_same_address {
-            // STO-022 - Factory must be staked to access associated storage in a deploy
-            if has_factory {
-                match entity.kind {
-                    EntityType::Paymaster | EntityType::Aggregator => {
-                        // If its a paymaster/aggregator, then the entity must be staked to access associated storage
-                        // during a deploy
-                        restrictions.push(StorageRestriction::NeedsStake(
-                            entity.kind,
-                            entity.kind,
-                            Some(EntityType::Account),
-                            address,
-                            *slot,
-                        ));
-                    }
-                    EntityType::Account | EntityType::Factory => {
-                        restrictions.push(StorageRestriction::NeedsStake(
-                            EntityType::Factory,
-                            entity.kind,
-                            Some(EntityType::Account),
-                            address,
-                            *slot,
-                        ));
-                    }
-                }
-            }
-        } else if is_entity_associated || is_same_address {
-            restrictions.push(StorageRestriction::NeedsStake(
-                entity.kind,
-                entity.kind,
-                Some(entity.kind),
-                address,
-                *slot,
-            ));
-        } else if is_read_permission {
-            restrictions.push(StorageRestriction::NeedsStake(
-                entity.kind,
-                entity.kind,
-                None,
-                address,
-                *slot,
-            ));
-        } else {
-            restrictions.push(StorageRestriction::Banned(*slot));
-        }
-    }
-
-    Ok(restrictions)
 }
 
 /// Simulation Settings
@@ -328,61 +195,4 @@ impl Default for Settings {
             max_verification_gas: 5_000_000,
         }
     }
-}
-
-fn override_is_staked(ei: &mut EntityInfo, allow_unstaked_addresses: &HashSet<Address>) {
-    ei.is_staked = allow_unstaked_addresses.contains(&ei.address) || ei.is_staked;
-}
-
-fn override_infos_staked(eis: &mut EntityInfos, allow_unstaked_addresses: &HashSet<Address>) {
-    override_is_staked(&mut eis.sender, allow_unstaked_addresses);
-
-    if let Some(mut factory) = eis.factory {
-        override_is_staked(&mut factory, allow_unstaked_addresses);
-    }
-    if let Some(mut paymaster) = eis.paymaster {
-        override_is_staked(&mut paymaster, allow_unstaked_addresses);
-    }
-    if let Some(mut aggregator) = eis.aggregator {
-        override_is_staked(&mut aggregator, allow_unstaked_addresses);
-    }
-}
-
-fn infos_from_validation_output(
-    factory_address: Option<Address>,
-    sender_address: Address,
-    paymaster_address: Option<Address>,
-    entry_point_out: &ValidationOutput,
-    sim_settings: Settings,
-) -> EntityInfos {
-    let factory = factory_address.map(|address| EntityInfo {
-        address,
-        is_staked: is_staked(entry_point_out.factory_info, sim_settings),
-    });
-    let sender = EntityInfo {
-        address: sender_address,
-        is_staked: is_staked(entry_point_out.sender_info, sim_settings),
-    };
-    let paymaster = paymaster_address.map(|address| EntityInfo {
-        address,
-        is_staked: is_staked(entry_point_out.paymaster_info, sim_settings),
-    });
-    let aggregator = entry_point_out
-        .aggregator_info
-        .map(|aggregator_info| EntityInfo {
-            address: aggregator_info.address,
-            is_staked: is_staked(aggregator_info.stake_info, sim_settings),
-        });
-
-    EntityInfos {
-        factory,
-        sender,
-        paymaster,
-        aggregator,
-    }
-}
-
-pub(crate) fn is_staked(info: StakeInfo, sim_settings: Settings) -> bool {
-    info.stake >= sim_settings.min_stake_value.into()
-        && info.unstake_delay_sec >= sim_settings.min_unstake_delay.into()
 }

--- a/crates/sim/src/simulation/v0_6/context.rs
+++ b/crates/sim/src/simulation/v0_6/context.rs
@@ -1,0 +1,337 @@
+// This file is part of Rundler.
+//
+// Rundler is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Rundler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Rundler.
+// If not, see https://www.gnu.org/licenses/.
+
+use std::{collections::HashSet, sync::Arc};
+
+use ethers::{abi::AbiDecode, types::BlockId};
+use rundler_provider::{Provider, SimulationProvider};
+use rundler_types::{
+    contracts::v0_6::i_entry_point::FailedOp, pool::SimulationViolation, v0_6::UserOperation,
+    EntityType, UserOperation as UserOperationTrait, ValidationOutput,
+};
+
+use super::{
+    tracer::{SimulateValidationTracer, SimulateValidationTracerImpl},
+    REQUIRED_VERIFICATION_GAS_LIMIT_BUFFER,
+};
+use crate::{
+    simulation::context::{
+        self as sim_context, ValidationContext,
+        ValidationContextProvider as ValidationContextProviderTrait,
+    },
+    SimulationSettings, ViolationError,
+};
+
+/// A provider for creating `ValidationContext` for entry point v0.6.
+pub(crate) struct ValidationContextProvider<T> {
+    simulate_validation_tracer: T,
+    sim_settings: SimulationSettings,
+}
+
+#[async_trait::async_trait]
+impl<T> ValidationContextProviderTrait for ValidationContextProvider<T>
+where
+    T: SimulateValidationTracer,
+{
+    type UO = UserOperation;
+
+    async fn get_context(
+        &self,
+        op: Self::UO,
+        block_id: BlockId,
+    ) -> Result<ValidationContext<Self::UO>, ViolationError<SimulationViolation>> {
+        let factory_address = op.factory();
+        let sender_address = op.sender;
+        let paymaster_address = op.paymaster();
+        let tracer_out = self
+            .simulate_validation_tracer
+            .trace_simulate_validation(op.clone(), block_id, self.sim_settings.max_verification_gas)
+            .await?;
+        let num_phases = tracer_out.phases.len() as u32;
+        // Check if there are too many phases here, then check too few at the
+        // end. We are detecting cases where the entry point is broken. Too many
+        // phases definitely means it's broken, but too few phases could still
+        // mean the entry point is fine if one of the phases fails and it
+        // doesn't reach the end of execution.
+        if num_phases > 3 {
+            Err(ViolationError::Violations(vec![
+                SimulationViolation::WrongNumberOfPhases(num_phases),
+            ]))?
+        }
+        let Some(ref revert_data) = tracer_out.revert_data else {
+            Err(ViolationError::Violations(vec![
+                SimulationViolation::DidNotRevert,
+            ]))?
+        };
+        let last_entity_type =
+            sim_context::entity_type_from_simulation_phase(tracer_out.phases.len() - 1).unwrap();
+
+        if let Ok(failed_op) = FailedOp::decode_hex(revert_data) {
+            let entity_addr = match last_entity_type {
+                EntityType::Factory => factory_address,
+                EntityType::Paymaster => paymaster_address,
+                EntityType::Account => Some(sender_address),
+                _ => None,
+            };
+            Err(ViolationError::Violations(vec![
+                SimulationViolation::UnintendedRevertWithMessage(
+                    last_entity_type,
+                    failed_op.reason,
+                    entity_addr,
+                ),
+            ]))?
+        }
+        let Ok(entry_point_out) = ValidationOutput::decode_v0_6_hex(revert_data) else {
+            let entity_addr = match last_entity_type {
+                EntityType::Factory => factory_address,
+                EntityType::Paymaster => paymaster_address,
+                EntityType::Account => Some(sender_address),
+                _ => None,
+            };
+            Err(ViolationError::Violations(vec![
+                SimulationViolation::UnintendedRevert(last_entity_type, entity_addr),
+            ]))?
+        };
+        let entity_infos = sim_context::infos_from_validation_output(
+            factory_address,
+            sender_address,
+            paymaster_address,
+            &entry_point_out,
+            self.sim_settings,
+        );
+        if num_phases < 3 {
+            Err(ViolationError::Violations(vec![
+                SimulationViolation::WrongNumberOfPhases(num_phases),
+            ]))?
+        }
+
+        let associated_addresses = tracer_out.associated_slots_by_address.addresses();
+        let has_factory = op.factory().is_some();
+        Ok(ValidationContext {
+            op,
+            block_id,
+            entity_infos,
+            tracer_out,
+            entry_point_out,
+            associated_addresses,
+            entities_needing_stake: vec![],
+            accessed_addresses: HashSet::new(),
+            has_factory,
+        })
+    }
+
+    fn get_specific_violations(
+        &self,
+        context: &ValidationContext<Self::UO>,
+    ) -> Vec<SimulationViolation> {
+        let mut violations = vec![];
+
+        let &ValidationContext {
+            entry_point_out,
+            op,
+            ..
+        } = &context;
+
+        // v0.6 doesn't distinguish between the different types of signature failures
+        // both of these will be set to true if the signature failed.
+        if entry_point_out.return_info.account_sig_failed
+            || entry_point_out.return_info.paymaster_sig_failed
+        {
+            violations.push(SimulationViolation::InvalidSignature);
+        }
+
+        // This is a special case to cover a bug in the 0.6 entrypoint contract where a specially
+        // crafted UO can use extra verification gas that isn't caught during simulation, but when
+        // it runs on chain causes the transaction to revert.
+        let verification_gas_used = entry_point_out
+            .return_info
+            .pre_op_gas
+            .saturating_sub(op.pre_verification_gas());
+        let verification_buffer = op
+            .total_verification_gas_limit()
+            .saturating_sub(verification_gas_used);
+        if verification_buffer < REQUIRED_VERIFICATION_GAS_LIMIT_BUFFER {
+            violations.push(SimulationViolation::VerificationGasLimitBufferTooLow(
+                op.total_verification_gas_limit(),
+                verification_gas_used + REQUIRED_VERIFICATION_GAS_LIMIT_BUFFER,
+            ));
+        }
+
+        violations
+    }
+}
+
+impl<P, E> ValidationContextProvider<SimulateValidationTracerImpl<P, E>>
+where
+    P: Provider,
+    E: SimulationProvider<UO = UserOperation>,
+{
+    /// Creates a new `ValidationContextProvider` for entry point v0.6 with the given provider and entry point.
+    pub(crate) fn new(provider: Arc<P>, entry_point: E, sim_settings: SimulationSettings) -> Self {
+        Self {
+            simulate_validation_tracer: SimulateValidationTracerImpl::new(provider, entry_point),
+            sim_settings,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, str::FromStr};
+
+    use ethers::{
+        abi::AbiEncode,
+        types::{Address, Bytes, U256},
+        utils::hex,
+    };
+    use rundler_types::{contracts::v0_6::i_entry_point::FailedOp, v0_6::UserOperation};
+
+    use super::*;
+    use crate::simulation::context::{Phase, TracerOutput};
+
+    fn get_test_tracer_output() -> TracerOutput {
+        TracerOutput {
+            accessed_contract_addresses: vec![
+                Address::from_str("0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789").unwrap(),
+                Address::from_str("0xb856dbd4fa1a79a46d426f537455e7d3e79ab7c4").unwrap(),
+                Address::from_str("0x8abb13360b87be5eeb1b98647a016add927a136c").unwrap(),
+            ],
+            associated_slots_by_address: serde_json::from_str(r#"
+            {
+                "0x0000000000000000000000000000000000000000": [
+                    "0xd5c1ebdd81c5c7bebcd52bc11c8d37f7038b3c64f849c2ca58a022abeab1adae",
+                    "0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5"
+                ],
+                "0xb856dbd4fa1a79a46d426f537455e7d3e79ab7c4": [
+                    "0x3072884cc37d411af7360b34f105e1e860b1631783232a4f2d5c094d365cdaab",
+                    "0xf5357e1da3acf909ceaed3492183cbad85a3c9e1f0076495f66d3eed05219bd5",
+                    "0xf264fff4db20d04721712f34a6b5a8bca69a212345e40a92101082e79bdd1f0a"
+                ]
+            }
+            "#).unwrap(),
+            factory_called_create2_twice: false,
+            expected_storage: serde_json::from_str(r#"
+            {
+                "0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789": {
+                    "0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb6": "0x0000000000000000000000000000000000000000000000000000000000000000"
+                }
+            }
+            "#).unwrap(),
+            phases: vec![
+                Phase {
+                    addresses_calling_with_value: vec![],
+                    called_banned_entry_point_method: false,
+                    called_non_entry_point_with_value: false,
+                    forbidden_opcodes_used: vec![],
+                    forbidden_precompiles_used: vec![],
+                    ran_out_of_gas: false,
+                    storage_accesses: HashMap::new(),
+                    undeployed_contract_accesses: vec![],
+                    ext_code_access_info: HashMap::new(),
+                },
+                Phase {
+                    addresses_calling_with_value: vec![Address::from_str("0xb856dbd4fa1a79a46d426f537455e7d3e79ab7c4").unwrap()],
+                    called_banned_entry_point_method: false,
+                    called_non_entry_point_with_value: false,
+                    forbidden_opcodes_used: vec![],
+                    forbidden_precompiles_used: vec![],
+                    ran_out_of_gas: false,
+                    storage_accesses:  HashMap::new(),
+                    undeployed_contract_accesses: vec![],
+                    ext_code_access_info: HashMap::new(),
+                },
+                Phase {
+                    addresses_calling_with_value: vec![],
+                    called_banned_entry_point_method: false,
+                    called_non_entry_point_with_value: false,
+                    forbidden_opcodes_used: vec![],
+                    forbidden_precompiles_used: vec![],
+                    ran_out_of_gas: false,
+                    storage_accesses: HashMap::new(),
+                    undeployed_contract_accesses: vec![],
+                    ext_code_access_info: HashMap::new(),
+                }
+            ],
+            revert_data: Some("0xe0cff05f00000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000014eff00000000000000000000000000000000000000000000000000000b7679c50c24000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffff00000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000000".into()),
+        }
+    }
+
+    mockall::mock! {
+        Tracer {}
+
+        #[async_trait::async_trait]
+        impl SimulateValidationTracer for Tracer {
+            async fn trace_simulate_validation(
+                &self,
+                op: UserOperation,
+                block_id: BlockId,
+                max_validation_gas: u64,
+            ) -> anyhow::Result<TracerOutput>;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_context_two_phases_unintended_revert() {
+        let mut tracer = MockTracer::new();
+
+        tracer
+            .expect_trace_simulate_validation()
+            .returning(|_, _, _| {
+                let mut tracer_output = get_test_tracer_output();
+                tracer_output.revert_data = Some(hex::encode(
+                    FailedOp {
+                        op_index: U256::from(100),
+                        reason: "AA23 reverted (or OOG)".to_string(),
+                    }
+                    .encode(),
+                ));
+                Ok(tracer_output)
+            });
+
+        let user_operation = UserOperation {
+            sender: Address::from_str("b856dbd4fa1a79a46d426f537455e7d3e79ab7c4").unwrap(),
+            nonce: U256::from(264),
+            init_code: Bytes::from_str("0x").unwrap(),
+            call_data: Bytes::from_str("0xb61d27f6000000000000000000000000b856dbd4fa1a79a46d426f537455e7d3e79ab7c4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000004d087d28800000000000000000000000000000000000000000000000000000000").unwrap(),
+            call_gas_limit: U256::from(9100),
+            verification_gas_limit: U256::from(64805),
+            pre_verification_gas: U256::from(46128),
+            max_fee_per_gas: U256::from(105000100),
+            max_priority_fee_per_gas: U256::from(105000000),
+            paymaster_and_data: Bytes::from_str("0x").unwrap(),
+            signature: Bytes::from_str("0x98f89993ce573172635b44ef3b0741bd0c19dd06909d3539159f6d66bef8c0945550cc858b1cf5921dfce0986605097ba34c2cf3fc279154dd25e161ea7b3d0f1c").unwrap(),
+        };
+
+        let context = ValidationContextProvider {
+            simulate_validation_tracer: tracer,
+            sim_settings: Default::default(),
+        };
+
+        let res = context
+            .get_context(user_operation.clone(), BlockId::Number(0.into()))
+            .await;
+
+        assert!(matches!(
+            res,
+            Err(ViolationError::Violations(violations)) if matches!(
+                violations.first(),
+                Some(&SimulationViolation::UnintendedRevertWithMessage(
+                    EntityType::Paymaster,
+                    ref reason,
+                    _
+                )) if reason == "AA23 reverted (or OOG)"
+            )
+        ));
+    }
+}

--- a/crates/sim/src/simulation/v0_6/mod.rs
+++ b/crates/sim/src/simulation/v0_6/mod.rs
@@ -13,11 +13,10 @@
 
 use ethers::types::U256;
 
-mod simulator;
-pub use simulator::Simulator;
+mod context;
+pub(crate) use context::ValidationContextProvider;
 
 mod tracer;
-pub use tracer::{SimulateValidationTracer, SimulateValidationTracerImpl};
 
 /// Required buffer for verification gas limit when targeting the 0.6 entrypoint contract
 pub(crate) const REQUIRED_VERIFICATION_GAS_LIMIT_BUFFER: U256 = U256([2000, 0, 0, 0]);

--- a/crates/types/src/validation_results.rs
+++ b/crates/types/src/validation_results.rs
@@ -63,7 +63,7 @@ pub enum ValidationError {
 /// Equivalent to the generated `ValidationResult` or
 /// `ValidationResultWithAggregation` from `EntryPoint`, but with named structs
 /// instead of tuples and with a helper for deserializing.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ValidationOutput {
     /// The return info from the validation function
     pub return_info: ValidationReturnInfo,
@@ -174,7 +174,7 @@ impl From<ValidationResultV0_7> for ValidationOutput {
 }
 
 /// ValidationReturnInfo from EntryPoint contract
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ValidationReturnInfo {
     /// The amount of gas used before the op was executed (pre verification gas and validation gas)
     pub pre_op_gas: U256,


### PR DESCRIPTION
## Proposed Changes

  - Refactor tracing and context providing from simulation
  - Introduce a `ValidationContextProvider` trait.
  - This trait can be implemented for both v0.6 and v0.7 to surface all of the tracing information needed to compile the simulation violations.
  - The `ValidationContext` result is likely to change when v0.7 is implemented, but wanted to do this refactor first to limit the diff.
  - The trait also exposes a `get_specific_violations` function for any entry point specific logic (likely only to be used for v0.6)
