### PR TITLE
feat(sim): ban access to arbitrum stylus contracts during sim

### DIFF
--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -649,6 +649,7 @@ message SimulationViolationError {
     InvalidPaymasterSignature invalid_paymaster_signature = 22;
     AssociatedStorageDuringDeploy associated_storage_during_deploy = 23;
     InvalidTimeRange invalid_time_range = 24;
+    AccessedUnsupportedContractType accessed_unsupported_contract_type = 25;
   }
 }
 
@@ -763,4 +764,9 @@ message OperationRevert {
 }
 message UnknownRevert {
   bytes revert_bytes = 1;
+}
+
+message AccessedUnsupportedContractType {
+  string contract_type = 1;
+  bytes contract_address = 2;
 }

--- a/crates/rpc/src/eth/error.rs
+++ b/crates/rpc/src/eth/error.rs
@@ -340,6 +340,7 @@ impl From<SimulationViolation> for EthRpcError {
             }
             SimulationViolation::UsedForbiddenPrecompile(_, _, _)
             | SimulationViolation::AccessedUndeployedContract(_, _)
+            | SimulationViolation::AccessedUnsupportedContractType(_, _)
             | SimulationViolation::CalledBannedEntryPointMethod(_)
             | SimulationViolation::CallHadValue(_) => Self::OpcodeViolationMap(value),
             SimulationViolation::FactoryCalledCreate2Twice(_) => {

--- a/crates/sim/src/simulation/context.rs
+++ b/crates/sim/src/simulation/context.rs
@@ -41,7 +41,7 @@ pub struct ValidationContext<UO> {
 pub(crate) struct TracerOutput {
     pub(crate) phases: Vec<Phase>,
     pub(crate) revert_data: Option<String>,
-    pub(crate) accessed_contract_addresses: Vec<Address>,
+    pub(crate) accessed_contracts: HashMap<Address, ContractInfo>,
     pub(crate) associated_slots_by_address: AssociatedSlotsByAddress,
     pub(crate) factory_called_create2_twice: bool,
     pub(crate) expected_storage: ExpectedStorage,
@@ -58,6 +58,14 @@ pub(crate) struct Phase {
     pub(crate) ran_out_of_gas: bool,
     pub(crate) undeployed_contract_accesses: Vec<Address>,
     pub(crate) ext_code_access_info: HashMap<Address, Opcode>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ContractInfo {
+    pub(crate) header: String,
+    pub(crate) opcode: Opcode,
+    pub(crate) length: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/sim/src/simulation/v0_6/context.rs
+++ b/crates/sim/src/simulation/v0_6/context.rs
@@ -201,18 +201,40 @@ mod tests {
         types::{Address, Bytes, U256},
         utils::hex,
     };
-    use rundler_types::{contracts::v0_6::i_entry_point::FailedOp, v0_6::UserOperation};
+    use rundler_types::{contracts::v0_6::i_entry_point::FailedOp, v0_6::UserOperation, Opcode};
+    use sim_context::ContractInfo;
 
     use super::*;
     use crate::simulation::context::{Phase, TracerOutput};
 
     fn get_test_tracer_output() -> TracerOutput {
         TracerOutput {
-            accessed_contract_addresses: vec![
-                Address::from_str("0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789").unwrap(),
-                Address::from_str("0xb856dbd4fa1a79a46d426f537455e7d3e79ab7c4").unwrap(),
-                Address::from_str("0x8abb13360b87be5eeb1b98647a016add927a136c").unwrap(),
-            ],
+            accessed_contracts: HashMap::from([
+                (
+                    Address::from_str("0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789").unwrap(),
+                    ContractInfo {
+                        header: "0x608060".to_string(),
+                        opcode: Opcode::CALL,
+                        length: 32,
+                    }
+                ),
+                (
+                    Address::from_str("0xb856dbd4fa1a79a46d426f537455e7d3e79ab7c4").unwrap(),
+                    ContractInfo {
+                        header: "0x608060".to_string(),
+                        opcode: Opcode::CALL,
+                        length: 32,
+                    }
+                ),
+                (
+                    Address::from_str("0x8abb13360b87be5eeb1b98647a016add927a136c").unwrap(),
+                    ContractInfo {
+                        header: "0x608060".to_string(),
+                        opcode: Opcode::CALL,
+                        length: 32,
+                    }
+                ),
+            ]),
             associated_slots_by_address: serde_json::from_str(r#"
             {
                 "0x0000000000000000000000000000000000000000": [

--- a/crates/sim/src/simulation/v0_7/context.rs
+++ b/crates/sim/src/simulation/v0_7/context.rs
@@ -346,10 +346,10 @@ impl<T> ValidationContextProvider<T> {
         }
 
         // Accessed contracts
-        let accessed_contract_addresses = tracer_out
+        let accessed_contracts = tracer_out
             .calls_from_entry_point
             .iter()
-            .flat_map(|call| call.contract_size.keys().cloned())
+            .flat_map(|call| call.contract_info.clone())
             .collect();
 
         // Associated slots
@@ -378,7 +378,7 @@ impl<T> ValidationContextProvider<T> {
         Ok(ContextTracerOutput {
             phases,
             revert_data: None,
-            accessed_contract_addresses,
+            accessed_contracts,
             associated_slots_by_address: AssociatedSlotsByAddress(associated_slots_by_address),
             factory_called_create2_twice,
             expected_storage: tracer_out.expected_storage,
@@ -417,8 +417,8 @@ impl<T> ValidationContextProvider<T> {
 
         let mut forbidden_precompiles_used = vec![];
         let mut undeployed_contract_accesses = vec![];
-        call.contract_size.iter().for_each(|(address, info)| {
-            if info.contract_size == 0 {
+        call.contract_info.iter().for_each(|(address, info)| {
+            if info.length == 0 {
                 if *address < MAX_PRECOMPILE_ADDRESS {
                     // [OP-062] - banned precompiles
                     // The tracer catches any allowed precompiles and does not add them to this list

--- a/crates/sim/src/simulation/v0_7/tracer.rs
+++ b/crates/sim/src/simulation/v0_7/tracer.rs
@@ -22,7 +22,7 @@ use rundler_provider::{Provider, SimulationProvider};
 use rundler_types::{v0_7::UserOperation, Opcode};
 use serde::Deserialize;
 
-use crate::ExpectedStorage;
+use crate::{simulation::context::ContractInfo, ExpectedStorage};
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -43,7 +43,7 @@ pub(super) struct TopLevelCallInfo {
     pub(super) top_level_target_address: String,
     pub(super) opcodes: HashMap<Opcode, u64>,
     pub(super) access: HashMap<Address, AccessInfo>,
-    pub(super) contract_size: HashMap<Address, ContractSizeInfo>,
+    pub(super) contract_info: HashMap<Address, ContractInfo>,
     pub(super) ext_code_access_info: HashMap<Address, Opcode>,
     pub(super) oog: Option<bool>,
 }
@@ -53,14 +53,6 @@ pub(super) struct TopLevelCallInfo {
 pub(super) struct AccessInfo {
     pub(super) reads: HashMap<U256, U256>,
     pub(super) writes: HashMap<U256, u64>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[allow(unused)]
-pub(super) struct ContractSizeInfo {
-    pub(super) opcode: Opcode,
-    pub(super) contract_size: u64,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/crates/types/src/pool/error.rs
+++ b/crates/types/src/pool/error.rs
@@ -225,6 +225,9 @@ pub enum SimulationViolation {
     /// Verification gas limit doesn't have the required buffer on the measured gas
     #[display("verification gas limit doesn't have the required buffer on the measured gas, limit: {0}, needed: {1}")]
     VerificationGasLimitBufferTooLow(U256, U256),
+    /// Unsupported contract type
+    #[display("accessed unsupported contract type: {0:?} at {1:?}. Address must be whitelisted")]
+    AccessedUnsupportedContractType(String, Address),
 }
 
 /// Information about a storage violation based on stake status


### PR DESCRIPTION
## Proposed Changes

  - Add a new simulation error for unsupported contract type
  - Capture contract "header" (first 3 bytes) for each call during tracing
  - If header matches the Arbitrum stylus header `0xEFF000`, add a violation
