### PR TITLE
fix failed spec test

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           path: bundler-test-executors
           repository: alchemyplatform/bundler-test-executor
-          ref: releases/v0.7
+          ref: master
 
       - name: Build rundler image locally
         run: docker buildx build ./rundler -t alchemyplatform/rundler:latest

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           path: bundler-test-executors
           repository: alchemyplatform/bundler-test-executor
-          ref: releases/v0.6
+          ref: releases/v0.7
 
       - name: Build rundler image locally
         run: docker buildx build ./rundler -t alchemyplatform/rundler:latest

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -29,6 +29,7 @@ jobs:
           path: bundler-test-executors
           repository: alchemyplatform/bundler-test-executor
           ref: master
+          submodules: recursive
 
       - name: Build rundler image locally
         run: docker buildx build ./rundler -t alchemyplatform/rundler:latest

--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -19,6 +19,9 @@ jobs:
           path: rundler
           submodules: recursive
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - uses: KengoTODA/actions-setup-docker-compose@v1
         with:
           version: '2.14.2'

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -13,10 +13,7 @@
 
 use anyhow::Context;
 use async_trait::async_trait;
-use ethers::{
-    core::k256::elliptic_curve::consts::True,
-    types::{Address, H256},
-};
+use ethers::types::{Address, H256};
 use futures_util::StreamExt;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use rundler_types::{
@@ -87,6 +84,7 @@ pub trait DebugApi {
         entry_point: Address,
     ) -> RpcResult<Vec<RpcDebugPaymasterBalance>>;
 
+    /// Clear the reputations of pool.
     #[method(name = "bundler_clearReputation")]
     async fn bundler_clear_reputation(&self) -> RpcResult<String>;
 }
@@ -192,8 +190,11 @@ where
     }
 
     async fn bundler_clear_reputation(&self) -> RpcResult<String> {
-        utils::safe_call_rpc_handler("bundler_clearState", DebugApi::bundler_clear_state(self))
-            .await
+        utils::safe_call_rpc_handler(
+            "bundler_clearState",
+            DebugApi::bundler_clear_reputation(self),
+        )
+        .await
     }
 }
 
@@ -371,5 +372,14 @@ where
         }
 
         Ok(results)
+    }
+
+    async fn bundler_clear_reputation(&self) -> InternalRpcResult<String> {
+        self.pool
+            .debug_clear_state(false, false, true)
+            .await
+            .context("should clear state")?;
+
+        Ok("ok".to_string())
     }
 }

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -13,7 +13,10 @@
 
 use anyhow::Context;
 use async_trait::async_trait;
-use ethers::types::{Address, H256};
+use ethers::{
+    core::k256::elliptic_curve::consts::True,
+    types::{Address, H256},
+};
 use futures_util::StreamExt;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use rundler_types::{
@@ -83,6 +86,9 @@ pub trait DebugApi {
         &self,
         entry_point: Address,
     ) -> RpcResult<Vec<RpcDebugPaymasterBalance>>;
+
+    #[method(name = "bundler_clearReputation")]
+    async fn bundler_clear_reputation(&self) -> RpcResult<String>;
 }
 
 pub(crate) struct DebugApi<P, B> {
@@ -183,6 +189,11 @@ where
             DebugApi::bundler_dump_paymaster_balances(self, entry_point),
         )
         .await
+    }
+
+    async fn bundler_clear_reputation(&self) -> RpcResult<String> {
+        utils::safe_call_rpc_handler("bundler_clearState", DebugApi::bundler_clear_state(self))
+            .await
     }
 }
 

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -191,7 +191,7 @@ where
 
     async fn bundler_clear_reputation(&self) -> RpcResult<String> {
         utils::safe_call_rpc_handler(
-            "bundler_clearState",
+            "bundler_clearReputation",
             DebugApi::bundler_clear_reputation(self),
         )
         .await
@@ -378,7 +378,7 @@ where
         self.pool
             .debug_clear_state(false, false, true)
             .await
-            .context("should clear state")?;
+            .context("should clear reputation")?;
 
         Ok("ok".to_string())
     }


### PR DESCRIPTION
I can't tag release/0.7 in alchemyplatform/bundler-test-executor so use master instead. since alchemyplatform/bundler-test-executor is owned by alchemy so I think it is low risk for now.

this pr also add `debug_bundler_clearReputation` endpoint. it simply calls `debug_bundler_clearState`. 