### PR TITLE
fix(provider): use latest for fee history in pending base fee

### DIFF
--- a/crates/provider/src/alloy/evm.rs
+++ b/crates/provider/src/alloy/evm.rs
@@ -152,7 +152,7 @@ where
     }
 
     async fn get_pending_base_fee(&self) -> ProviderResult<u128> {
-        let fee_history = self.fee_history(1, BlockNumberOrTag::Pending, &[]).await?;
+        let fee_history = self.fee_history(1, BlockNumberOrTag::Latest, &[]).await?;
         Ok(fee_history
             .next_block_base_fee()
             .context("should have a next block base fee")?)


### PR DESCRIPTION
## Proposed Changes

  - `latest` should work on all networks, and still returns the next block's base fee as per the [json-rpc spec](https://ethereum.github.io/execution-apis/api-documentation/)
