### PR TITLE
refactor: modify uo gas limit calcs & v0.6 builder

### DIFF
--- a/bin/rundler/chain_specs/arbitrum.toml
+++ b/bin/rundler/chain_specs/arbitrum.toml
@@ -1,9 +1,10 @@
 name = "Arbitrum"
 id = 42161
 
-calldata_pre_verification_gas = true 
-l1_gas_oracle_contract_type = "ARBITRUM_NITRO"
-l1_gas_oracle_contract_address = "0x00000000000000000000000000000000000000C8"
+da_pre_verification_gas = true 
+da_gas_oracle_contract_type = "ARBITRUM_NITRO"
+da_gas_oracle_contract_address = "0x00000000000000000000000000000000000000C8"
+include_da_gas_in_gas_limit = true
 
 supports_eip1559 = false
 max_transaction_size_bytes = 95000

--- a/bin/rundler/chain_specs/base.toml
+++ b/bin/rundler/chain_specs/base.toml
@@ -1,10 +1,9 @@
 name = "Base"
 id = 8453
 
-calldata_pre_verification_gas = true
-l1_gas_oracle_contract_type = "OPTIMISM_BEDROCK"
-l1_gas_oracle_contract_address = "0x420000000000000000000000000000000000000F"
-include_l1_gas_in_gas_limit = false
+da_pre_verification_gas = true
+da_gas_oracle_contract_type = "OPTIMISM_BEDROCK"
+da_gas_oracle_contract_address = "0x420000000000000000000000000000000000000F"
 
 max_transaction_size_bytes = 130000
 

--- a/bin/rundler/chain_specs/optimism.toml
+++ b/bin/rundler/chain_specs/optimism.toml
@@ -1,10 +1,9 @@
 name = "Optimism"
 id = 10
 
-calldata_pre_verification_gas = true
-l1_gas_oracle_contract_type = "OPTIMISM_BEDROCK"
-l1_gas_oracle_contract_address = "0x420000000000000000000000000000000000000F"
-include_l1_gas_in_gas_limit = false
+da_pre_verification_gas = true
+da_gas_oracle_contract_type = "OPTIMISM_BEDROCK"
+da_gas_oracle_contract_address = "0x420000000000000000000000000000000000000F"
 
 priority_fee_oracle_type = "USAGE_BASED"
 min_max_priority_fee_per_gas = 100000

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -54,9 +54,9 @@ mockall = {workspace = true, optional = true }
 
 [dev-dependencies]
 mockall.workspace = true
-rundler-types = { path = "../types", features = ["test-utils"] }
-rundler-provider = { path = "../provider", features = ["test-utils"] }
-rundler-sim = { path = "../sim", features = ["test-utils"] }
+rundler-types = { workspace = true, features = ["test-utils"] }
+rundler-provider = { workspace = true, features = ["test-utils"] }
+rundler-sim = { workspace = true, features = ["test-utils"] }
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/pool/Cargo.toml
+++ b/crates/pool/Cargo.toml
@@ -43,8 +43,8 @@ mockall = {workspace = true, optional = true }
 
 [dev-dependencies]
 mockall.workspace = true
-rundler-sim = { path = "../sim", features = ["test-utils"] }
-rundler-provider = { path = "../provider", features = ["test-utils"] }
+rundler-sim = { workspace = true, features = ["test-utils"] }
+rundler-provider = { workspace = true, features = ["test-utils"] }
 reth-tasks.workspace = true
 
 [build-dependencies]

--- a/crates/pool/src/server/remote/protos.rs
+++ b/crates/pool/src/server/remote/protos.rs
@@ -68,21 +68,25 @@ pub trait TryUoFromProto<T>: Sized {
 impl TryUoFromProto<UserOperationV06> for v0_6::UserOperation {
     fn try_uo_from_proto(
         op: UserOperationV06,
-        _chain_spec: &ChainSpec,
+        chain_spec: &ChainSpec,
     ) -> Result<Self, ConversionError> {
-        Ok(v0_6::UserOperation {
-            sender: from_bytes(&op.sender)?,
-            nonce: from_bytes(&op.nonce)?,
-            init_code: op.init_code.into(),
-            call_data: op.call_data.into(),
-            call_gas_limit: from_bytes(&op.call_gas_limit)?,
-            verification_gas_limit: from_bytes(&op.verification_gas_limit)?,
-            pre_verification_gas: from_bytes(&op.pre_verification_gas)?,
-            max_fee_per_gas: from_bytes(&op.max_fee_per_gas)?,
-            max_priority_fee_per_gas: from_bytes(&op.max_priority_fee_per_gas)?,
-            paymaster_and_data: op.paymaster_and_data.into(),
-            signature: op.signature.into(),
-        })
+        Ok(v0_6::UserOperationBuilder::new(
+            chain_spec,
+            v0_6::UserOperationRequiredFields {
+                sender: from_bytes(&op.sender)?,
+                nonce: from_bytes(&op.nonce)?,
+                init_code: op.init_code.into(),
+                call_data: op.call_data.into(),
+                call_gas_limit: from_bytes(&op.call_gas_limit)?,
+                verification_gas_limit: from_bytes(&op.verification_gas_limit)?,
+                pre_verification_gas: from_bytes(&op.pre_verification_gas)?,
+                max_fee_per_gas: from_bytes(&op.max_fee_per_gas)?,
+                max_priority_fee_per_gas: from_bytes(&op.max_priority_fee_per_gas)?,
+                paymaster_and_data: op.paymaster_and_data.into(),
+                signature: op.signature.into(),
+            },
+        )
+        .build())
     }
 }
 

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -38,7 +38,7 @@ mockall = {workspace = true, optional = true }
 test-utils = [ "mockall" ]
 
 [dev-dependencies]
-rundler-provider = { path = ".", features = ["test-utils"] }
+rundler-provider = { workspace = true, features = ["test-utils"] }
 alloy-provider = {workspace = true,  features=["debug-api", "anvil-node"]}
 alloy-node-bindings = "0.4.2"
 tokio.workspace = true

--- a/crates/provider/src/alloy/entry_point/arbitrum.rs
+++ b/crates/provider/src/alloy/entry_point/arbitrum.rs
@@ -37,7 +37,7 @@ sol! {
     }
 }
 
-pub(crate) async fn estimate_l1_gas<AP: AlloyProvider<T>, T: Transport + Clone>(
+pub(crate) async fn estimate_da_gas<AP: AlloyProvider<T>, T: Transport + Clone>(
     provider: AP,
     oracle_address: Address,
     to_address: Address,

--- a/crates/provider/src/alloy/entry_point/mod.rs
+++ b/crates/provider/src/alloy/entry_point/mod.rs
@@ -17,7 +17,7 @@ use alloy_provider::Provider as AlloyProvider;
 use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::TransactionRequest;
 use alloy_transport::Transport;
-use rundler_types::chain::{ChainSpec, L1GasOracleContractType};
+use rundler_types::chain::{ChainSpec, DAGasOracleContractType};
 
 use crate::ProviderResult;
 
@@ -28,27 +28,27 @@ mod arbitrum;
 mod optimism;
 
 #[derive(Debug, Default, Clone)]
-enum L1GasOracle {
+enum DAGasOracle {
     ArbitrumNitro(Address),
     OptimismBedrock(Address),
     #[default]
     None,
 }
 
-impl L1GasOracle {
-    fn new(chain_spec: &ChainSpec) -> L1GasOracle {
-        match chain_spec.l1_gas_oracle_contract_type {
-            L1GasOracleContractType::ArbitrumNitro => {
-                L1GasOracle::ArbitrumNitro(chain_spec.l1_gas_oracle_contract_address)
+impl DAGasOracle {
+    fn new(chain_spec: &ChainSpec) -> DAGasOracle {
+        match chain_spec.da_gas_oracle_contract_type {
+            DAGasOracleContractType::ArbitrumNitro => {
+                DAGasOracle::ArbitrumNitro(chain_spec.da_gas_oracle_contract_address)
             }
-            L1GasOracleContractType::OptimismBedrock => {
-                L1GasOracle::OptimismBedrock(chain_spec.l1_gas_oracle_contract_address)
+            DAGasOracleContractType::OptimismBedrock => {
+                DAGasOracle::OptimismBedrock(chain_spec.da_gas_oracle_contract_address)
             }
-            L1GasOracleContractType::None => L1GasOracle::None,
+            DAGasOracleContractType::None => DAGasOracle::None,
         }
     }
 
-    async fn estimate_l1_gas<AP: AlloyProvider<T>, T: Transport + Clone>(
+    async fn estimate_da_gas<AP: AlloyProvider<T>, T: Transport + Clone>(
         &self,
         provider: AP,
         to_address: Address,
@@ -56,13 +56,13 @@ impl L1GasOracle {
         gas_price: u128,
     ) -> ProviderResult<u128> {
         match self {
-            L1GasOracle::ArbitrumNitro(oracle_address) => {
-                arbitrum::estimate_l1_gas(provider, *oracle_address, to_address, data).await
+            DAGasOracle::ArbitrumNitro(oracle_address) => {
+                arbitrum::estimate_da_gas(provider, *oracle_address, to_address, data).await
             }
-            L1GasOracle::OptimismBedrock(oracle_address) => {
-                optimism::estimate_l1_gas(provider, *oracle_address, data, gas_price).await
+            DAGasOracle::OptimismBedrock(oracle_address) => {
+                optimism::estimate_da_gas(provider, *oracle_address, data, gas_price).await
             }
-            L1GasOracle::None => Ok(0),
+            DAGasOracle::None => Ok(0),
         }
     }
 }

--- a/crates/provider/src/alloy/entry_point/optimism.rs
+++ b/crates/provider/src/alloy/entry_point/optimism.rs
@@ -27,7 +27,7 @@ sol! {
     }
 }
 
-pub(crate) async fn estimate_l1_gas<AP: AlloyProvider<T>, T: Transport + Clone>(
+pub(crate) async fn estimate_da_gas<AP: AlloyProvider<T>, T: Transport + Clone>(
     provider: AP,
     oracle_address: Address,
     data: Bytes,
@@ -41,7 +41,7 @@ pub(crate) async fn estimate_l1_gas<AP: AlloyProvider<T>, T: Transport + Clone>(
         .await?
         ._0
         .try_into()
-        .context("failed to convert L1 fee to u128")?;
+        .context("failed to convert DA fee to u128")?;
 
     Ok(l1_fee.checked_div(gas_price).unwrap_or(u128::MAX))
 }

--- a/crates/provider/src/alloy/entry_point/v0_7.rs
+++ b/crates/provider/src/alloy/entry_point/v0_7.rs
@@ -40,18 +40,18 @@ use rundler_types::{
     ValidationRevert,
 };
 
-use super::L1GasOracle;
+use super::DAGasOracle;
 use crate::{
-    AggregatorOut, AggregatorSimOut, BundleHandler, DepositInfo, EntryPoint,
+    AggregatorOut, AggregatorSimOut, BundleHandler, DAGasProvider, DepositInfo, EntryPoint,
     EntryPointProvider as EntryPointProviderTrait, EvmCall, ExecutionResult, HandleOpsOut,
-    L1GasProvider, ProviderResult, SignatureAggregator, SimulationProvider,
+    ProviderResult, SignatureAggregator, SimulationProvider,
 };
 
 /// Entry point provider for v0.7
 #[derive(Clone)]
 pub struct EntryPointProvider<AP, T> {
     i_entry_point: IEntryPointInstance<T, AP>,
-    l1_gas_oracle: L1GasOracle,
+    da_gas_oracle: DAGasOracle,
     max_aggregation_gas: u64,
 }
 
@@ -64,7 +64,7 @@ where
     pub fn new(chain_spec: &ChainSpec, max_aggregation_gas: u64, provider: AP) -> Self {
         Self {
             i_entry_point: IEntryPointInstance::new(chain_spec.entry_point_address_v0_7, provider),
-            l1_gas_oracle: L1GasOracle::new(chain_spec),
+            da_gas_oracle: DAGasOracle::new(chain_spec),
             max_aggregation_gas,
         }
     }
@@ -144,6 +144,7 @@ where
 
         let packed_ops = ops.into_iter().map(|op| op.pack()).collect();
 
+        // TODO(danc): HERE
         let result = aggregator
             .aggregateSignatures(packed_ops)
             .gas(self.max_aggregation_gas)
@@ -258,14 +259,14 @@ where
 }
 
 #[async_trait::async_trait]
-impl<AP, T> L1GasProvider for EntryPointProvider<AP, T>
+impl<AP, T> DAGasProvider for EntryPointProvider<AP, T>
 where
     T: Transport + Clone,
     AP: AlloyProvider<T>,
 {
     type UO = UserOperation;
 
-    async fn calc_l1_gas(
+    async fn calc_da_gas(
         &self,
         entry_point_address: Address,
         user_op: UserOperation,
@@ -281,8 +282,8 @@ where
 
         let bundle_data = super::max_bundle_transaction_data(entry_point_address, data, gas_price);
 
-        self.l1_gas_oracle
-            .estimate_l1_gas(
+        self.da_gas_oracle
+            .estimate_da_gas(
                 self.i_entry_point.provider(),
                 entry_point_address,
                 bundle_data,

--- a/crates/provider/src/traits/entry_point.rs
+++ b/crates/provider/src/traits/entry_point.rs
@@ -150,19 +150,19 @@ pub trait BundleHandler: Send + Sync {
     ) -> TransactionRequest;
 }
 
-/// Trait for calculating L1 gas costs for user operations
+/// Trait for calculating Data Availability (DA) gas costs for user operations
 ///
-/// Used for L2 gas estimation
+/// Used for L2+ gas estimation
 #[async_trait::async_trait]
 #[auto_impl::auto_impl(&, &mut, Rc, Arc, Box)]
-pub trait L1GasProvider: Send + Sync {
+pub trait DAGasProvider: Send + Sync {
     /// The type of user operation used by this entry point
     type UO: UserOperation;
 
-    /// Calculate the L1 portion of the gas for a user operation
+    /// Calculate the DA portion of the gas for a user operation
     ///
-    /// Returns zero for operations that do not require L1 gas
-    async fn calc_l1_gas(
+    /// Returns zero for operations that do not require DA gas
+    async fn calc_da_gas(
         &self,
         entry_point_address: Address,
         op: Self::UO,
@@ -224,6 +224,6 @@ pub trait EntryPointProvider<UO>:
     + SignatureAggregator<UO = UO>
     + BundleHandler<UO = UO>
     + SimulationProvider<UO = UO>
-    + L1GasProvider<UO = UO>
+    + DAGasProvider<UO = UO>
 {
 }

--- a/crates/provider/src/traits/test_utils.rs
+++ b/crates/provider/src/traits/test_utils.rs
@@ -27,9 +27,9 @@ use rundler_types::{
 
 use super::error::ProviderResult;
 use crate::{
-    AggregatorOut, BundleHandler, DepositInfo, EntryPoint, EvmCall,
-    EvmProvider as EvmProviderTrait, ExecutionResult, HandleOpsOut, L1GasProvider,
-    SignatureAggregator, SimulationProvider,
+    AggregatorOut, BundleHandler, DAGasProvider, DepositInfo, EntryPoint, EvmCall,
+    EvmProvider as EvmProviderTrait, ExecutionResult, HandleOpsOut, SignatureAggregator,
+    SimulationProvider,
 };
 
 mockall::mock! {
@@ -173,9 +173,9 @@ mockall::mock! {
     }
 
     #[async_trait::async_trait]
-    impl L1GasProvider for EntryPointV0_6 {
+    impl DAGasProvider for EntryPointV0_6 {
         type UO = v0_6::UserOperation;
-        async fn calc_l1_gas(
+        async fn calc_da_gas(
             &self,
             entry_point_address: Address,
             op: v0_6::UserOperation,
@@ -265,9 +265,9 @@ mockall::mock! {
     }
 
     #[async_trait::async_trait]
-    impl L1GasProvider for EntryPointV0_7 {
+    impl DAGasProvider for EntryPointV0_7 {
         type UO = v0_7::UserOperation;
-        async fn calc_l1_gas(
+        async fn calc_da_gas(
             &self,
             entry_point_address: Address,
             op: v0_7::UserOperation,

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -36,6 +36,6 @@ futures-util.workspace = true
 [dev-dependencies]
 mockall.workspace = true
 alloy-consensus.workspace = true
-rundler-provider = { path = "../provider", features = ["test-utils"]}
-rundler-sim = { path = "../sim", features = ["test-utils"] }
-rundler-types= { path = "../types", features = ["test-utils"]}
+rundler-provider = { workspace = true, features = ["test-utils"]}
+rundler-sim = { workspace = true, features = ["test-utils"] }
+rundler-types= { workspace = true, features = ["test-utils"]}

--- a/crates/rpc/src/eth/events/v0_7.rs
+++ b/crates/rpc/src/eth/events/v0_7.rs
@@ -19,7 +19,7 @@ use rundler_contracts::v0_7::IEntryPoint::{
 use rundler_provider::{Log, TransactionReceipt};
 use rundler_types::{
     chain::ChainSpec,
-    v0_7::{self, UserOperation},
+    v0_7::{UserOperation, UserOperationBuilder},
 };
 
 use super::common::{EntryPointEvents, UserOperationEventProviderImpl};
@@ -86,16 +86,22 @@ impl EntryPointEvents for EntryPointFiltersV0_7 {
             IEntryPointCalls::handleOps(handle_ops_call) => handle_ops_call
                 .ops
                 .into_iter()
-                .filter_map(|op| v0_7::unpack_user_operation(op, chain_spec).ok())
+                .filter_map(|op| {
+                    UserOperationBuilder::from_packed(op, chain_spec)
+                        .ok()
+                        .map(|uo| uo.build())
+                })
                 .collect(),
             IEntryPointCalls::handleAggregatedOps(handle_aggregated_ops_call) => {
                 handle_aggregated_ops_call
                     .opsPerAggregator
                     .into_iter()
                     .flat_map(|ops| {
-                        ops.userOps
-                            .into_iter()
-                            .filter_map(|op| v0_7::unpack_user_operation(op, chain_spec).ok())
+                        ops.userOps.into_iter().filter_map(|op| {
+                            UserOperationBuilder::from_packed(op, chain_spec)
+                                .ok()
+                                .map(|uo| uo.build())
+                        })
                     })
                     .collect()
             }

--- a/crates/rpc/src/rundler.rs
+++ b/crates/rpc/src/rundler.rs
@@ -143,6 +143,7 @@ where
             Err(EthRpcError::InvalidParams("Invalid user operation for drop: preVerificationGas, callGasLimit, callData, and maxFeePerGas must be zero".to_string()))?;
         }
 
+        // TODO(danc): HERE
         let valid = self
             .entry_point_router
             .check_signature(&entry_point, uo, self.settings.max_verification_gas)

--- a/crates/rpc/src/types/v0_6.rs
+++ b/crates/rpc/src/types/v0_6.rs
@@ -14,7 +14,9 @@
 use alloy_primitives::{Address, Bytes, U128, U256};
 use rundler_types::{
     chain::ChainSpec,
-    v0_6::{UserOperation, UserOperationOptionalGas},
+    v0_6::{
+        UserOperation, UserOperationBuilder, UserOperationOptionalGas, UserOperationRequiredFields,
+    },
     GasEstimate,
 };
 use serde::{Deserialize, Serialize};
@@ -57,20 +59,24 @@ impl From<UserOperation> for RpcUserOperation {
 }
 
 impl FromRpc<RpcUserOperation> for UserOperation {
-    fn from_rpc(def: RpcUserOperation, _chain_spec: &ChainSpec) -> Self {
-        UserOperation {
-            sender: def.sender.into(),
-            nonce: def.nonce,
-            init_code: def.init_code,
-            call_data: def.call_data,
-            call_gas_limit: def.call_gas_limit.to(),
-            verification_gas_limit: def.verification_gas_limit.to(),
-            pre_verification_gas: def.pre_verification_gas.to(),
-            max_fee_per_gas: def.max_fee_per_gas.to(),
-            max_priority_fee_per_gas: def.max_priority_fee_per_gas.to(),
-            paymaster_and_data: def.paymaster_and_data,
-            signature: def.signature,
-        }
+    fn from_rpc(def: RpcUserOperation, chain_spec: &ChainSpec) -> Self {
+        UserOperationBuilder::new(
+            chain_spec,
+            UserOperationRequiredFields {
+                sender: def.sender.into(),
+                nonce: def.nonce,
+                init_code: def.init_code,
+                call_data: def.call_data,
+                call_gas_limit: def.call_gas_limit.to(),
+                verification_gas_limit: def.verification_gas_limit.to(),
+                pre_verification_gas: def.pre_verification_gas.to(),
+                max_fee_per_gas: def.max_fee_per_gas.to(),
+                max_priority_fee_per_gas: def.max_priority_fee_per_gas.to(),
+                paymaster_and_data: def.paymaster_and_data,
+                signature: def.signature,
+            },
+        )
+        .build()
     }
 }
 

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -38,8 +38,9 @@ mockall = {workspace = true, optional = true }
 
 [dev-dependencies]
 mockall.workspace = true
-rundler-provider = { path = "../provider", features = ["test-utils"] }
-rundler-sim = { path = ".", features = ["test-utils"] }
+rundler-provider = { workspace = true, features = ["test-utils"] }
+rundler-sim = { workspace = true, features = ["test-utils"] }
+rundler-types = { workspace = true, features = ["test-utils"] }
 alloy-primitives = { workspace = true, features = ["rand"]}
 
 [features]

--- a/crates/sim/src/estimation/estimate_call_gas.rs
+++ b/crates/sim/src/estimation/estimate_call_gas.rs
@@ -126,6 +126,7 @@ where
                     *self.entry_point.address(),
                     target_call_data,
                     block_hash.into(),
+                    // TODO(danc): HERE
                     self.settings.max_simulate_handle_ops_gas,
                     state_override.clone(),
                 )
@@ -218,6 +219,7 @@ where
                 *self.entry_point.address(),
                 target_call_data,
                 block_hash.into(),
+                // TODO(danc): HERE
                 self.settings.max_simulate_handle_ops_gas,
                 state_override.clone(),
             )

--- a/crates/sim/src/estimation/estimate_verification_gas.rs
+++ b/crates/sim/src/estimation/estimate_verification_gas.rs
@@ -127,6 +127,7 @@ where
                     Address::ZERO,
                     Bytes::new(),
                     block_hash.into(),
+                    // TODO(danc): HERE
                     self.settings.max_simulate_handle_ops_gas,
                     state_override,
                 )
@@ -149,6 +150,7 @@ where
         };
 
         let mut max_failure_gas = 1;
+
         let mut min_success_gas = self.settings.max_verification_gas;
 
         if gas_used.gasUsed.gt(&U256::from(u128::MAX)) {

--- a/crates/sim/src/estimation/v0_6.rs
+++ b/crates/sim/src/estimation/v0_6.rs
@@ -107,7 +107,8 @@ where
         let mut op_with_gas = full_op;
         op_with_gas.verification_gas_limit = verification_gas_limit;
         op_with_gas.call_gas_limit = call_gas_limit;
-        let gas_limit = op_with_gas.execution_gas_limit(&self.chain_spec, true);
+        // require that this can fit in a bundle of size 1
+        let gas_limit = op_with_gas.execution_gas_limit(&self.chain_spec, Some(1));
         if gas_limit > self.settings.max_total_execution_gas {
             return Err(GasEstimationError::GasTotalTooLarge(
                 gas_limit,

--- a/crates/sim/src/estimation/v0_7.rs
+++ b/crates/sim/src/estimation/v0_7.rs
@@ -123,7 +123,8 @@ where
         op_with_gas.call_gas_limit = call_gas_limit;
         op_with_gas.verification_gas_limit = verification_gas_limit;
         op_with_gas.paymaster_verification_gas_limit = paymaster_verification_gas_limit;
-        let gas_limit = op_with_gas.execution_gas_limit(&self.chain_spec, true);
+        // require that this can fit in a bundle of size 1
+        let gas_limit = op_with_gas.execution_gas_limit(&self.chain_spec, Some(1));
         if gas_limit > self.settings.max_total_execution_gas {
             return Err(GasEstimationError::GasTotalTooLarge(
                 gas_limit,

--- a/crates/sim/src/gas/gas.rs
+++ b/crates/sim/src/gas/gas.rs
@@ -46,11 +46,6 @@ pub async fn estimate_pre_verification_gas<
     random_op: &UO,
     gas_price: u128,
 ) -> anyhow::Result<u128> {
-    let static_gas = full_op.static_pre_verification_gas(chain_spec);
-
-    // Currently assume 1 op bundle
-    let shared_gas = chain_spec.transaction_intrinsic_gas();
-
     let da_gas = if chain_spec.da_pre_verification_gas {
         entry_point
             .calc_da_gas(*entry_point.address(), random_op.clone(), gas_price)
@@ -59,7 +54,8 @@ pub async fn estimate_pre_verification_gas<
         0
     };
 
-    Ok(static_gas.saturating_add(shared_gas).saturating_add(da_gas))
+    // Currently assume 1 op bundle
+    Ok(full_op.required_pre_verification_gas(chain_spec, 1, da_gas))
 }
 
 /// Calculate the required pre_verification_gas for the given user operation and the provided base fee.
@@ -74,11 +70,6 @@ pub async fn calc_required_pre_verification_gas<
     op: &UO,
     base_fee: u128,
 ) -> anyhow::Result<u128> {
-    let static_gas = op.static_pre_verification_gas(chain_spec);
-
-    // Currently assume 1 op bundle
-    let shared_gas = chain_spec.transaction_intrinsic_gas();
-
     let da_gas = if chain_spec.da_pre_verification_gas {
         let gas_price = cmp::min(
             base_fee + op.max_priority_fee_per_gas(),
@@ -96,7 +87,8 @@ pub async fn calc_required_pre_verification_gas<
         0
     };
 
-    Ok(static_gas.saturating_add(shared_gas).saturating_add(da_gas))
+    // Currently assume 1 op bundle
+    Ok(op.required_pre_verification_gas(chain_spec, 1, da_gas))
 }
 
 /// Different modes for calculating the required priority fee

--- a/crates/sim/src/precheck.rs
+++ b/crates/sim/src/precheck.rs
@@ -240,9 +240,9 @@ where
             ));
         }
 
-        // compute the worst case total gas limit by assuming the UO is in its own bundle and has a postOp call.
+        // Compute the worst case total gas limit by assuming the UO is in its own bundle.
         // This is conservative and potentially may invalidate some very large UOs that would otherwise be valid.
-        let gas_limit = op.execution_gas_limit(&self.chain_spec, true);
+        let gas_limit = op.execution_gas_limit(&self.chain_spec, Some(1));
         if gas_limit > max_total_execution_gas {
             violations.push(PrecheckViolation::TotalGasLimitTooHigh(
                 gas_limit,
@@ -523,7 +523,7 @@ mod tests {
 
         let res = prechecker.check_gas(&op, get_test_async_data());
 
-        let total_gas_limit = op.gas_limit(&cs, true);
+        let total_gas_limit = op.gas_limit(&cs, Some(1));
 
         assert_eq!(
             res,

--- a/crates/sim/src/simulation/simulator.rs
+++ b/crates/sim/src/simulation/simulator.rs
@@ -420,6 +420,8 @@ where
                 Some(block_id),
             )
             .map_err(|e| SimulationError::from(anyhow::anyhow!("should call get_code_hash {e:?}")));
+
+        // TODO(danc): HERE
         let aggregator_signature_future = self.validate_aggregator_signature(
             op,
             aggregator_address,
@@ -686,7 +688,11 @@ mod tests {
     use rundler_provider::{
         AggregatorOut, BlockId, BlockNumberOrTag, MockEntryPointV0_6, MockEvmProvider,
     };
-    use rundler_types::{v0_6::UserOperation, Opcode, StakeInfo};
+    use rundler_types::{
+        chain::ChainSpec,
+        v0_6::{UserOperation, UserOperationBuilder, UserOperationRequiredFields},
+        Opcode, StakeInfo,
+    };
 
     use self::context::{Phase, TracerOutput};
     use super::*;
@@ -893,7 +899,7 @@ mod tests {
             .expect_validate_user_op_signature()
             .returning(|_, _, _| Ok(AggregatorOut::NotNeeded));
 
-        let user_operation = UserOperation {
+        let user_operation = UserOperationBuilder::new(&ChainSpec::default(),UserOperationRequiredFields {
             sender: address!("b856dbd4fa1a79a46d426f537455e7d3e79ab7c4"),
             nonce: U256::from(264),
             init_code: Bytes::default(),
@@ -905,7 +911,7 @@ mod tests {
             max_priority_fee_per_gas: 105000000,
             paymaster_and_data: Bytes::default(),
             signature: bytes!("98f89993ce573172635b44ef3b0741bd0c19dd06909d3539159f6d66bef8c0945550cc858b1cf5921dfce0986605097ba34c2cf3fc279154dd25e161ea7b3d0f1c"),
-        };
+        }).build();
 
         let simulator = create_simulator(provider, entry_point, context);
         let res = simulator

--- a/crates/sim/src/simulation/unsafe_sim.rs
+++ b/crates/sim/src/simulation/unsafe_sim.rs
@@ -81,6 +81,7 @@ where
             }
         };
 
+        // TODO(danc): HERE
         // simulate the validation
         let validation_result = self
             .entry_point
@@ -127,6 +128,7 @@ where
         let mut violations = vec![];
 
         let aggregator = if let Some(aggregator_info) = validation_result.aggregator_info {
+            // TODO(danc): HERE
             let agg_out = self
                 .entry_point
                 .validate_user_op_signature(

--- a/crates/sim/src/simulation/v0_6/context.rs
+++ b/crates/sim/src/simulation/v0_6/context.rs
@@ -183,6 +183,7 @@ where
     /// Creates a new `ValidationContextProvider` for entry point v0.6 with the given provider and entry point.
     pub(crate) fn new(provider: P, entry_point: E, sim_settings: SimulationSettings) -> Self {
         Self {
+            // TODO(danc): HERE
             simulate_validation_tracer: SimulateValidationTracerImpl::new(
                 provider,
                 entry_point,
@@ -201,7 +202,11 @@ mod tests {
     use alloy_primitives::{address, bytes, hex, Bytes, U256};
     use alloy_sol_types::SolError;
     use rundler_contracts::v0_6::IEntryPoint::FailedOp;
-    use rundler_types::{v0_6::UserOperation, Opcode};
+    use rundler_types::{
+        chain::ChainSpec,
+        v0_6::{UserOperation, UserOperationBuilder, UserOperationRequiredFields},
+        Opcode,
+    };
     use sim_context::ContractInfo;
 
     use super::*;
@@ -322,7 +327,7 @@ mod tests {
             Ok(tracer_output)
         });
 
-        let user_operation = UserOperation {
+        let user_operation = UserOperationBuilder::new(&ChainSpec::default(),UserOperationRequiredFields {
             sender: address!("b856dbd4fa1a79a46d426f537455e7d3e79ab7c4"),
             nonce: U256::from(264),
             init_code: Bytes::default(),
@@ -334,7 +339,7 @@ mod tests {
             max_priority_fee_per_gas: 105000000,
             paymaster_and_data: Bytes::default(),
             signature: bytes!("98f89993ce573172635b44ef3b0741bd0c19dd06909d3539159f6d66bef8c0945550cc858b1cf5921dfce0986605097ba34c2cf3fc279154dd25e161ea7b3d0f1c"),
-        };
+        }).build();
 
         let context = ValidationContextProvider {
             simulate_validation_tracer: tracer,

--- a/crates/sim/src/simulation/v0_7/context.rs
+++ b/crates/sim/src/simulation/v0_7/context.rs
@@ -465,6 +465,7 @@ where
     pub(crate) fn new(provider: P, entry_point: E, sim_settings: SimulationSettings) -> Self {
         Self {
             entry_point_address: *entry_point.address(),
+            // TODO(danc): HERE
             simulate_validation_tracer: SimulateValidationTracerImpl::new(
                 provider,
                 entry_point,

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -31,7 +31,7 @@ thiserror.workspace = true
 mockall = {workspace = true, optional = true }
 
 [dev-dependencies]
-rundler-types = { path = ".", features = ["test-utils"] }
+rundler-types = { workspace = true, features = ["test-utils"] }
 alloy-primitives = { workspace = true, features = ["rand"] }
 
 [features]

--- a/crates/types/src/chain.rs
+++ b/crates/types/src/chain.rs
@@ -62,16 +62,16 @@ pub struct ChainSpec {
     /*
      * Gas estimation
      */
-    /// true if calldata is priced in preVerificationGas
-    pub calldata_pre_verification_gas: bool,
+    /// true if DA is priced in preVerificationGas
+    pub da_pre_verification_gas: bool,
     /// type of gas oracle contract for pricing calldata in preVerificationGas
-    /// If calldata_pre_verification_gas is true, this must not be None
-    pub l1_gas_oracle_contract_type: L1GasOracleContractType,
+    /// If da_pre_verification_gas is true, this must not be None
+    pub da_gas_oracle_contract_type: DAGasOracleContractType,
     /// address of gas oracle contract for pricing calldata in preVerificationGas
-    pub l1_gas_oracle_contract_address: Address,
-    /// true if L1 calldata gas should be included in the gas limit
-    /// only applies when calldata_pre_verification_gas is true
-    pub include_l1_gas_in_gas_limit: bool,
+    pub da_gas_oracle_contract_address: Address,
+    /// true if Data Availability (DA) calldata gas should be included in the gas limit
+    /// only applies when da_pre_verification_gas is true
+    pub include_da_gas_in_gas_limit: bool,
 
     /*
      * Fee estimation
@@ -121,7 +121,7 @@ pub struct ChainSpec {
 /// Type of gas oracle contract for pricing calldata in preVerificationGas
 #[derive(Clone, Copy, Debug, Deserialize, Default, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum L1GasOracleContractType {
+pub enum DAGasOracleContractType {
     /// No gas oracle contract
     #[default]
     None,
@@ -158,10 +158,10 @@ impl Default for ChainSpec {
             calldata_zero_byte_gas: 4,
             calldata_non_zero_byte_gas: 16,
             eip1559_enabled: true,
-            calldata_pre_verification_gas: false,
-            l1_gas_oracle_contract_type: L1GasOracleContractType::default(),
-            l1_gas_oracle_contract_address: Address::ZERO,
-            include_l1_gas_in_gas_limit: true,
+            da_pre_verification_gas: false,
+            da_gas_oracle_contract_type: DAGasOracleContractType::default(),
+            da_gas_oracle_contract_address: Address::ZERO,
+            include_da_gas_in_gas_limit: false,
             priority_fee_oracle_type: PriorityFeeOracleType::default(),
             min_max_priority_fee_per_gas: 0,
             max_max_priority_fee_per_gas: u64::MAX,


### PR DESCRIPTION
## Proposed Changes

  - Change L1 -> DA (Data Availability) in variable names about DA gas
  - Move gas limit functions to UO trait
  - Use builder pattern for v0.6 UO
  - Introduce `da_pre_verification_gas_limit` function for retrieving the DA portion of the PVG as it applies to the gas limit.

This work is in preparation for #783 and #744

NOTE: The `TODO(danc): HERE` comments are where I'm planning on updating for #783, they just got caught up in this PR. They'll be removed in the subsequent PR before the feature branch merges.
