### PR TITLE
fix(sim): use same method for expected storage in v0.7 from v0.6 tracer

### DIFF
--- a/crates/sim/src/simulation/v0_7/tracer.rs
+++ b/crates/sim/src/simulation/v0_7/tracer.rs
@@ -22,6 +22,8 @@ use rundler_provider::{Provider, SimulationProvider};
 use rundler_types::v0_7::UserOperation;
 use serde::Deserialize;
 
+use crate::ExpectedStorage;
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(unused)]
@@ -29,6 +31,7 @@ pub(super) struct TracerOutput {
     pub(super) calls_from_entry_point: Vec<TopLevelCallInfo>,
     pub(super) keccak: Vec<String>,
     pub(super) calls: Vec<CallInfo>,
+    pub(super) expected_storage: ExpectedStorage,
     pub(super) logs: Vec<LogInfo>,
     pub(super) debug: Option<Vec<String>>,
 }


### PR DESCRIPTION
## Proposed Changes

  - The reference tracer tracks reads/writes within top level calls, not globally. This led to bugs when the factory would write to some slot and then the account would read it (i.e. a deploy). Our existing approach would capture the account read as an expected slot, and fail to send the bundle.
  - The fix uses the same approach from the v0.6 tracer to capture global accesses, only returning slots that were first read.
