### PR TITLE
feat(builder): cancel transaction when replacement underpriced

### DIFF
--- a/crates/builder/src/sender/bloxroute.rs
+++ b/crates/builder/src/sender/bloxroute.rs
@@ -19,6 +19,7 @@ use ethers::{
     providers::{JsonRpcClient, Middleware, Provider},
     types::{
         transaction::eip2718::TypedTransaction, Address, Bytes, TransactionReceipt, TxHash, H256,
+        U256,
     },
     utils::hex,
 };
@@ -28,12 +29,16 @@ use jsonrpsee::{
     http_client::{transport::HttpBackend, HeaderMap, HeaderValue, HttpClient, HttpClientBuilder},
 };
 use rundler_sim::ExpectedStorage;
+use rundler_types::GasFees;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use tokio::time;
 use tonic::async_trait;
 
-use super::{fill_and_sign, Result, SentTxInfo, TransactionSender, TxStatus};
+use super::{
+    create_hard_cancel_tx, fill_and_sign, CancelTxInfo, Result, SentTxInfo, TransactionSender,
+    TxStatus,
+};
 
 pub(crate) struct PolygonBloxrouteTransactionSender<C, S>
 where
@@ -60,6 +65,29 @@ where
         let (raw_tx, nonce) = fill_and_sign(&self.provider, tx).await?;
         let tx_hash = self.client.send_transaction(raw_tx).await?;
         Ok(SentTxInfo { nonce, tx_hash })
+    }
+
+    async fn cancel_transaction(
+        &self,
+        _tx_hash: H256,
+        nonce: U256,
+        to: Address,
+        gas_fees: GasFees,
+    ) -> Result<CancelTxInfo> {
+        let tx = create_hard_cancel_tx(self.provider.address(), to, nonce, gas_fees);
+
+        let (raw_tx, _) = fill_and_sign(&self.provider, tx).await?;
+
+        let tx_hash = self
+            .provider
+            .provider()
+            .request("eth_sendRawTransaction", (raw_tx,))
+            .await?;
+
+        Ok(CancelTxInfo {
+            tx_hash,
+            soft_cancelled: false,
+        })
     }
 
     async fn get_transaction_status(&self, tx_hash: H256) -> Result<TxStatus> {

--- a/crates/builder/src/server/local.rs
+++ b/crates/builder/src/server/local.rs
@@ -186,9 +186,6 @@ impl LocalBuilderServerRunner {
                                     SendBundleResult::NoOperationsInitially => {
                                         Err(anyhow::anyhow!("no ops to send").into())
                                     },
-                                    SendBundleResult::NoOperationsAfterFeeIncreases { .. } => {
-                                        Err(anyhow::anyhow!("bundle initially had operations, but after increasing gas fees it was empty").into())
-                                    },
                                     SendBundleResult::StalledAtMaxFeeIncreases => Err(anyhow::anyhow!("stalled at max fee increases").into()),
                                     SendBundleResult::Error(e) => Err(anyhow::anyhow!("send bundle error: {e:?}").into()),
                                 }


### PR DESCRIPTION
Closes #550 

## Proposed Changes

  - Define bundle abandonment as - there is a pending bundle but after fee increases there are no longer any high enough paying UOs to increase the fees.
  - Modify sender state machine to funnel every bundle abandonment to the same state - "replacement underpriced." That is, when a bundle is abandoned clear the transaction tracker and start from scratch. On networks where the previous txn may still be in the mempool, we will get a "replacement underpriced." On other networks, starting from scratch allows us to continue.
  - Handle "replacement underpriced" errors with cancellations.
  - For the flashbots sender, use a "soft cancellation", which is just an API call and doesn't require polling
  - For all other senders, use a "hard cancellation", which requires a transaction to be sent to clear the mempool.
  
  TODO (in follow up PRs):
- [x] Consider splitting the monolith state machine function to make it easier to grok.
- [ ] Consider delaying moving to the cancellation state by counting the number of "replacement underpriced" errors without landing a bundle. This will reduce the amount of wasted cancellation funds at the expense of being less reactive.
- [ ] Unit testing of `bundle_sender`
