### PR TITLE
chore(simulation): remove postop gas estimates

### DIFF
--- a/crates/rpc/src/types/mod.rs
+++ b/crates/rpc/src/types/mod.rs
@@ -167,7 +167,6 @@ pub(crate) struct RpcGasEstimate {
     call_gas_limit: U256,
     verification_gas_limit: U256,
     paymaster_verification_gas_limit: Option<U256>,
-    paymaster_post_op_gas_limit: Option<U256>,
 }
 
 impl From<GasEstimate> for RpcGasEstimate {
@@ -177,7 +176,6 @@ impl From<GasEstimate> for RpcGasEstimate {
             call_gas_limit: estimate.call_gas_limit,
             verification_gas_limit: estimate.verification_gas_limit,
             paymaster_verification_gas_limit: estimate.paymaster_verification_gas_limit,
-            paymaster_post_op_gas_limit: estimate.paymaster_post_op_gas_limit,
         }
     }
 }

--- a/crates/sim/src/estimation/v0_6.rs
+++ b/crates/sim/src/estimation/v0_6.rs
@@ -147,7 +147,6 @@ where
             verification_gas_limit,
             call_gas_limit,
             paymaster_verification_gas_limit: None,
-            paymaster_post_op_gas_limit: None,
         })
     }
 }

--- a/crates/sim/src/estimation/v0_7.rs
+++ b/crates/sim/src/estimation/v0_7.rs
@@ -108,7 +108,6 @@ where
             paymaster_verification_gas_limit: op
                 .paymaster
                 .map(|_| paymaster_verification_gas_limit),
-            paymaster_post_op_gas_limit: op.paymaster.map(|_| 1_000_000.into()),
         })
     }
 }

--- a/crates/types/src/user_operation/mod.rs
+++ b/crates/types/src/user_operation/mod.rs
@@ -332,12 +332,6 @@ pub struct GasEstimate {
     ///
     /// v0.7: populated only if the user operation has a paymaster
     pub paymaster_verification_gas_limit: Option<U256>,
-    /// Paymaster post op gas limit
-    ///
-    /// v0.6: unused
-    ///
-    /// v0.7: populated only if the user operation has a paymaster
-    pub paymaster_post_op_gas_limit: Option<U256>,
 }
 
 /// User operations per aggregator


### PR DESCRIPTION
We don't have a reasonable way to compute these and they are soon getting removed in an update to ERC-4337.