### PR TITLE
fix(sim): use H256 instead of U256 for expected storage

### DIFF
--- a/crates/sim/src/estimation/v0_7.rs
+++ b/crates/sim/src/estimation/v0_7.rs
@@ -65,7 +65,7 @@ where
         Ok(GasEstimate {
             pre_verification_gas,
             call_gas_limit: 100_000.into(),
-            verification_gas_limit: 100_000.into(),
+            verification_gas_limit: 500_000.into(),
             paymaster_verification_gas_limit: op.paymaster.map(|_| 100_000.into()),
             paymaster_post_op_gas_limit: op.paymaster.map(|_| 100_000.into()),
         })

--- a/crates/sim/src/types.rs
+++ b/crates/sim/src/types.rs
@@ -14,13 +14,13 @@
 use std::collections::{btree_map, BTreeMap};
 
 use anyhow::bail;
-use ethers::types::{Address, U256};
+use ethers::types::{Address, H256, U256};
 use serde::{Deserialize, Serialize};
 
 /// The expected storage values for a user operation that must
 /// be checked to determine if this operation is valid.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct ExpectedStorage(pub BTreeMap<Address, BTreeMap<U256, U256>>);
+pub struct ExpectedStorage(pub BTreeMap<Address, BTreeMap<H256, H256>>);
 
 impl ExpectedStorage {
     /// Merge this expected storage with another one, accounting for conflicts.
@@ -45,6 +45,17 @@ impl ExpectedStorage {
             }
         }
         Ok(())
+    }
+
+    /// Insert a new storage slot value for a given address.
+    pub fn insert(&mut self, address: Address, slot: U256, value: U256) {
+        let buf: [u8; 32] = slot.into();
+        let slot = H256::from_slice(&buf);
+
+        let buf: [u8; 32] = value.into();
+        let value = H256::from_slice(&buf);
+
+        self.0.entry(address).or_default().insert(slot, value);
     }
 }
 

--- a/crates/types/src/validation_results.rs
+++ b/crates/types/src/validation_results.rs
@@ -276,11 +276,11 @@ pub fn parse_validation_data(data: U256) -> ValidationData {
     let slice: [u8; 32] = data.into();
     let aggregator = Address::from_slice(&slice[12..]);
 
-    let mut buf = [0_u8; 8];
+    let mut buf = [0; 8];
     buf[2..8].copy_from_slice(&slice[6..12]);
     let valid_until = u64::from_be_bytes(buf);
 
-    let mut buf = [0_u8; 8];
+    let mut buf = [0; 8];
     buf[2..8].copy_from_slice(&slice[..6]);
     let valid_after = u64::from_be_bytes(buf);
 


### PR DESCRIPTION
## Proposed Changes

  - A previous change moved this erroneously to U256 for v0.7, move it back and provide a simple insert function.
