### PR TITLE
fix(cli): enforce num keys greater than or equal to num builders

### DIFF
--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -198,6 +198,7 @@ impl BuilderArgs {
         };
 
         let mut entry_points = vec![];
+        let mut num_builders = 0;
 
         if common.entry_point_v0_6_enabled {
             entry_points.push(EntryPointBuilderSettings {
@@ -208,6 +209,7 @@ impl BuilderArgs {
                 mempool_configs: mempool_configs
                     .get_for_entry_point(chain_spec.entry_point_address_v0_6),
             });
+            num_builders += common.num_builders_v0_6;
         }
         if common.entry_point_v0_7_enabled {
             entry_points.push(EntryPointBuilderSettings {
@@ -218,6 +220,20 @@ impl BuilderArgs {
                 mempool_configs: mempool_configs
                     .get_for_entry_point(chain_spec.entry_point_address_v0_7),
             });
+            num_builders += common.num_builders_v0_7;
+        }
+
+        if self.private_key.is_some() {
+            if num_builders > 1 {
+                return Err(anyhow::anyhow!(
+                    "Cannot use a private key with multiple builders. You may need to disable one of the entry points."
+                ));
+            }
+        } else if self.aws_kms_key_ids.len() < num_builders as usize {
+            return Err(anyhow::anyhow!(
+                "Not enough AWS KMS key IDs for the number of builders. Need {} keys, found {}. You may need to disable one of the entry points.",
+                num_builders, self.aws_kms_key_ids.len()
+            ));
         }
 
         Ok(BuilderTaskArgs {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -166,7 +166,7 @@ List of command line options for configuring the Builder.
   - *Only required when running in distributed mode* 
 - `--builder.private_key`: Private key to use for signing transactions
   - env: *BUILDER_PRIVATE_KEY*
-  - *Only required if BUILDER_AWS_KMS_KEY_IDS is not provided* 
+  - *Always used if provided. If not provided builder.aws_kms_key_ids is used*
 - `--builder.aws_kms_key_ids`: AWS KMS key IDs to use for signing transactions (comma-separated)
   - env: *BUILDER_AWS_KMS_KEY_IDS*
   - *Only required if BUILDER_PRIVATE_KEY is not provided* 


### PR DESCRIPTION
## Proposed Changes

  - On startup check that the configured number of keys is greater than or equal to the total number of builders across the two entrypoints.