### PR TITLE
fix(provider): use state overrides for gas used, not ctor method

### DIFF
--- a/bin/rundler/chain_specs/arbitrum.toml
+++ b/bin/rundler/chain_specs/arbitrum.toml
@@ -6,4 +6,4 @@ l1_gas_oracle_contract_type = "ARBITRUM_NITRO"
 l1_gas_oracle_contract_address = "0x00000000000000000000000000000000000000C8"
 
 supports_eip1559 = false
-max_bundle_size_bytes = 95000
+max_transaction_size_bytes = 95000

--- a/bin/rundler/chain_specs/base.toml
+++ b/bin/rundler/chain_specs/base.toml
@@ -8,4 +8,4 @@ include_l1_gas_in_gas_limit = false
 
 priority_fee_oracle_type = "USAGE_BASED"
 min_max_priority_fee_per_gas = "0x0186A0" # 100_000
-max_bundle_size_bytes = 130000
+max_transaction_size_bytes = 130000

--- a/bin/rundler/chain_specs/optimism.toml
+++ b/bin/rundler/chain_specs/optimism.toml
@@ -8,4 +8,4 @@ include_l1_gas_in_gas_limit = false
 
 priority_fee_oracle_type = "USAGE_BASED"
 min_max_priority_fee_per_gas = "0x0186A0" # 100_000
-max_bundle_size_bytes = 90000
+max_transaction_size_bytes = 90000

--- a/bin/rundler/chain_specs/polygon.toml
+++ b/bin/rundler/chain_specs/polygon.toml
@@ -4,4 +4,4 @@ id = 137
 priority_fee_oracle_type = "USAGE_BASED"
 min_max_priority_fee_per_gas = "0x06FC23AC00" # 30_000_000_000
 bloxroute_enabled = true
-max_bundle_size_bytes = 300000
+max_transaction_size_bytes = 300000

--- a/crates/provider/src/traits/provider.rs
+++ b/crates/provider/src/traits/provider.rs
@@ -13,7 +13,7 @@
 
 //! Trait for interacting with chain data and contracts.
 
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 use ethers::{
     abi::{AbiDecode, AbiEncode},
@@ -25,6 +25,7 @@ use ethers::{
 };
 #[cfg(feature = "test-utils")]
 use mockall::automock;
+use rundler_types::contracts::utils::get_gas_used::GasUsedResult;
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::error::ProviderError;
@@ -127,4 +128,13 @@ pub trait Provider: Send + Sync + Debug + 'static {
 
     /// Get the logs matching a filter
     async fn get_logs(&self, filter: &Filter) -> ProviderResult<Vec<Log>>;
+
+    /// Measures the gas used by a call to target with value and data.
+    async fn get_gas_used(
+        self: &Arc<Self>,
+        target: Address,
+        value: U256,
+        data: Bytes,
+        state_overrides: spoof::State,
+    ) -> ProviderResult<GasUsedResult>;
 }

--- a/crates/rpc/src/task.rs
+++ b/crates/rpc/src/task.rs
@@ -188,6 +188,13 @@ where
             .set_logger(RpcMetricsLogger)
             .set_middleware(service_builder)
             .max_connections(self.args.max_connections)
+            // Set max request body size to 2x the max transaction size as none of our
+            // APIs should require more than that.
+            .max_request_body_size(
+                (self.args.chain_spec.max_transaction_size_bytes * 2)
+                    .try_into()
+                    .expect("max_transaction_size_bytes * 2 overflowed u32"),
+            )
             .http_only()
             .build(addr)
             .await?;

--- a/crates/sim/src/estimation/v0_6.rs
+++ b/crates/sim/src/estimation/v0_6.rs
@@ -698,15 +698,15 @@ mod tests {
                 }))
             });
 
-        provider.expect_call_constructor().returning(
-            move |_a, _b: (Address, U256, Bytes), _c, _d| {
+        provider
+            .expect_get_gas_used()
+            .returning(move |_a, _b, _c, _d| {
                 Ok(GasUsedResult {
                     gas_used: gas_usage * 2,
                     success: false,
                     result: Bytes::new(),
                 })
-            },
-        );
+            });
 
         let (estimator, _) = create_estimator(entry, provider);
         let optional_op = demo_user_op_optional_gas(Some(U256::from(10000)));
@@ -757,15 +757,15 @@ mod tests {
 
         // this gas used number is larger than a u64 max number so we need to
         // check for this overflow
-        provider.expect_call_constructor().returning(
-            move |_a, _b: (Address, U256, Bytes), _c, _d| {
+        provider
+            .expect_get_gas_used()
+            .returning(move |_a, _b, _c, _d| {
                 Ok(GasUsedResult {
                     gas_used: U256::from(18446744073709551616_u128),
                     success: false,
                     result: Bytes::new(),
                 })
-            },
-        );
+            });
 
         let (estimator, _) = create_estimator(entry, provider);
         let optional_op = demo_user_op_optional_gas(Some(U256::from(10000)));
@@ -814,15 +814,15 @@ mod tests {
 
         // the success field should not be true as the
         // call should always revert
-        provider.expect_call_constructor().returning(
-            move |_a, _b: (Address, U256, Bytes), _c, _d| {
+        provider
+            .expect_get_gas_used()
+            .returning(move |_a, _b, _c, _d| {
                 Ok(GasUsedResult {
                     gas_used: U256::from(20000),
                     success: true,
                     result: Bytes::new(),
                 })
-            },
-        );
+            });
 
         let (estimator, _) = create_estimator(entry, provider);
         let optional_op = demo_user_op_optional_gas(Some(U256::from(10000)));
@@ -861,15 +861,15 @@ mod tests {
                 }))
             });
 
-        provider.expect_call_constructor().returning(
-            move |_a, _b: (Address, U256, Bytes), _c, _d| {
+        provider
+            .expect_get_gas_used()
+            .returning(move |_a, _b, _c, _d| {
                 Ok(GasUsedResult {
                     gas_used: U256::from(20000),
                     success: false,
                     result: Bytes::new(),
                 })
-            },
-        );
+            });
 
         let (estimator, _) = create_estimator(entry, provider);
         let optional_op = demo_user_op_optional_gas(Some(U256::from(10000)));
@@ -903,15 +903,15 @@ mod tests {
             .expect_call_spoofed_simulate_op()
             .returning(|_a, _b, _c, _d, _e, _f| Err(anyhow!("Invalid spoof error")));
 
-        provider.expect_call_constructor().returning(
-            move |_a, _b: (Address, U256, Bytes), _c, _d| {
+        provider
+            .expect_get_gas_used()
+            .returning(move |_a, _b, _c, _d| {
                 Ok(GasUsedResult {
                     gas_used: U256::from(20000),
                     success: false,
                     result: Bytes::new(),
                 })
-            },
-        );
+            });
 
         let (estimator, _) = create_estimator(entry, provider);
         let optional_op = demo_user_op_optional_gas(Some(U256::from(10000)));
@@ -956,13 +956,11 @@ mod tests {
                 }))
             });
 
-        provider.expect_call_constructor().returning(
-            move |_a, _b: (Address, U256, Bytes), _c, _d| {
-                let ret: Result<GasUsedResult, anyhow::Error> =
-                    Err(anyhow::anyhow!("This should always revert"));
-                ret
-            },
-        );
+        provider
+            .expect_get_gas_used()
+            .returning(move |_a, _b, _c, _d| {
+                Err(anyhow::anyhow!("This should always revert").into())
+            });
 
         let (estimator, _) = create_estimator(entry, provider);
         let optional_op = demo_user_op_optional_gas(Some(U256::from(10000)));
@@ -1146,15 +1144,15 @@ mod tests {
         provider
             .expect_get_latest_block_hash_and_number()
             .returning(|| Ok((H256::zero(), U64::zero())));
-        provider.expect_call_constructor().returning(
-            move |_a, _b: (Address, U256, Bytes), _c, _d| {
+        provider
+            .expect_get_gas_used()
+            .returning(move |_a, _b, _c, _d| {
                 Ok(GasUsedResult {
                     gas_used: gas_usage,
                     success: false,
                     result: Bytes::new(),
                 })
-            },
-        );
+            });
 
         provider.expect_get_base_fee().returning(|| Ok(TEST_FEE));
         provider

--- a/crates/sim/src/utils.rs
+++ b/crates/sim/src/utils.rs
@@ -12,12 +12,9 @@
 // If not, see https://www.gnu.org/licenses/.
 
 use anyhow::Context;
-use ethers::types::{spoof, Address, BlockId, Bytes, H256, U256};
+use ethers::types::{spoof, Address, BlockId, H256};
 use rundler_provider::Provider;
-use rundler_types::contracts::utils::{
-    get_code_hashes::{CodeHashesResult, GETCODEHASHES_BYTECODE},
-    get_gas_used::{GasUsedResult, GETGASUSED_BYTECODE},
-};
+use rundler_types::contracts::utils::get_code_hashes::{CodeHashesResult, GETCODEHASHES_BYTECODE};
 
 /// Hashes together the code from all the provided addresses. The order of the input addresses does
 /// not matter.
@@ -37,22 +34,4 @@ pub(crate) async fn get_code_hash<P: Provider>(
         .await
         .context("should compute code hashes")?;
     Ok(H256(out.hash))
-}
-
-/// Measures the gas used by a call to target with value and data.
-pub(crate) async fn get_gas_used<P: Provider>(
-    provider: &P,
-    target: Address,
-    value: U256,
-    data: Bytes,
-    state_overrides: &spoof::State,
-) -> anyhow::Result<GasUsedResult> {
-    provider
-        .call_constructor(
-            &GETGASUSED_BYTECODE,
-            (target, value, data),
-            None,
-            state_overrides,
-        )
-        .await
 }

--- a/crates/types/contracts/src/utils/GetGasUsed.sol
+++ b/crates/types/contracts/src/utils/GetGasUsed.sol
@@ -1,24 +1,33 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.19;
 
-// Not intended to be deployed on-chain.. Instead, using a call to simulate
-// deployment will revert with an error containing the desired result.
+// Not intended to be deployed on-chain.. Instead use state overrides to deploy the bytecode and call it.
 
 contract GetGasUsed {
-    error GasUsedResult(uint256 gasUsed, bool success, bytes result);
+    struct GasUsedResult {
+        uint256 gasUsed; 
+        bool success; 
+        bytes result;
+    }
 
-    constructor(address target, uint256 value, bytes memory data) {
-        (uint256 gasUsed, bool success, bytes memory result) = getGas(target, value, data);
-        revert GasUsedResult(gasUsed, success, result);
+    /**
+     * Contract should not be deployed
+     */
+    constructor() {
+        require(block.number < 100, "should not be deployed");
     }
 
     function getGas(
         address target, 
         uint256 value, 
         bytes memory data
-    ) public returns (uint256, bool, bytes memory) {
+    ) public returns (GasUsedResult memory) {
         uint256 preGas = gasleft();
         (bool success, bytes memory result) = target.call{value : value}(data);
-        return (preGas - gasleft(), success, result);
+        return GasUsedResult({
+            gasUsed: preGas - gasleft(),
+            success: success,
+            result: result
+        });
     }
 }

--- a/crates/types/src/chain.rs
+++ b/crates/types/src/chain.rs
@@ -41,6 +41,8 @@ pub struct ChainSpec {
     /// NOTE: This must take into account when the storage slot was originally 0
     /// and is now non-zero, making the overhead slightly higher for most operations.
     pub deposit_transfer_overhead: U256,
+    /// The maximum size of a transaction in bytes
+    pub max_transaction_size_bytes: usize,
 
     /*
      * Gas estimation
@@ -77,8 +79,6 @@ pub struct ChainSpec {
     /// This parameter is used to trigger the builder to send a bundle after a specified
     /// amount of time, before a new block is not received.
     pub bundle_max_send_interval_millis: u64,
-    /// The maximum size that an bundle can be in bytes.
-    pub max_bundle_size_bytes: u64,
 
     /*
      * Senders
@@ -139,7 +139,7 @@ impl Default for ChainSpec {
             priority_fee_oracle_type: PriorityFeeOracleType::default(),
             min_max_priority_fee_per_gas: U256::zero(),
             max_max_priority_fee_per_gas: U256::MAX,
-            max_bundle_size_bytes: 100000,
+            max_transaction_size_bytes: 131072, // 128 KiB
             bundle_max_send_interval_millis: u64::MAX,
             flashbots_enabled: false,
             flashbots_relay_url: None,

--- a/crates/types/src/user_operation/v0_6.rs
+++ b/crates/types/src/user_operation/v0_6.rs
@@ -354,6 +354,15 @@ impl UserOperationOptionalGas {
         }
     }
 
+    /// Abi encoded size of the user operation (with its dummy fields)
+    pub fn abi_encoded_size(&self) -> usize {
+        ABI_ENCODED_USER_OPERATION_FIXED_LEN
+            + super::byte_array_abi_len(&self.init_code)
+            + super::byte_array_abi_len(&self.call_data)
+            + super::byte_array_abi_len(&self.paymaster_and_data)
+            + super::byte_array_abi_len(&self.signature)
+    }
+
     fn random_bytes(len: usize) -> Bytes {
         let mut bytes = vec![0_u8; len];
         rand::thread_rng().fill_bytes(&mut bytes);

--- a/crates/types/src/user_operation/v0_7.rs
+++ b/crates/types/src/user_operation/v0_7.rs
@@ -507,6 +507,21 @@ impl UserOperationOptionalGas {
         builder
     }
 
+    /// Abi encoded size of the user operation (with its dummy fields)
+    pub fn abi_encoded_size(&self) -> usize {
+        let mut base = ABI_ENCODED_USER_OPERATION_FIXED_LEN
+            + super::byte_array_abi_len(&self.call_data)
+            + super::byte_array_abi_len(&self.signature);
+        if self.factory.is_some() {
+            base += super::byte_array_abi_len(&self.factory_data) + 32; // account for factory address
+        }
+        if self.paymaster.is_some() {
+            base += super::byte_array_abi_len(&self.paymaster_data) + 64; // account for paymaster address and gas limits
+        }
+
+        base
+    }
+
     fn random_bytes(len: usize) -> Bytes {
         let mut bytes = vec![0_u8; len];
         rand::thread_rng().fill_bytes(&mut bytes);

--- a/docs/architecture/builder.md
+++ b/docs/architecture/builder.md
@@ -42,7 +42,7 @@ Once a candidate bundle is constructed, each UO is re-simulated and validation r
 
 After 2nd simulation the entire bundle is validated via an `eth_call`, and ops that fail validation are again removed from the bundle. This process is repeated until the entire bundle passes validation.
 
-NOTE: This procedure implements an old version of the spec and will be updated to conform soon. See [here](https://github.com/eth-infinitism/account-abstraction/blob/develop/erc/ERCS/erc-4337.md#bundling) for more details on the new implementation.
+NOTE: This procedure implements an old version of the spec and will be updated to conform soon. See [here](https://eips.ethereum.org/EIPS/eip-4337#bundling) for more details on the new implementation.
 
 ## Transaction Signers
 

--- a/docs/architecture/pool.md
+++ b/docs/architecture/pool.md
@@ -6,9 +6,9 @@ The `Pool` task is responsible for receiving, validating, sorting, and storing u
 
 Upon each `add_operation` call the `Pool` will preforms a series of checks.
 
-1. Run a series of [prechecks](https://github.com/eth-infinitism/account-abstraction/blob/develop/erc/ERCS/erc-4337.md#client-behavior-upon-receiving-a-useroperation) to catch any reasons why the UO may not be mined.
+1. Run a series of [prechecks](https://eips.ethereum.org/EIPS/eip-4337#client-behavior-upon-receiving-a-useroperation) to catch any reasons why the UO may not be mined.
 
-2. Simulate the UO via a `debug_traceCall` as per the [ERC-4337 spec](https://github.com/eth-infinitism/account-abstraction/blob/develop/erc/ERCS/erc-4337.md#simulation).
+2. Simulate the UO via a `debug_traceCall` as per the [ERC-4337 spec](https://eips.ethereum.org/EIPS/eip-4337#simulation).
 
 If violations are found, the UO is rejected. Else, the UO is added to the pool. 
 
@@ -18,7 +18,7 @@ A typescript based tracer is used to collect relevant information from the `debu
 
 ## Reputation
 
-The `Pool` tracks the reputation of entities as per the [ERC-4337 spec](https://github.com/eth-infinitism/account-abstraction/blob/develop/erc/ERCS/erc-4337.md#reputation-scoring-and-throttlingbanning-for-global-entities).
+The `Pool` tracks the reputation of entities as per the [ERC-4337 spec](https://eips.ethereum.org/EIPS/eip-4337#reputation-scoring-and-throttlingbanning-for-global-entities).
 
 
 ### Allowlist/Blocklist

--- a/docs/architecture/rpc.md
+++ b/docs/architecture/rpc.md
@@ -15,7 +15,7 @@ It also supports a health check endpoint.
 
 ### `eth_` Namespace
 
-Methods defined by the [ERC-4337 spec](https://github.com/eth-infinitism/account-abstraction/blob/develop/erc/ERCS/erc-4337.md#rpc-methods-eth-namespace).
+Methods defined by the [ERC-4337 spec](https://eips.ethereum.org/EIPS/eip-4337#rpc-methods-eth-namespace).
 
 | Method | Supported |
 | ------ | :-----------: |
@@ -28,7 +28,7 @@ Methods defined by the [ERC-4337 spec](https://github.com/eth-infinitism/account
 
 ### `debug_` Namespace
 
-Method defined by the [ERC-4337 spec](https://github.com/eth-infinitism/account-abstraction/blob/develop/erc/ERCS/erc-4337.md#rpc-methods-debug-namespace). Used only for debugging/testing and should be disabled on production APIs.
+Method defined by the [ERC-4337 spec](https://eips.ethereum.org/EIPS/eip-4337#rpc-methods-debug-namespace). Used only for debugging/testing and should be disabled on production APIs.
 
 | Method | Supported | Non-Standard |
 | ------ | :-----------: | :--: |


### PR DESCRIPTION
## Proposed Changes

  - Old code used the constructor revert method to check gas used. This ran into the limitation that Geth limits the initCode supplied on contract creation to 48 KiB which is less than what it uses for its transaction limit, 128 KiB.
  - New code uses state overrides instead, which is the preferred method as it makes the contracts easier to reason about.
  - Added a check at the RPC layer for UO size
  - Added a setting to the RPC server for max body size as max transaction size * 2
