### PR TITLE
feat(rpc): return internal errors and increment metric on panic

### DIFF
--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -11,21 +11,22 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
+use anyhow::Context;
 use async_trait::async_trait;
 use ethers::types::{Address, H256};
 use futures_util::StreamExt;
-use jsonrpsee::{core::RpcResult, proc_macros::rpc, types::error::INTERNAL_ERROR_CODE};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use rundler_types::{
     builder::{Builder, BundlingMode},
     pool::Pool,
 };
 
 use crate::{
-    error::rpc_err,
     types::{
         RpcDebugPaymasterBalance, RpcReputationInput, RpcReputationOutput, RpcStakeInfo,
         RpcStakeStatus, RpcUserOperation,
     },
+    utils::{self, InternalRpcResult},
 };
 
 /// Debug API
@@ -102,48 +103,138 @@ where
     B: Builder,
 {
     async fn bundler_clear_state(&self) -> RpcResult<String> {
-        let _ = self
-            .pool
-            .debug_clear_state(true, true, true)
+        utils::safe_call_rpc_handler("bundler_clearState", DebugApi::bundler_clear_state(self))
             .await
-            .map_err(|e| rpc_err(INTERNAL_ERROR_CODE, e.to_string()))?;
-
-        Ok("ok".to_string())
     }
 
     async fn bundler_clear_mempool(&self) -> RpcResult<String> {
-        let _ = self
-            .pool
-            .debug_clear_state(true, true, false)
+        utils::safe_call_rpc_handler(
+            "bundler_clearMempool",
+            DebugApi::bundler_clear_mempool(self),
+        )
+        .await
+    }
+
+    async fn bundler_dump_mempool(&self, entry_point: Address) -> RpcResult<Vec<RpcUserOperation>> {
+        utils::safe_call_rpc_handler(
+            "bundler_dumpMempool",
+            DebugApi::bundler_dump_mempool(self, entry_point),
+        )
+        .await
+    }
+
+    async fn bundler_send_bundle_now(&self) -> RpcResult<H256> {
+        utils::safe_call_rpc_handler(
+            "bundler_sendBundleNow",
+            DebugApi::bundler_send_bundle_now(self),
+        )
+        .await
+    }
+
+    async fn bundler_set_bundling_mode(&self, mode: BundlingMode) -> RpcResult<String> {
+        utils::safe_call_rpc_handler(
+            "bundler_setBundlingMode",
+            DebugApi::bundler_set_bundling_mode(self, mode),
+        )
+        .await
+    }
+
+    async fn bundler_set_reputation(
+        &self,
+        reputations: Vec<RpcReputationInput>,
+        entry_point: Address,
+    ) -> RpcResult<String> {
+        utils::safe_call_rpc_handler(
+            "bundler_setReputation",
+            DebugApi::bundler_set_reputation(self, reputations, entry_point),
+        )
+        .await
+    }
+
+    async fn bundler_dump_reputation(
+        &self,
+        entry_point: Address,
+    ) -> RpcResult<Vec<RpcReputationOutput>> {
+        utils::safe_call_rpc_handler(
+            "bundler_dumpReputation",
+            DebugApi::bundler_dump_reputation(self, entry_point),
+        )
+        .await
+    }
+
+    async fn bundler_get_stake_status(
+        &self,
+        address: Address,
+        entry_point: Address,
+    ) -> RpcResult<RpcStakeStatus> {
+        utils::safe_call_rpc_handler(
+            "bundler_getStakeStatus",
+            DebugApi::bundler_get_stake_status(self, address, entry_point),
+        )
+        .await
+    }
+
+    async fn bundler_dump_paymaster_balances(
+        &self,
+        entry_point: Address,
+    ) -> RpcResult<Vec<RpcDebugPaymasterBalance>> {
+        utils::safe_call_rpc_handler(
+            "bundler_dumpPaymasterBalances",
+            DebugApi::bundler_dump_paymaster_balances(self, entry_point),
+        )
+        .await
+    }
+}
+
+impl<P, B> DebugApi<P, B>
+where
+    P: Pool,
+    B: Builder,
+{
+    async fn bundler_clear_state(&self) -> InternalRpcResult<String> {
+        self.pool
+            .debug_clear_state(true, true, true)
             .await
-            .map_err(|e| rpc_err(INTERNAL_ERROR_CODE, e.to_string()))?;
+            .context("should clear state")?;
 
         Ok("ok".to_string())
     }
 
-    async fn bundler_dump_mempool(&self, entry_point: Address) -> RpcResult<Vec<RpcUserOperation>> {
+    async fn bundler_clear_mempool(&self) -> InternalRpcResult<String> {
+        self.pool
+            .debug_clear_state(true, true, false)
+            .await
+            .context("should clear mempool")?;
+
+        Ok("ok".to_string())
+    }
+
+    async fn bundler_dump_mempool(
+        &self,
+        entry_point: Address,
+    ) -> InternalRpcResult<Vec<RpcUserOperation>> {
         Ok(self
             .pool
             .debug_dump_mempool(entry_point)
             .await
-            .map_err(|e| rpc_err(INTERNAL_ERROR_CODE, e.to_string()))?
+            .context("should dump mempool")?
             .into_iter()
             .map(|pop| pop.uo.into())
             .collect::<Vec<RpcUserOperation>>())
     }
 
-    async fn bundler_send_bundle_now(&self) -> RpcResult<H256> {
+    async fn bundler_send_bundle_now(&self) -> InternalRpcResult<H256> {
         tracing::debug!("Sending bundle");
 
         let mut new_heads = self
             .pool
             .subscribe_new_heads()
             .await
-            .map_err(|e| rpc_err(INTERNAL_ERROR_CODE, e.to_string()))?;
+            .context("should subscribe new heads")?;
 
         let (tx, block_number) = self.builder.debug_send_bundle_now().await.map_err(|e| {
             tracing::error!("Error sending bundle {e:?}");
-            rpc_err(INTERNAL_ERROR_CODE, e.to_string())
+            anyhow::anyhow!(e)
         })?;
 
         tracing::debug!("Waiting for block number {block_number}");
@@ -160,7 +251,7 @@ where
                     }
                 }
                 None => {
-                    return Err(rpc_err(INTERNAL_ERROR_CODE, "Next block not available"));
+                    Err(anyhow::anyhow!("Next block not available"))?;
                 }
             }
         }
@@ -168,13 +259,13 @@ where
         Ok(tx)
     }
 
-    async fn bundler_set_bundling_mode(&self, mode: BundlingMode) -> RpcResult<String> {
+    async fn bundler_set_bundling_mode(&self, mode: BundlingMode) -> InternalRpcResult<String> {
         tracing::debug!("Setting bundling mode to {:?}", mode);
 
         self.builder
             .debug_set_bundling_mode(mode)
             .await
-            .map_err(|e| rpc_err(INTERNAL_ERROR_CODE, e.to_string()))?;
+            .context("should set bundling mode")?;
 
         Ok("ok".to_string())
     }
@@ -183,7 +274,7 @@ where
         &self,
         reputations: Vec<RpcReputationInput>,
         entry_point: Address,
-    ) -> RpcResult<String> {
+    ) -> InternalRpcResult<String> {
         let _ = self
             .pool
             .debug_set_reputations(
@@ -198,12 +289,12 @@ where
     async fn bundler_dump_reputation(
         &self,
         entry_point: Address,
-    ) -> RpcResult<Vec<RpcReputationOutput>> {
+    ) -> InternalRpcResult<Vec<RpcReputationOutput>> {
         let result = self
             .pool
             .debug_dump_reputation(entry_point)
             .await
-            .map_err(|e| rpc_err(INTERNAL_ERROR_CODE, e.to_string()))?;
+            .context("should dump reputation")?;
 
         let mut results = Vec::new();
         for r in result {
@@ -211,7 +302,7 @@ where
                 .pool
                 .get_reputation_status(entry_point, r.address)
                 .await
-                .map_err(|e| rpc_err(INTERNAL_ERROR_CODE, e.to_string()))?;
+                .context("should get reputation status")?;
 
             let reputation = RpcReputationOutput {
                 address: r.address,
@@ -230,12 +321,12 @@ where
         &self,
         address: Address,
         entry_point: Address,
-    ) -> RpcResult<RpcStakeStatus> {
+    ) -> InternalRpcResult<RpcStakeStatus> {
         let result = self
             .pool
             .get_stake_status(entry_point, address)
             .await
-            .map_err(|e| rpc_err(INTERNAL_ERROR_CODE, e.to_string()))?;
+            .context("should get stake status")?;
 
         Ok(RpcStakeStatus {
             is_staked: result.is_staked,
@@ -250,12 +341,12 @@ where
     async fn bundler_dump_paymaster_balances(
         &self,
         entry_point: Address,
-    ) -> RpcResult<Vec<RpcDebugPaymasterBalance>> {
+    ) -> InternalRpcResult<Vec<RpcDebugPaymasterBalance>> {
         let result = self
             .pool
             .debug_dump_paymaster_balances(entry_point)
             .await
-            .map_err(|e| rpc_err(INTERNAL_ERROR_CODE, e.to_string()))?;
+            .context("should dump paymaster balances")?;
 
         let mut results = Vec::new();
         for b in result {

--- a/crates/rpc/src/eth/mod.rs
+++ b/crates/rpc/src/eth/mod.rs
@@ -19,7 +19,7 @@ mod router;
 pub(crate) use router::*;
 
 mod error;
-pub(crate) use error::EthRpcError;
+pub(crate) use error::{EthResult, EthRpcError};
 mod events;
 pub(crate) use events::{UserOperationEventProviderV0_6, UserOperationEventProviderV0_7};
 mod server;

--- a/crates/rpc/src/eth/server.rs
+++ b/crates/rpc/src/eth/server.rs
@@ -16,9 +16,12 @@ use jsonrpsee::core::RpcResult;
 use rundler_types::{pool::Pool, UserOperationVariant};
 
 use super::{api::EthApi, EthApiServer};
-use crate::types::{
-    FromRpc, RpcGasEstimate, RpcUserOperation, RpcUserOperationByHash, RpcUserOperationOptionalGas,
-    RpcUserOperationReceipt,
+use crate::{
+    types::{
+        FromRpc, RpcGasEstimate, RpcUserOperation, RpcUserOperationByHash,
+        RpcUserOperationOptionalGas, RpcUserOperationReceipt,
+    },
+    utils,
 };
 
 #[async_trait::async_trait]
@@ -31,12 +34,15 @@ where
         op: RpcUserOperation,
         entry_point: Address,
     ) -> RpcResult<H256> {
-        Ok(EthApi::send_user_operation(
-            self,
-            UserOperationVariant::from_rpc(op, entry_point, self.chain_spec.id),
-            entry_point,
+        utils::safe_call_rpc_handler(
+            "eth_sendUserOperation",
+            EthApi::send_user_operation(
+                self,
+                UserOperationVariant::from_rpc(op, entry_point, self.chain_spec.id),
+                entry_point,
+            ),
         )
-        .await?)
+        .await
     }
 
     async fn estimate_user_operation_gas(
@@ -45,31 +51,44 @@ where
         entry_point: Address,
         state_override: Option<spoof::State>,
     ) -> RpcResult<RpcGasEstimate> {
-        Ok(
-            EthApi::estimate_user_operation_gas(self, op.into(), entry_point, state_override)
-                .await?,
+        utils::safe_call_rpc_handler(
+            "eth_estimateUserOperationGas",
+            EthApi::estimate_user_operation_gas(self, op.into(), entry_point, state_override),
         )
+        .await
     }
 
     async fn get_user_operation_by_hash(
         &self,
         hash: H256,
     ) -> RpcResult<Option<RpcUserOperationByHash>> {
-        Ok(EthApi::get_user_operation_by_hash(self, hash).await?)
+        utils::safe_call_rpc_handler(
+            "eth_getUserOperationByHash",
+            EthApi::get_user_operation_by_hash(self, hash),
+        )
+        .await
     }
 
     async fn get_user_operation_receipt(
         &self,
         hash: H256,
     ) -> RpcResult<Option<RpcUserOperationReceipt>> {
-        Ok(EthApi::get_user_operation_receipt(self, hash).await?)
+        utils::safe_call_rpc_handler(
+            "eth_getUserOperationReceipt",
+            EthApi::get_user_operation_receipt(self, hash),
+        )
+        .await
     }
 
     async fn supported_entry_points(&self) -> RpcResult<Vec<String>> {
-        Ok(EthApi::supported_entry_points(self).await?)
+        utils::safe_call_rpc_handler(
+            "eth_supportedEntryPoints",
+            EthApi::supported_entry_points(self),
+        )
+        .await
     }
 
     async fn chain_id(&self) -> RpcResult<U64> {
-        Ok(EthApi::chain_id(self).await?)
+        utils::safe_call_rpc_handler("eth_chainId", EthApi::chain_id(self)).await
     }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -40,3 +40,4 @@ mod task;
 pub use task::{Args as RpcTaskArgs, RpcTask};
 
 mod types;
+mod utils;

--- a/crates/rpc/src/utils.rs
+++ b/crates/rpc/src/utils.rs
@@ -1,0 +1,58 @@
+// This file is part of Rundler.
+//
+// Rundler is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Rundler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Rundler.
+// If not, see https://www.gnu.org/licenses/.
+
+use std::panic::AssertUnwindSafe;
+
+use futures_util::{Future, FutureExt};
+use jsonrpsee::{
+    core::RpcResult,
+    types::{error::INTERNAL_ERROR_CODE, ErrorObjectOwned},
+};
+
+use crate::{error::rpc_err, eth::EthRpcError};
+
+pub(crate) async fn safe_call_rpc_handler<F, R, E>(rpc_name: &'static str, f: F) -> RpcResult<R>
+where
+    F: Future<Output = Result<R, E>> + Send,
+    E: Into<ErrorObjectOwned>,
+{
+    let f = AssertUnwindSafe(f);
+    match f.catch_unwind().await {
+        Ok(r) => r.map_err(Into::into),
+        Err(_) => {
+            metrics::counter!("rpc_panic_count", "rpc_name" => rpc_name).increment(1);
+            tracing::error!("PANIC in RPC handler: {}", rpc_name);
+            Err(EthRpcError::Internal(anyhow::anyhow!("internal error: panic, see logs")).into())
+        }
+    }
+}
+
+/// Internal RPC result type.
+pub(crate) type InternalRpcResult<T> = std::result::Result<T, InternalRpcError>;
+
+/// Internal RPC error.
+///
+/// Allowing easy use of anyhow in RPC handlers for internal errors.
+pub(crate) struct InternalRpcError(anyhow::Error);
+
+impl From<anyhow::Error> for InternalRpcError {
+    fn from(e: anyhow::Error) -> Self {
+        Self(e)
+    }
+}
+
+impl From<InternalRpcError> for ErrorObjectOwned {
+    fn from(e: InternalRpcError) -> Self {
+        rpc_err(INTERNAL_ERROR_CODE, e.0.to_string())
+    }
+}


### PR DESCRIPTION
## Proposed Changes

  - Previously panics would just drop the connection and silently occur
  - New behavior is to catch them, return an internal error, and increment a metric that can be alerted upon
