### PR TITLE
feat(error): use unexpected error instead

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -21,7 +21,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.79.0
         with:
           components: llvm-tools-preview
 

--- a/crates/pool/src/server/local.rs
+++ b/crates/pool/src/server/local.rs
@@ -106,9 +106,14 @@ impl LocalPoolHandle {
                 response: send,
             })
             .await
-            .map_err(|_| anyhow::anyhow!("LocalPoolServer closed"))?;
-        recv.await
-            .map_err(|_| anyhow::anyhow!("LocalPoolServer closed"))?
+            .map_err(|_| {
+                error!("LocalPoolServer sender closed");
+                PoolError::UnexpectedResponse
+            })?;
+        recv.await.map_err(|_| {
+            error!("LocalPoolServer receiver closed");
+            PoolError::UnexpectedResponse
+        })?
     }
 }
 

--- a/crates/sim/src/gas/gas.rs
+++ b/crates/sim/src/gas/gas.rs
@@ -13,7 +13,7 @@
 
 use std::{cmp, fmt::Debug, sync::Arc};
 
-use anyhow::Context;
+use anyhow::{bail, Context};
 use ethers::types::U256;
 use rundler_provider::{EntryPoint, L1GasProvider, Provider};
 use rundler_types::{
@@ -83,6 +83,10 @@ pub async fn calc_required_pre_verification_gas<
         base_fee + op.max_priority_fee_per_gas(),
         op.max_fee_per_gas(),
     );
+
+    if gas_price.is_zero() {
+        bail!("Gas price cannot be zero")
+    }
 
     let dynamic_gas = entry_point
         .calc_l1_gas(entry_point.address(), op.clone(), gas_price)

--- a/crates/sim/src/precheck.rs
+++ b/crates/sim/src/precheck.rs
@@ -408,7 +408,6 @@ where
     ) -> anyhow::Result<U256> {
         gas::calc_required_pre_verification_gas(&self.chain_spec, &self.entry_point, &op, base_fee)
             .await
-            .context("should calculate pre-verification gas")
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

  - Log pool closed error and just propagate the UnexpectedResponse error instead. We do not really want to be saying that the pool sender has closed in rpc responses
  - Check that the gas price is not equal to zero before calculating the dynamic gas as this will lead to an integer overflow
