### PR TITLE
feat(rpc): return validation revert data from rpc

### DIFF
--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -751,8 +751,9 @@ message EntryPointRevert {
   string reason = 1;
 }
 message OperationRevert {
-  string reason = 1;
-  bytes revert_bytes = 2;
+  string entry_point_reason = 1;
+  bytes inner_revert_data = 2;
+  string inner_revert_reason = 3;
 }
 message UnknownRevert {
   bytes revert_bytes = 1;

--- a/crates/pool/src/server/remote/error.rs
+++ b/crates/pool/src/server/remote/error.rs
@@ -798,12 +798,15 @@ impl From<ValidationRevert> for ProtoValidationRevert {
             ValidationRevert::EntryPoint(reason) => {
                 validation_revert::Revert::EntryPoint(EntryPointRevert { reason })
             }
-            ValidationRevert::Operation(reason, revert_bytes) => {
-                validation_revert::Revert::Operation(OperationRevert {
-                    reason,
-                    revert_bytes: revert_bytes.to_vec(),
-                })
-            }
+            ValidationRevert::Operation {
+                entry_point_reason,
+                inner_revert_data,
+                inner_revert_reason,
+            } => validation_revert::Revert::Operation(OperationRevert {
+                entry_point_reason,
+                inner_revert_data: inner_revert_data.to_vec(),
+                inner_revert_reason: inner_revert_reason.unwrap_or_default(),
+            }),
             ValidationRevert::Unknown(revert_bytes) => {
                 validation_revert::Revert::Unknown(UnknownRevert {
                     revert_bytes: revert_bytes.to_vec(),
@@ -824,9 +827,11 @@ impl TryFrom<ProtoValidationRevert> for ValidationRevert {
             Some(validation_revert::Revert::EntryPoint(e)) => {
                 ValidationRevert::EntryPoint(e.reason)
             }
-            Some(validation_revert::Revert::Operation(e)) => {
-                ValidationRevert::Operation(e.reason, e.revert_bytes.into())
-            }
+            Some(validation_revert::Revert::Operation(e)) => ValidationRevert::Operation {
+                entry_point_reason: e.entry_point_reason,
+                inner_revert_data: e.inner_revert_data.into(),
+                inner_revert_reason: Some(e.inner_revert_reason).filter(|s| !s.is_empty()),
+            },
             Some(validation_revert::Revert::Unknown(e)) => {
                 ValidationRevert::Unknown(e.revert_bytes.into())
             }

--- a/crates/provider/src/traits/entry_point.rs
+++ b/crates/provider/src/traits/entry_point.rs
@@ -16,6 +16,7 @@ use ethers::types::{
 };
 use rundler_types::{
     GasFees, Timestamp, UserOperation, UserOpsPerAggregator, ValidationError, ValidationOutput,
+    ValidationRevert,
 };
 
 /// Output of a successful signature aggregator simulation call
@@ -221,13 +222,13 @@ pub trait SimulationProvider: Send + Sync + 'static {
         block_hash: H256,
         gas: U256,
         spoofed_state: &spoof::State,
-    ) -> anyhow::Result<Result<ExecutionResult, String>>;
+    ) -> anyhow::Result<Result<ExecutionResult, ValidationRevert>>;
 
     /// Decode the revert data from a call to `simulateHandleOps`
     fn decode_simulate_handle_ops_revert(
         &self,
         revert_data: Bytes,
-    ) -> Result<ExecutionResult, String>;
+    ) -> Result<ExecutionResult, ValidationRevert>;
 
     /// Returns true if this entry point uses reverts to communicate simulation
     /// results.

--- a/crates/provider/src/traits/test_utils.rs
+++ b/crates/provider/src/traits/test_utils.rs
@@ -14,7 +14,9 @@
 use ethers::types::{
     spoof, transaction::eip2718::TypedTransaction, Address, BlockId, Bytes, H256, U256,
 };
-use rundler_types::{v0_6, v0_7, GasFees, UserOpsPerAggregator, ValidationError, ValidationOutput};
+use rundler_types::{
+    v0_6, v0_7, GasFees, UserOpsPerAggregator, ValidationError, ValidationOutput, ValidationRevert,
+};
 
 use crate::{
     AggregatorOut, BundleHandler, DepositInfo, EntryPoint, ExecutionResult, HandleOpsOut,
@@ -76,11 +78,11 @@ mockall::mock! {
             block_hash: H256,
             gas: U256,
             spoofed_state: &spoof::State,
-        ) -> anyhow::Result<Result<ExecutionResult, String>>;
+        ) -> anyhow::Result<Result<ExecutionResult, ValidationRevert>>;
         fn decode_simulate_handle_ops_revert(
             &self,
             revert_data: Bytes,
-        ) -> Result<ExecutionResult, String>;
+        ) -> Result<ExecutionResult, ValidationRevert>;
         fn simulation_should_revert(&self) -> bool;
     }
 
@@ -169,11 +171,11 @@ mockall::mock! {
             block_hash: H256,
             gas: U256,
             spoofed_state: &spoof::State,
-        ) -> anyhow::Result<Result<ExecutionResult, String>>;
+        ) -> anyhow::Result<Result<ExecutionResult, ValidationRevert>>;
         fn decode_simulate_handle_ops_revert(
             &self,
             revert_data: Bytes,
-        ) -> Result<ExecutionResult, String>;
+        ) -> Result<ExecutionResult, ValidationRevert>;
         fn simulation_should_revert(&self) -> bool;
     }
 

--- a/crates/sim/src/estimation/mod.rs
+++ b/crates/sim/src/estimation/mod.rs
@@ -14,7 +14,7 @@
 use ethers::types::{Bytes, U256};
 #[cfg(feature = "test-utils")]
 use mockall::automock;
-use rundler_types::GasEstimate;
+use rundler_types::{GasEstimate, ValidationRevert};
 
 use crate::precheck::MIN_CALL_GAS_LIMIT;
 
@@ -31,15 +31,21 @@ pub use v0_7::GasEstimator as GasEstimatorV0_7;
 /// Error type for gas estimation
 #[derive(Debug, thiserror::Error)]
 pub enum GasEstimationError {
+    /// Gas estimation was given an invalid settings struct
+    #[error("{0}")]
+    InvalidSettings(String),
     /// Validation reverted
     #[error("{0}")]
-    RevertInValidation(String),
+    RevertInValidation(ValidationRevert),
     /// Call reverted with a string message
     #[error("user operation's call reverted: {0}")]
     RevertInCallWithMessage(String),
     /// Call reverted with bytes
     #[error("user operation's call reverted: {0:#x}")]
     RevertInCallWithBytes(Bytes),
+    /// Call used too much gas
+    #[error("gas_used cannot be larger than a u64 integer")]
+    GasUsedTooLarge,
     /// Other error
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/crates/sim/src/estimation/v0_6.rs
+++ b/crates/sim/src/estimation/v0_6.rs
@@ -126,7 +126,7 @@ where
         let call_gas_limit = call_gas_limit?;
 
         if let Some(err) = settings.validate() {
-            return Err(GasEstimationError::RevertInValidation(err));
+            return Err(GasEstimationError::InvalidSettings(err));
         }
 
         // Add a buffer to the verification gas limit. Add 10% or 2000 gas, whichever is larger
@@ -267,7 +267,7 @@ where
                     &state_override,
                 )
                 .await?
-                .map_err(GasEstimationError::RevertInCallWithMessage)?
+                .map_err(GasEstimationError::RevertInValidation)?
                 .target_result;
             if let Ok(result) = EstimateCallGasResult::decode(&target_revert_data) {
                 num_rounds += result.num_rounds;
@@ -350,7 +350,7 @@ mod tests {
         chain::L1GasOracleContractType,
         contracts::{utils::get_gas_used::GasUsedResult, v0_6::i_entry_point},
         v0_6::{UserOperation, UserOperationOptionalGas},
-        UserOperation as UserOperationTrait,
+        UserOperation as UserOperationTrait, ValidationRevert,
     };
 
     use super::*;
@@ -665,7 +665,7 @@ mod tests {
             .expect_call_spoofed_simulate_op()
             .returning(move |op, _b, _c, _d, _e, _f| {
                 if op.total_verification_gas_limit() < gas_usage {
-                    return Ok(Err("AA23".to_string()));
+                    return Ok(Err(ValidationRevert::EntryPoint("AA23".to_string())));
                 }
 
                 Ok(Ok(ExecutionResult {
@@ -755,7 +755,7 @@ mod tests {
 
         assert!(matches!(
             estimation,
-            Some(GasEstimationError::RevertInValidation(..))
+            Some(GasEstimationError::GasUsedTooLarge)
         ));
     }
 
@@ -820,7 +820,11 @@ mod tests {
         // checking for this simulated revert
         entry
             .expect_decode_simulate_handle_ops_revert()
-            .returning(|_a| Err(String::from("Error with reverted message")));
+            .returning(|_a| {
+                Err(ValidationRevert::EntryPoint(
+                    "Error with reverted message".to_string(),
+                ))
+            });
         entry
             .expect_call_spoofed_simulate_op()
             .returning(|_a, _b, _c, _d, _e, _f| {
@@ -1088,7 +1092,7 @@ mod tests {
             .expect_call_spoofed_simulate_op()
             .returning(move |op, _b, _c, _d, _e, _f| {
                 if op.total_verification_gas_limit() < gas_usage {
-                    return Ok(Err("AA23".to_string()));
+                    return Ok(Err(ValidationRevert::EntryPoint("AA23".to_string())));
                 }
 
                 Ok(Ok(ExecutionResult {
@@ -1242,7 +1246,7 @@ mod tests {
 
         assert!(matches!(
             estimation,
-            Some(GasEstimationError::RevertInValidation(..))
+            Some(GasEstimationError::InvalidSettings(..))
         ));
     }
 }


### PR DESCRIPTION
When validation fails in 0.7 in either simulation or gas estimation, the entry point now surfaces the inner revert which caused validation to fail. Surface this in the error response in the rpc, using the `data` field to return an object with the fields:

- `entry_point_reason`: the entry point string like "AA99 some failure". This is the only field populated in v0.6.
- `inner_revert_bytes`: the raw bytes of the inner revert message.
- `inner_revert_reason`: if the inner revert is caused by a Solidity `require` or `assert`, then the string message provided to it.
