### PR TITLE
fix(tracer): set tracer timeout default back to 10s

### DIFF
--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -169,7 +169,7 @@ pub struct CommonArgs {
         long = "tracer_timeout",
         name = "tracer_timeout",
         env = "TRACER_TIMEOUT",
-        default_value = "15s",
+        default_value = "10s",
         global = true
     )]
     tracer_timeout: String,


### PR DESCRIPTION

## Proposed Changes

  - Set back to 10s after testing 15s localy

