### PR TITLE
feat(tracer): add timeout of 10s to tracer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,6 +2017,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "go-parse-duration"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558b88954871f5e5b2af0e62e2e176c8bde7a6c2c4ed41b13d138d96da2e2cbd"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4027,6 +4033,7 @@ dependencies = [
  "config",
  "dotenv",
  "ethers",
+ "go-parse-duration",
  "itertools 0.12.1",
  "metrics",
  "metrics-exporter-prometheus",

--- a/bin/rundler/Cargo.toml
+++ b/bin/rundler/Cargo.toml
@@ -27,6 +27,7 @@ dotenv = "0.15.0"
 ethers.workspace = true
 itertools = "0.12.1"
 metrics = "0.22.1"
+go-parse-duration = "0.1"
 metrics-exporter-prometheus = { version = "0.13.1", default-features = false, features = ["http-listener"] }
 metrics-process = "1.2.1"
 metrics-util = "0.16.2"

--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -286,7 +286,7 @@ impl BuilderArgs {
             priority_fee_mode,
             sender_args,
             eth_poll_interval: Duration::from_millis(common.eth_poll_interval_millis),
-            sim_settings: common.into(),
+            sim_settings: common.try_into()?,
             max_blocks_to_wait_for_mine: self.max_blocks_to_wait_for_mine,
             replacement_fee_percent_increase: self.replacement_fee_percent_increase,
             max_fee_increases: self.max_fee_increases,

--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use anyhow::Context;
+use anyhow::{bail, Context};
 use clap::{builder::PossibleValuesParser, Args, Parser, Subcommand};
 
 mod builder;
@@ -163,11 +163,14 @@ pub struct CommonArgs {
     )]
     min_unstake_delay: u32,
 
+    /// String representation of timeount in a format that is parsable by the
+    /// `ParseDuration` function on the ethereum node.
+    /// Docs: https://pkg.go.dev/time#ParseDuration
     #[arg(
         long = "tracer_timeout",
         name = "tracer_timeout",
         env = "TRACER_TIMEOUT",
-        default_value = "10s",
+        default_value = "15s",
         global = true
     )]
     tracer_timeout: String,
@@ -366,15 +369,21 @@ impl TryFrom<&CommonArgs> for PrecheckSettings {
     }
 }
 
-impl From<&CommonArgs> for SimulationSettings {
-    fn from(value: &CommonArgs) -> Self {
-        Self::new(
+impl TryFrom<&CommonArgs> for SimulationSettings {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &CommonArgs) -> Result<Self, Self::Error> {
+        if let Err(_) = go_parse_duration::parse_duration(&value.tracer_timeout) {
+            bail!("Invalid value for tracer_timeout, must be parsable by the ParseDuration function. See docs https://pkg.go.dev/time#ParseDuration")
+        }
+
+        Ok(Self::new(
             value.min_unstake_delay,
             value.min_stake_value,
             value.max_simulate_handle_ops_gas,
             value.max_verification_gas,
             value.tracer_timeout.clone(),
-        )
+        ))
     }
 }
 

--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -373,7 +373,7 @@ impl TryFrom<&CommonArgs> for SimulationSettings {
     type Error = anyhow::Error;
 
     fn try_from(value: &CommonArgs) -> Result<Self, Self::Error> {
-        if let Err(_) = go_parse_duration::parse_duration(&value.tracer_timeout) {
+        if go_parse_duration::parse_duration(&value.tracer_timeout).is_err() {
             bail!("Invalid value for tracer_timeout, must be parsable by the ParseDuration function. See docs https://pkg.go.dev/time#ParseDuration")
         }
 

--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -163,9 +163,8 @@ pub struct CommonArgs {
     )]
     min_unstake_delay: u32,
 
-    /// String representation of timeount in a format that is parsable by the
-    /// `ParseDuration` function on the ethereum node.
-    /// Docs: https://pkg.go.dev/time#ParseDuration
+    /// String representation of the timeout of a custom tracer in a format that is parsable by the
+    /// `ParseDuration` function on the ethereum node. See Docs: https://pkg.go.dev/time#ParseDuration
     #[arg(
         long = "tracer_timeout",
         name = "tracer_timeout",

--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -163,6 +163,15 @@ pub struct CommonArgs {
     )]
     min_unstake_delay: u32,
 
+    #[arg(
+        long = "tracer_timeout",
+        name = "tracer_timeout",
+        env = "TRACER_TIMEOUT",
+        default_value = "10s",
+        global = true
+    )]
+    tracer_timeout: String,
+
     /// Amount of blocks to search when calling eth_getUserOperationByHash.
     /// Defaults from 0 to latest block
     #[arg(
@@ -364,6 +373,7 @@ impl From<&CommonArgs> for SimulationSettings {
             value.min_stake_value,
             value.max_simulate_handle_ops_gas,
             value.max_verification_gas,
+            value.tracer_timeout.clone(),
         )
     }
 }

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -195,7 +195,7 @@ impl PoolArgs {
             blocklist: blocklist.clone(),
             allowlist: allowlist.clone(),
             precheck_settings: common.try_into()?,
-            sim_settings: common.into(),
+            sim_settings: common.try_into()?,
             throttled_entity_mempool_count: self.throttled_entity_mempool_count,
             throttled_entity_live_blocks: self.throttled_entity_live_blocks,
             paymaster_tracking_enabled: self.paymaster_tracking_enabled,

--- a/crates/builder/src/task.rs
+++ b/crates/builder/src/task.rs
@@ -267,7 +267,7 @@ where
                     UnsafeSimulator::new(
                         Arc::clone(&provider),
                         ep_v0_6.clone(),
-                        self.args.sim_settings,
+                        self.args.sim_settings.clone(),
                     ),
                 )
                 .await?
@@ -279,7 +279,7 @@ where
                     simulation::new_v0_6_simulator(
                         Arc::clone(&provider),
                         ep_v0_6.clone(),
-                        self.args.sim_settings,
+                        self.args.sim_settings.clone(),
                         ep.mempool_configs.clone(),
                     ),
                 )
@@ -316,7 +316,7 @@ where
                     UnsafeSimulator::new(
                         Arc::clone(&provider),
                         ep_v0_7.clone(),
-                        self.args.sim_settings,
+                        self.args.sim_settings.clone(),
                     ),
                 )
                 .await?
@@ -328,7 +328,7 @@ where
                     simulation::new_v0_7_simulator(
                         Arc::clone(&provider),
                         ep_v0_7.clone(),
-                        self.args.sim_settings,
+                        self.args.sim_settings.clone(),
                         ep.mempool_configs.clone(),
                     ),
                 )

--- a/crates/pool/src/task.rs
+++ b/crates/pool/src/task.rs
@@ -196,8 +196,11 @@ impl PoolTask {
         );
 
         if unsafe_mode {
-            let simulator =
-                UnsafeSimulator::new(Arc::clone(&provider), ep.clone(), pool_config.sim_settings);
+            let simulator = UnsafeSimulator::new(
+                Arc::clone(&provider),
+                ep.clone(),
+                pool_config.sim_settings.clone(),
+            );
             Self::create_mempool(
                 chain_spec,
                 pool_config,
@@ -210,7 +213,7 @@ impl PoolTask {
             let simulator = simulation::new_v0_6_simulator(
                 Arc::clone(&provider),
                 ep.clone(),
-                pool_config.sim_settings,
+                pool_config.sim_settings.clone(),
                 pool_config.mempool_channel_configs.clone(),
             );
             Self::create_mempool(
@@ -239,8 +242,11 @@ impl PoolTask {
         );
 
         if unsafe_mode {
-            let simulator =
-                UnsafeSimulator::new(Arc::clone(&provider), ep.clone(), pool_config.sim_settings);
+            let simulator = UnsafeSimulator::new(
+                Arc::clone(&provider),
+                ep.clone(),
+                pool_config.sim_settings.clone(),
+            );
             Self::create_mempool(
                 chain_spec,
                 pool_config,
@@ -253,7 +259,7 @@ impl PoolTask {
             let simulator = simulation::new_v0_7_simulator(
                 Arc::clone(&provider),
                 ep.clone(),
-                pool_config.sim_settings,
+                pool_config.sim_settings.clone(),
                 pool_config.mempool_channel_configs.clone(),
             );
             Self::create_mempool(

--- a/crates/sim/src/simulation/context.rs
+++ b/crates/sim/src/simulation/context.rs
@@ -124,7 +124,7 @@ pub(crate) fn infos_from_validation_output(
     sender_address: Address,
     paymaster_address: Option<Address>,
     entry_point_out: &ValidationOutput,
-    sim_settings: Settings,
+    sim_settings: &Settings,
 ) -> EntityInfos {
     let mut ei = EntityInfos::default();
     ei.set_sender(
@@ -153,7 +153,7 @@ pub(crate) fn infos_from_validation_output(
     ei
 }
 
-pub(crate) fn is_staked(info: StakeInfo, sim_settings: Settings) -> bool {
+pub(crate) fn is_staked(info: StakeInfo, sim_settings: &Settings) -> bool {
     info.stake >= sim_settings.min_stake_value.into()
         && info.unstake_delay_sec >= sim_settings.min_unstake_delay.into()
 }

--- a/crates/sim/src/simulation/mod.rs
+++ b/crates/sim/src/simulation/mod.rs
@@ -150,7 +150,7 @@ pub trait Simulator: Send + Sync + 'static {
 }
 
 /// Simulation Settings
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct Settings {
     /// The minimum amount of time that a staked entity must have configured as
     /// their unstake delay on the entry point contract in order to be considered staked.
@@ -162,6 +162,8 @@ pub struct Settings {
     pub max_simulate_handle_ops_gas: u64,
     /// The maximum amount of verification gas that can be used during the simulation call
     pub max_verification_gas: u64,
+    /// The max duration of the custom javascript tracer
+    pub tracer_timeout: String,
 }
 
 impl Settings {
@@ -171,12 +173,14 @@ impl Settings {
         min_stake_value: u128,
         max_simulate_handle_ops_gas: u64,
         max_verification_gas: u64,
+        tracer_timeout: String,
     ) -> Self {
         Self {
             min_unstake_delay,
             min_stake_value,
             max_simulate_handle_ops_gas,
             max_verification_gas,
+            tracer_timeout,
         }
     }
 }
@@ -192,6 +196,7 @@ impl Default for Settings {
             // 550 million gas: currently the defaults for Alchemy eth_call
             max_simulate_handle_ops_gas: 550_000_000,
             max_verification_gas: 5_000_000,
+            tracer_timeout: "10s".to_string(),
         }
     }
 }

--- a/crates/sim/src/simulation/mod.rs
+++ b/crates/sim/src/simulation/mod.rs
@@ -162,7 +162,8 @@ pub struct Settings {
     pub max_simulate_handle_ops_gas: u64,
     /// The maximum amount of verification gas that can be used during the simulation call
     pub max_verification_gas: u64,
-    /// The max duration of the custom javascript tracer
+    /// The max duration of the custom javascript tracer. Must be in a format parseable by the
+    /// ParseDuration function on an ethereum node. See Docs: https://pkg.go.dev/time#ParseDuration
     pub tracer_timeout: String,
 }
 

--- a/crates/sim/src/simulation/simulator.rs
+++ b/crates/sim/src/simulation/simulator.rs
@@ -63,7 +63,7 @@ where
     SimulatorImpl::new(
         provider.clone(),
         entry_point.clone(),
-        ValidationContextProviderV0_6::new(provider, entry_point, sim_settings),
+        ValidationContextProviderV0_6::new(provider, entry_point, sim_settings.clone()),
         sim_settings,
         mempool_configs,
     )
@@ -86,7 +86,7 @@ where
     SimulatorImpl::new(
         provider.clone(),
         entry_point.clone(),
-        ValidationContextProviderV0_7::new(provider, entry_point, sim_settings),
+        ValidationContextProviderV0_7::new(provider, entry_point, sim_settings.clone()),
         sim_settings,
         mempool_configs,
     )
@@ -345,7 +345,7 @@ where
         }
 
         if let Some(aggregator_info) = entry_point_out.aggregator_info {
-            if !context::is_staked(aggregator_info.stake_info, self.sim_settings) {
+            if !context::is_staked(aggregator_info.stake_info, &self.sim_settings) {
                 // [EREP-040]
                 violations.push(SimulationViolation::UnstakedAggregator)
             }
@@ -514,7 +514,7 @@ where
             sender_info,
             ..
         } = entry_point_out;
-        let account_is_staked = context::is_staked(sender_info, self.sim_settings);
+        let account_is_staked = context::is_staked(sender_info, &self.sim_settings);
         let ValidationReturnInfo {
             pre_op_gas,
             valid_after,
@@ -798,7 +798,7 @@ mod tests {
                     paymaster_info: StakeInfo::from((U256::default(), U256::default())),
                     aggregator_info: None,
                 },
-                Settings::default(),
+                &Settings::default(),
             ),
             tracer_out,
             entry_point_out: ValidationOutput {

--- a/crates/sim/src/simulation/v0_6/context.rs
+++ b/crates/sim/src/simulation/v0_6/context.rs
@@ -55,7 +55,12 @@ where
         let paymaster_address = op.paymaster();
         let tracer_out = self
             .simulate_validation_tracer
-            .trace_simulate_validation(op.clone(), block_id, self.sim_settings.max_verification_gas)
+            .trace_simulate_validation(
+                op.clone(),
+                block_id,
+                self.sim_settings.max_verification_gas,
+                self.sim_settings.tracer_timeout.clone(),
+            )
             .await?;
         let num_phases = tracer_out.phases.len() as u32;
         // Check if there are too many phases here, then check too few at the
@@ -107,7 +112,7 @@ where
             sender_address,
             paymaster_address,
             &entry_point_out,
-            self.sim_settings,
+            &self.sim_settings,
         );
 
         let associated_addresses = tracer_out.associated_slots_by_address.addresses();
@@ -276,6 +281,7 @@ mod tests {
                 op: UserOperation,
                 block_id: BlockId,
                 max_validation_gas: u64,
+                tracer_timeout: String,
             ) -> anyhow::Result<TracerOutput>;
         }
     }
@@ -286,7 +292,7 @@ mod tests {
 
         tracer
             .expect_trace_simulate_validation()
-            .returning(|_, _, _| {
+            .returning(|_, _, _, _| {
                 let mut tracer_output = get_test_tracer_output();
                 tracer_output.revert_data = Some(hex::encode(
                     FailedOp {

--- a/crates/sim/src/simulation/v0_6/tracer.rs
+++ b/crates/sim/src/simulation/v0_6/tracer.rs
@@ -44,6 +44,7 @@ pub(super) trait SimulateValidationTracer: Send + Sync + 'static {
         op: UserOperation,
         block_id: BlockId,
         max_validation_gas: u64,
+        tracer_timeout: String,
     ) -> anyhow::Result<TracerOutput>;
 }
 
@@ -68,6 +69,7 @@ where
         op: UserOperation,
         block_id: BlockId,
         max_validation_gas: u64,
+        tracer_timeout: String,
     ) -> anyhow::Result<TracerOutput> {
         let (tx, state_override) = self
             .entry_point
@@ -83,6 +85,7 @@ where
                             tracer: Some(GethDebugTracerType::JsTracer(
                                 validation_tracer_js().to_string(),
                             )),
+                            timeout: Some(tracer_timeout),
                             ..Default::default()
                         },
                         state_overrides: Some(state_override),

--- a/crates/sim/src/simulation/v0_6/tracer.rs
+++ b/crates/sim/src/simulation/v0_6/tracer.rs
@@ -43,8 +43,6 @@ pub(super) trait SimulateValidationTracer: Send + Sync + 'static {
         &self,
         op: UserOperation,
         block_id: BlockId,
-        max_validation_gas: u64,
-        tracer_timeout: String,
     ) -> anyhow::Result<TracerOutput>;
 }
 
@@ -53,6 +51,8 @@ pub(super) trait SimulateValidationTracer: Send + Sync + 'static {
 pub(crate) struct SimulateValidationTracerImpl<P, E> {
     provider: Arc<P>,
     entry_point: E,
+    max_validation_gas: u64,
+    tracer_timeout: String,
 }
 
 /// Runs the bundler's custom tracer on the entry point's `simulateValidation`
@@ -68,12 +68,10 @@ where
         &self,
         op: UserOperation,
         block_id: BlockId,
-        max_validation_gas: u64,
-        tracer_timeout: String,
     ) -> anyhow::Result<TracerOutput> {
         let (tx, state_override) = self
             .entry_point
-            .get_tracer_simulate_validation_call(op, max_validation_gas);
+            .get_tracer_simulate_validation_call(op, self.max_validation_gas);
 
         TracerOutput::try_from(
             self.provider
@@ -85,7 +83,7 @@ where
                             tracer: Some(GethDebugTracerType::JsTracer(
                                 validation_tracer_js().to_string(),
                             )),
-                            timeout: Some(tracer_timeout),
+                            timeout: Some(self.tracer_timeout.clone()),
                             ..Default::default()
                         },
                         state_overrides: Some(state_override),
@@ -98,10 +96,17 @@ where
 
 impl<P, E> SimulateValidationTracerImpl<P, E> {
     /// Creates a new instance of the bundler's custom tracer.
-    pub(crate) fn new(provider: Arc<P>, entry_point: E) -> Self {
+    pub(crate) fn new(
+        provider: Arc<P>,
+        entry_point: E,
+        max_validation_gas: u64,
+        tracer_timeout: String,
+    ) -> Self {
         Self {
             provider,
             entry_point,
+            max_validation_gas,
+            tracer_timeout,
         }
     }
 }

--- a/crates/sim/src/simulation/v0_7/context.rs
+++ b/crates/sim/src/simulation/v0_7/context.rs
@@ -101,12 +101,7 @@ where
     ) -> Result<ValidationContext<Self::UO>, ViolationError<SimulationViolation>> {
         let tracer_out = self
             .simulate_validation_tracer
-            .trace_simulate_validation(
-                op.clone(),
-                block_id,
-                self.sim_settings.max_verification_gas,
-                self.sim_settings.tracer_timeout.clone(),
-            )
+            .trace_simulate_validation(op.clone(), block_id)
             .await?;
 
         let call_stack = self.parse_call_stack(tracer_out.calls.clone())?;
@@ -494,7 +489,12 @@ where
     pub(crate) fn new(provider: Arc<P>, entry_point: E, sim_settings: SimulationSettings) -> Self {
         Self {
             entry_point_address: entry_point.address(),
-            simulate_validation_tracer: SimulateValidationTracerImpl::new(provider, entry_point),
+            simulate_validation_tracer: SimulateValidationTracerImpl::new(
+                provider,
+                entry_point,
+                sim_settings.max_verification_gas,
+                sim_settings.tracer_timeout.clone(),
+            ),
             sim_settings,
         }
     }

--- a/crates/sim/src/simulation/v0_7/context.rs
+++ b/crates/sim/src/simulation/v0_7/context.rs
@@ -101,7 +101,12 @@ where
     ) -> Result<ValidationContext<Self::UO>, ViolationError<SimulationViolation>> {
         let tracer_out = self
             .simulate_validation_tracer
-            .trace_simulate_validation(op.clone(), block_id, self.sim_settings.max_verification_gas)
+            .trace_simulate_validation(
+                op.clone(),
+                block_id,
+                self.sim_settings.max_verification_gas,
+                self.sim_settings.tracer_timeout.clone(),
+            )
             .await?;
 
         let call_stack = self.parse_call_stack(tracer_out.calls.clone())?;
@@ -133,7 +138,7 @@ where
             op.sender(),
             op.paymaster(),
             &entry_point_out,
-            self.sim_settings,
+            &self.sim_settings,
         );
 
         let mut tracer_out = self.parse_tracer_out(&op, tracer_out)?;

--- a/crates/sim/src/simulation/v0_7/tracer.rs
+++ b/crates/sim/src/simulation/v0_7/tracer.rs
@@ -125,8 +125,6 @@ pub(super) trait SimulateValidationTracer: Send + Sync + 'static {
         &self,
         op: UserOperation,
         block_id: BlockId,
-        max_validation_gas: u64,
-        tracer_timeout: String,
     ) -> anyhow::Result<TracerOutput>;
 }
 
@@ -135,6 +133,8 @@ pub(super) trait SimulateValidationTracer: Send + Sync + 'static {
 pub(crate) struct SimulateValidationTracerImpl<P, E> {
     provider: Arc<P>,
     entry_point: E,
+    max_validation_gas: u64,
+    tracer_timeout: String,
 }
 
 /// Runs the bundler's custom tracer on the entry point's `simulateValidation`
@@ -150,12 +150,10 @@ where
         &self,
         op: UserOperation,
         block_id: BlockId,
-        max_validation_gas: u64,
-        tracer_timeout: String,
     ) -> anyhow::Result<TracerOutput> {
         let (tx, state_override) = self
             .entry_point
-            .get_tracer_simulate_validation_call(op, max_validation_gas);
+            .get_tracer_simulate_validation_call(op, self.max_validation_gas);
 
         let out = self
             .provider
@@ -167,7 +165,7 @@ where
                         tracer: Some(GethDebugTracerType::JsTracer(
                             validation_tracer_js().to_string(),
                         )),
-                        timeout: Some(tracer_timeout),
+                        timeout: Some(self.tracer_timeout.clone()),
                         ..Default::default()
                     },
                     state_overrides: Some(state_override),
@@ -181,10 +179,17 @@ where
 
 impl<P, E> SimulateValidationTracerImpl<P, E> {
     /// Creates a new instance of the bundler's custom tracer.
-    pub(crate) fn new(provider: Arc<P>, entry_point: E) -> Self {
+    pub(crate) fn new(
+        provider: Arc<P>,
+        entry_point: E,
+        max_validation_gas: u64,
+        tracer_timeout: String,
+    ) -> Self {
         Self {
             provider,
             entry_point,
+            max_validation_gas,
+            tracer_timeout,
         }
     }
 }

--- a/crates/sim/src/simulation/v0_7/tracer.rs
+++ b/crates/sim/src/simulation/v0_7/tracer.rs
@@ -126,6 +126,7 @@ pub(super) trait SimulateValidationTracer: Send + Sync + 'static {
         op: UserOperation,
         block_id: BlockId,
         max_validation_gas: u64,
+        tracer_timeout: String,
     ) -> anyhow::Result<TracerOutput>;
 }
 
@@ -150,6 +151,7 @@ where
         op: UserOperation,
         block_id: BlockId,
         max_validation_gas: u64,
+        tracer_timeout: String,
     ) -> anyhow::Result<TracerOutput> {
         let (tx, state_override) = self
             .entry_point
@@ -165,6 +167,7 @@ where
                         tracer: Some(GethDebugTracerType::JsTracer(
                             validation_tracer_js().to_string(),
                         )),
+                        timeout: Some(tracer_timeout),
                         ..Default::default()
                     },
                     state_overrides: Some(state_override),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,6 +73,8 @@ See [chain spec](./architecture/chain_spec.md) for a detailed description of cha
   - env: *DISABLE_ENTRY_POINT_V0_7*
 - `--num_builders_v0_7`: The number of bundle builders to run on entry point v0.7 (default: `1`)
   - env: *NUM_BUILDERS_V0_7*
+- `--tracer_timeout`: The timeout used for custom javascript tracers, the string must be in a valid parseable format that can be used in the `ParseDuration` function on an ethereum node. See Docs [Here](https://pkg.go.dev/time#ParseDuration). (default: `15s`)
+  - env: *TRACER_TIMEOUT*
 
 ## Metrics Options
 


### PR DESCRIPTION
## Proposed Changes

  - Change timeout of debug_traceCall for custom tracers to 10s instead of the default 5s
  - Add CLI flag to make it customizable 
  
  DOCS: 
  https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug
  https://pkg.go.dev/time#ParseDuration