### PR TITLE
feat: inject providers from bin

### DIFF
--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -11,6 +11,8 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
+use std::sync::Arc;
+
 use anyhow::{bail, Context};
 use clap::{builder::PossibleValuesParser, Args, Parser, Subcommand};
 
@@ -27,9 +29,14 @@ use builder::BuilderCliArgs;
 use node::NodeCliArgs;
 use pool::PoolCliArgs;
 use rpc::RpcCliArgs;
+use rundler_provider::{EntryPointProvider, EthersEntryPointV0_6, EthersEntryPointV0_7, Provider};
 use rundler_rpc::{EthApiSettings, RundlerApiSettings};
 use rundler_sim::{
     EstimationSettings, PrecheckSettings, PriorityFeeMode, SimulationSettings, MIN_CALL_GAS_LIMIT,
+};
+use rundler_types::{
+    chain::ChainSpec, v0_6::UserOperation as UserOperationV0_6,
+    v0_7::UserOperation as UserOperationV0_7,
 };
 
 /// Main entry point for the CLI
@@ -489,4 +496,54 @@ pub struct Cli {
 
     #[clap(flatten)]
     logs: LogsArgs,
+}
+
+pub struct RundlerProviders<P, EP06, EP07> {
+    provider: Arc<P>,
+    ep_v0_6: Option<EP06>,
+    ep_v0_7: Option<EP07>,
+}
+
+pub fn construct_providers(
+    args: &CommonArgs,
+    chain_spec: &ChainSpec,
+) -> anyhow::Result<
+    RundlerProviders<
+        impl Provider,
+        impl EntryPointProvider<UserOperationV0_6>,
+        impl EntryPointProvider<UserOperationV0_7>,
+    >,
+> {
+    let provider = rundler_provider::new_provider(
+        args.node_http.as_ref().context("must provide node_http")?,
+        None,
+    )?;
+
+    let ep_v0_6 = if args.disable_entry_point_v0_6 {
+        None
+    } else {
+        Some(EthersEntryPointV0_6::new(
+            chain_spec.entry_point_address_v0_6,
+            chain_spec,
+            args.max_simulate_handle_ops_gas,
+            provider.clone(),
+        ))
+    };
+
+    let ep_v0_7 = if args.disable_entry_point_v0_7 {
+        None
+    } else {
+        Some(EthersEntryPointV0_7::new(
+            chain_spec.entry_point_address_v0_7,
+            chain_spec,
+            args.max_simulate_handle_ops_gas,
+            provider.clone(),
+        ))
+    };
+
+    Ok(RundlerProviders {
+        provider,
+        ep_v0_6,
+        ep_v0_7,
+    })
 }

--- a/crates/builder/src/signer/aws.rs
+++ b/crates/builder/src/signer/aws.rs
@@ -14,9 +14,9 @@
 use std::{sync::Arc, time::Duration};
 
 use anyhow::Context;
-use ethers::providers::Middleware;
 use ethers_signers::{AwsSigner, Signer};
 use rslock::{Lock, LockGuard, LockManager};
+use rundler_provider::Provider;
 use rundler_utils::handle::SpawnGuard;
 use rusoto_core::Region;
 use rusoto_kms::KmsClient;
@@ -33,8 +33,8 @@ pub(crate) struct KmsSigner {
 }
 
 impl KmsSigner {
-    pub(crate) async fn connect<M: Middleware + 'static>(
-        provider: Arc<M>,
+    pub(crate) async fn connect<P: Provider>(
+        provider: Arc<P>,
         chain_id: u64,
         region: Region,
         key_ids: Vec<String>,

--- a/crates/builder/src/signer/mod.rs
+++ b/crates/builder/src/signer/mod.rs
@@ -19,13 +19,13 @@ use async_trait::async_trait;
 pub(crate) use aws::*;
 use ethers::{
     abi::Address,
-    providers::Middleware,
     types::{
         transaction::{eip2718::TypedTransaction, eip712::Eip712},
         Signature,
     },
 };
 use ethers_signers::{AwsSignerError, LocalWallet, Signer, WalletError};
+use rundler_provider::Provider;
 use rundler_utils::handle::SpawnGuard;
 
 /// A local signer handle
@@ -36,8 +36,8 @@ pub(crate) struct LocalSigner {
 }
 
 impl LocalSigner {
-    pub(crate) async fn connect<M: Middleware + 'static>(
-        provider: Arc<M>,
+    pub(crate) async fn connect<P: Provider>(
+        provider: Arc<P>,
         chain_id: u64,
         private_key: String,
     ) -> anyhow::Result<Self> {
@@ -55,7 +55,7 @@ impl LocalSigner {
     }
 }
 
-pub(crate) async fn monitor_account_balance<M: Middleware>(addr: Address, provider: Arc<M>) {
+pub(crate) async fn monitor_account_balance<P: Provider>(addr: Address, provider: Arc<P>) {
     loop {
         match provider.get_balance(addr, None).await {
             Ok(balance) => {

--- a/crates/provider/src/traits/entry_point.rs
+++ b/crates/provider/src/traits/entry_point.rs
@@ -242,5 +242,6 @@ pub trait EntryPointProvider<UO>:
     + BundleHandler<UO = UO>
     + SimulationProvider<UO = UO>
     + L1GasProvider<UO = UO>
+    + Clone
 {
 }


### PR DESCRIPTION
Closes #416 

## Proposed Changes

  - Modify tasks to take providers as arguments.
  - Construct providers in bin in a single spot.
  - This preps us for moving to Alloy providers, as there are only a few places where we will need to update. Providers, signers, and bin being the major places.
