### PR TITLE
fix(sim): handle explicit zero fees in 0.6 pre-verification gas

### DIFF
--- a/crates/sim/src/estimation/v0_6.rs
+++ b/crates/sim/src/estimation/v0_6.rs
@@ -262,8 +262,10 @@ where
             // If the user provides fees, use them, otherwise use the current bundle fees
             let (bundle_fees, base_fee) = self.fee_estimator.required_bundle_fees(None).await?;
             if let (Some(max_fee), Some(prio_fee)) = (
-                optional_op.max_fee_per_gas,
-                optional_op.max_priority_fee_per_gas,
+                optional_op.max_fee_per_gas.filter(|fee| !fee.is_zero()),
+                optional_op
+                    .max_priority_fee_per_gas
+                    .filter(|fee| !fee.is_zero()),
             ) {
                 cmp::min(max_fee, base_fee.saturating_add(prio_fee))
             } else {


### PR DESCRIPTION
Treat explicitly passed zero values the same as absent values for gas fees in `preVerificationGas` estimation in v0.6, as is consistent with estimating gas limits.