### PR TITLE
fix: add bucket to histogram metrics

### DIFF
--- a/bin/rundler/src/cli/metrics.rs
+++ b/bin/rundler/src/cli/metrics.rs
@@ -23,6 +23,7 @@ pub fn initialize<'a>(
     sample_interval_millis: u64,
     listen_addr: SocketAddr,
     tags: impl IntoIterator<Item = &'a String>,
+    buckets: &[f64],
 ) -> anyhow::Result<()> {
     let mut builder = PrometheusBuilder::new().with_http_listener(listen_addr);
 
@@ -33,6 +34,8 @@ pub fn initialize<'a>(
     for (k, v) in tags {
         builder = builder.add_global_label(k, v);
     }
+
+    builder = builder.set_buckets(buckets)?;
 
     let (recorder, exporter) = builder.build()?;
     tokio::spawn(exporter);

--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -46,6 +46,7 @@ pub async fn run() -> anyhow::Result<()> {
         opt.metrics.sample_interval_millis,
         metrics_addr,
         &opt.metrics.tags,
+        &opt.metrics.buckets,
     )
     .context("metrics server should start")?;
 
@@ -443,6 +444,18 @@ pub struct MetricsArgs {
         global = true
     )]
     sample_interval_millis: u64,
+
+    /// Bucket for histogram metric.
+    #[arg(
+        long = "metrics.histogram_buckets", 
+        name = "metrics.histogram_buckets",
+        env = "METRICS_HISTOGRAM_BUCKETS",
+        default_values_t = vec![0.0, 1000.0, 2000.0, 3000.0, 4000.0, 5000.0, 6000.0, 7000.0,
+                                8000.0, 9000.0, 10000.0, 11000.0, 12000.0, 13000.0, 14000.0,
+                                15000.0, 16000.0, 32000.0, 64000.0, 128000.0, 256000.0, 512000.0],
+        global = true
+    )]
+    buckets: Vec<f64>,
 }
 
 /// CLI options for logging


### PR DESCRIPTION
[Closes/Fixes] #

rundler's histgram metrics are incomplete, they miss the bucket metrics. We can only get quantile info without weights. this pr is to add buckets info. the bucket is defined as 2^x, balancing metric density and data accuracy. 

## Proposed Changes

  -
  -
  -
