### PR TITLE
feat(estimation): increase max gas for simulation

### DIFF
--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -188,7 +188,7 @@ pub struct CommonArgs {
         long = "max_simulate_handle_ops_gas",
         name = "max_simulate_handle_ops_gas",
         env = "MAX_SIMULATE_HANDLE_OPS_GAS",
-        default_value = "20000000",
+        default_value = "550000000",
         global = true
     )]
     max_simulate_handle_ops_gas: u64,


### PR DESCRIPTION
## Proposed Changes

  - Increase the max gas for simulateHandleOps to the alchemy level max as no gas. If the value is too low on some networks we will be unable to estimate properly
