### PR TITLE
feat: move limits to providers, add da to limit

### DIFF
--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -396,8 +396,6 @@ impl TryFrom<&CommonArgs> for SimulationSettings {
         Ok(Self::new(
             value.min_unstake_delay,
             U256::from(value.min_stake_value),
-            value.max_simulate_handle_ops_gas,
-            value.max_verification_gas,
             value.tracer_timeout.clone(),
         ))
     }
@@ -419,7 +417,6 @@ impl TryFrom<&CommonArgs> for RundlerApiSettings {
                 value.priority_fee_mode_value,
             )?,
             bundle_priority_fee_overhead_percent: value.bundle_priority_fee_overhead_percent,
-            max_verification_gas: value.max_verification_gas,
         })
     }
 }
@@ -559,7 +556,9 @@ pub fn construct_providers(
         None
     } else {
         Some(AlloyEntryPointV0_6::new(
-            chain_spec,
+            chain_spec.clone(),
+            args.max_verification_gas,
+            args.max_simulate_handle_ops_gas,
             args.max_simulate_handle_ops_gas,
             provider.clone(),
         ))
@@ -569,7 +568,9 @@ pub fn construct_providers(
         None
     } else {
         Some(AlloyEntryPointV0_7::new(
-            chain_spec,
+            chain_spec.clone(),
+            args.max_verification_gas,
+            args.max_simulate_handle_ops_gas,
             args.max_simulate_handle_ops_gas,
             provider.clone(),
         ))

--- a/crates/builder/src/task.rs
+++ b/crates/builder/src/task.rs
@@ -225,11 +225,7 @@ where
                     i + ep.bundle_builder_index_offset,
                     self.provider.clone(),
                     ep_v0_6.clone(),
-                    UnsafeSimulator::new(
-                        self.provider.clone(),
-                        ep_v0_6.clone(),
-                        self.args.sim_settings.clone(),
-                    ),
+                    UnsafeSimulator::new(self.provider.clone(), ep_v0_6.clone()),
                     pk_iter,
                 )
                 .await?
@@ -277,11 +273,7 @@ where
                     i + ep.bundle_builder_index_offset,
                     self.provider.clone(),
                     ep_v0_7.clone(),
-                    UnsafeSimulator::new(
-                        self.provider.clone(),
-                        ep_v0_7.clone(),
-                        self.args.sim_settings.clone(),
-                    ),
+                    UnsafeSimulator::new(self.provider.clone(), ep_v0_7.clone()),
                     pk_iter,
                 )
                 .await?

--- a/crates/pool/src/task.rs
+++ b/crates/pool/src/task.rs
@@ -208,11 +208,7 @@ where
             .context("entry point v0.6 not supplied")?;
 
         if unsafe_mode {
-            let simulator = UnsafeSimulator::new(
-                self.provider.clone(),
-                ep.clone(),
-                pool_config.sim_settings.clone(),
-            );
+            let simulator = UnsafeSimulator::new(self.provider.clone(), ep.clone());
             Self::create_mempool(
                 task_spawner,
                 chain_spec,
@@ -255,11 +251,7 @@ where
             .context("entry point v0.7 not supplied")?;
 
         if unsafe_mode {
-            let simulator = UnsafeSimulator::new(
-                self.provider.clone(),
-                ep.clone(),
-                pool_config.sim_settings.clone(),
-            );
+            let simulator = UnsafeSimulator::new(self.provider.clone(), ep.clone());
             Self::create_mempool(
                 task_spawner,
                 chain_spec,

--- a/crates/provider/src/traits/entry_point.rs
+++ b/crates/provider/src/traits/entry_point.rs
@@ -121,7 +121,6 @@ pub trait SignatureAggregator: Send + Sync {
         &self,
         aggregator_address: Address,
         user_op: Self::UO,
-        gas_cap: u64,
     ) -> ProviderResult<AggregatorOut>;
 }
 
@@ -133,11 +132,13 @@ pub trait BundleHandler: Send + Sync {
     type UO: UserOperation;
 
     /// Call the entry point contract's `handleOps` function
+    ///
+    /// If `gas_limit` is `None`, the maximum gas limit is used.
     async fn call_handle_ops(
         &self,
         ops_per_aggregator: Vec<UserOpsPerAggregator<Self::UO>>,
         beneficiary: Address,
-        gas: u64,
+        gas_limit: Option<u64>,
     ) -> ProviderResult<HandleOpsOut>;
 
     /// Construct the transaction to send a bundle of operations to the entry point contract
@@ -145,7 +146,7 @@ pub trait BundleHandler: Send + Sync {
         &self,
         ops_per_aggregator: Vec<UserOpsPerAggregator<Self::UO>>,
         beneficiary: Address,
-        gas: u64,
+        gas_limit: u64,
         gas_fees: GasFees,
     ) -> TransactionRequest;
 }
@@ -181,14 +182,12 @@ pub trait SimulationProvider: Send + Sync {
     fn get_tracer_simulate_validation_call(
         &self,
         user_op: Self::UO,
-        max_validation_gas: u64,
     ) -> ProviderResult<(TransactionRequest, StateOverride)>;
 
     /// Call the entry point contract's `simulateValidation` function.
     async fn simulate_validation(
         &self,
         user_op: Self::UO,
-        max_validation_gas: u64,
         block_id: Option<BlockId>,
     ) -> ProviderResult<Result<ValidationOutput, ValidationRevert>>;
 
@@ -203,7 +202,6 @@ pub trait SimulationProvider: Send + Sync {
         target: Address,
         target_call_data: Bytes,
         block_hash: BlockId,
-        gas: u64,
         state_override: StateOverride,
     ) -> ProviderResult<Result<ExecutionResult, ValidationRevert>>;
 

--- a/crates/provider/src/traits/test_utils.rs
+++ b/crates/provider/src/traits/test_utils.rs
@@ -134,7 +134,6 @@ mockall::mock! {
             &self,
             aggregator_address: Address,
             user_op: v0_6::UserOperation,
-            gas_cap: u64,
         ) -> ProviderResult<AggregatorOut>;
     }
 
@@ -144,12 +143,10 @@ mockall::mock! {
         fn get_tracer_simulate_validation_call(
             &self,
             user_op: v0_6::UserOperation,
-            max_validation_gas: u64,
         ) -> ProviderResult<(TransactionRequest, StateOverride)>;
         async fn simulate_validation(
             &self,
             user_op: v0_6::UserOperation,
-            max_validation_gas: u64,
             block_id: Option<BlockId>
         ) -> ProviderResult<Result<ValidationOutput, ValidationRevert>>;
         fn get_simulate_handle_op_call(
@@ -163,7 +160,6 @@ mockall::mock! {
             target: Address,
             target_call_data: Bytes,
             block_id: BlockId,
-            gas: u64,
             state_override: StateOverride,
         ) -> ProviderResult<Result<ExecutionResult, ValidationRevert>>;
         fn decode_simulate_handle_ops_revert(
@@ -190,13 +186,13 @@ mockall::mock! {
             &self,
             ops_per_aggregator: Vec<UserOpsPerAggregator<v0_6::UserOperation>>,
             beneficiary: Address,
-            gas: u64,
+            gas_limit: Option<u64>,
         ) -> ProviderResult<HandleOpsOut>;
         fn get_send_bundle_transaction(
             &self,
             ops_per_aggregator: Vec<UserOpsPerAggregator<v0_6::UserOperation>>,
             beneficiary: Address,
-            gas: u64,
+            gas_limit: u64,
             gas_fees: GasFees,
         ) -> TransactionRequest;
     }
@@ -226,7 +222,6 @@ mockall::mock! {
             &self,
             aggregator_address: Address,
             user_op: v0_7::UserOperation,
-            gas_cap: u64,
         ) -> ProviderResult<AggregatorOut>;
     }
 
@@ -236,12 +231,10 @@ mockall::mock! {
         fn get_tracer_simulate_validation_call(
             &self,
             user_op: v0_7::UserOperation,
-            max_validation_gas: u64,
         ) -> ProviderResult<(TransactionRequest, StateOverride)>;
         async fn simulate_validation(
             &self,
             user_op: v0_7::UserOperation,
-            max_validation_gas: u64,
             block_id: Option<BlockId>
         ) -> ProviderResult<Result<ValidationOutput, ValidationRevert>>;
         fn get_simulate_handle_op_call(
@@ -255,7 +248,6 @@ mockall::mock! {
             target: Address,
             target_call_data: Bytes,
             block_id: BlockId,
-            gas: u64,
             state_override: StateOverride,
         ) -> ProviderResult<Result<ExecutionResult, ValidationRevert>>;
         fn decode_simulate_handle_ops_revert(
@@ -282,13 +274,13 @@ mockall::mock! {
             &self,
             ops_per_aggregator: Vec<UserOpsPerAggregator<v0_7::UserOperation>>,
             beneficiary: Address,
-            gas: u64,
+            gas_limit: Option<u64>,
         ) -> ProviderResult<HandleOpsOut>;
         fn get_send_bundle_transaction(
             &self,
             ops_per_aggregator: Vec<UserOpsPerAggregator<v0_7::UserOperation>>,
             beneficiary: Address,
-            gas: u64,
+            gas_limit: u64,
             gas_fees: GasFees,
         ) -> TransactionRequest;
     }

--- a/crates/rpc/src/eth/router.rs
+++ b/crates/rpc/src/eth/router.rs
@@ -191,10 +191,9 @@ impl EntryPointRouter {
         &self,
         entry_point: &Address,
         uo: UserOperationVariant,
-        max_verification_gas: u64,
     ) -> EthResult<bool> {
         self.check_and_get_route(entry_point, &uo)?
-            .check_signature(uo, max_verification_gas)
+            .check_signature(uo)
             .await
             .map_err(Into::into)
     }
@@ -245,11 +244,7 @@ pub(crate) trait EntryPointRoute: Send + Sync {
         state_override: Option<StateOverride>,
     ) -> Result<GasEstimate, GasEstimationError>;
 
-    async fn check_signature(
-        &self,
-        uo: UserOperationVariant,
-        max_verification_gas: u64,
-    ) -> anyhow::Result<bool>;
+    async fn check_signature(&self, uo: UserOperationVariant) -> anyhow::Result<bool>;
 }
 
 #[derive(Debug)]
@@ -298,14 +293,10 @@ where
             .await
     }
 
-    async fn check_signature(
-        &self,
-        uo: UserOperationVariant,
-        max_verification_gas: u64,
-    ) -> anyhow::Result<bool> {
+    async fn check_signature(&self, uo: UserOperationVariant) -> anyhow::Result<bool> {
         let output = self
             .entry_point
-            .simulate_validation(uo.into(), max_verification_gas, None)
+            .simulate_validation(uo.into(), None)
             .await??;
 
         Ok(!output.return_info.account_sig_failed)

--- a/crates/rpc/src/rundler.rs
+++ b/crates/rpc/src/rundler.rs
@@ -32,8 +32,6 @@ pub struct Settings {
     /// If using a bundle priority fee, the percentage to add to the network/oracle
     /// provided value as a safety margin for fast inclusion.
     pub bundle_priority_fee_overhead_percent: u32,
-    /// Max verification gas
-    pub max_verification_gas: u64,
 }
 
 #[rpc(client, server, namespace = "rundler")]
@@ -60,7 +58,6 @@ pub trait RundlerApi {
 
 pub(crate) struct RundlerApi<P, F> {
     chain_spec: ChainSpec,
-    settings: Settings,
     fee_estimator: F,
     pool_server: P,
     entry_point_router: EntryPointRouter,
@@ -103,11 +100,9 @@ where
         entry_point_router: EntryPointRouter,
         pool_server: P,
         fee_estimator: F,
-        settings: Settings,
     ) -> Self {
         Self {
             chain_spec: chain_spec.clone(),
-            settings,
             entry_point_router,
             pool_server,
             fee_estimator,
@@ -143,10 +138,9 @@ where
             Err(EthRpcError::InvalidParams("Invalid user operation for drop: preVerificationGas, callGasLimit, callData, and maxFeePerGas must be zero".to_string()))?;
         }
 
-        // TODO(danc): HERE
         let valid = self
             .entry_point_router
-            .check_signature(&entry_point, uo, self.settings.max_verification_gas)
+            .check_signature(&entry_point, uo)
             .await?;
         if !valid {
             Err(EthRpcError::InvalidParams(

--- a/crates/rpc/src/task.rs
+++ b/crates/rpc/src/task.rs
@@ -276,7 +276,6 @@ where
                     entry_point_router,
                     self.pool.clone(),
                     fee_estimator,
-                    self.args.rundler_api_settings,
                 )
                 .into_rpc(),
             )?;

--- a/crates/sim/src/estimation/estimate_call_gas.rs
+++ b/crates/sim/src/estimation/estimate_call_gas.rs
@@ -126,8 +126,6 @@ where
                     *self.entry_point.address(),
                     target_call_data,
                     block_hash.into(),
-                    // TODO(danc): HERE
-                    self.settings.max_simulate_handle_ops_gas,
                     state_override.clone(),
                 )
                 .await?
@@ -219,8 +217,6 @@ where
                 *self.entry_point.address(),
                 target_call_data,
                 block_hash.into(),
-                // TODO(danc): HERE
-                self.settings.max_simulate_handle_ops_gas,
                 state_override.clone(),
             )
             .await?

--- a/crates/sim/src/estimation/estimate_verification_gas.rs
+++ b/crates/sim/src/estimation/estimate_verification_gas.rs
@@ -127,8 +127,6 @@ where
                     Address::ZERO,
                     Bytes::new(),
                     block_hash.into(),
-                    // TODO(danc): HERE
-                    self.settings.max_simulate_handle_ops_gas,
                     state_override,
                 )
                 .await?

--- a/crates/sim/src/estimation/v0_7.rs
+++ b/crates/sim/src/estimation/v0_7.rs
@@ -208,15 +208,6 @@ where
         &self,
         optional_op: &UserOperationOptionalGas,
     ) -> Result<(), GasEstimationError> {
-        if let Some(pvg) = optional_op.pre_verification_gas {
-            // TODO(danc): HERE
-            if pvg > self.settings.max_verification_gas {
-                return Err(GasEstimationError::GasFieldTooLarge(
-                    "preVerificationGas",
-                    self.settings.max_verification_gas,
-                ));
-            }
-        }
         if let Some(vl) = optional_op.verification_gas_limit {
             if vl > self.settings.max_verification_gas {
                 return Err(GasEstimationError::GasFieldTooLarge(
@@ -624,25 +615,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_pvg_over_max() {
-        let (entry, provider) = create_base_config();
-        let (estimator, _) = create_estimator(entry, provider);
-
-        let optional_op = demo_user_op_optional_gas(Some(TEST_MAX_GAS_LIMITS + 1));
-
-        let estimation = estimator
-            .estimate_op_gas(optional_op, StateOverride::default())
-            .await
-            .err()
-            .unwrap();
-
-        assert!(matches!(
-            estimation,
-            GasEstimationError::GasFieldTooLarge("preVerificationGas", TEST_MAX_GAS_LIMITS)
-        ));
-    }
-
-    #[tokio::test]
     async fn test_vgl_over_max() {
         let (entry, provider) = create_base_config();
         let (estimator, _) = create_estimator(entry, provider);
@@ -735,7 +707,7 @@ mod tests {
 
         entry
             .expect_simulate_handle_op()
-            .returning(move |_a, _b, _c, _d, _e, _f| {
+            .returning(move |_a, _b, _c, _d, _e| {
                 Ok(Ok(ExecutionResult {
                     target_result: TestCallGasResult {
                         success: true,
@@ -796,7 +768,7 @@ mod tests {
 
         entry
             .expect_simulate_handle_op()
-            .returning(move |_a, _b, _c, _d, _e, _f| {
+            .returning(move |_a, _b, _c, _d, _e| {
                 Ok(Ok(ExecutionResult {
                     target_result: TestCallGasResult {
                         success: false,
@@ -834,7 +806,7 @@ mod tests {
 
         entry
             .expect_simulate_handle_op()
-            .returning(move |_a, _b, _c, _d, _e, _f| {
+            .returning(move |_a, _b, _c, _d, _e| {
                 Ok(Ok(ExecutionResult {
                     target_result: TestCallGasResult {
                         success: true,

--- a/crates/sim/src/simulation/mod.rs
+++ b/crates/sim/src/simulation/mod.rs
@@ -168,10 +168,6 @@ pub struct Settings {
     /// The minimum amount of stake that a staked entity must have on the entry point
     /// contract in order to be considered staked.
     pub min_stake_value: U256,
-    /// The maximum amount of gas that can be used during the simulation call
-    pub max_simulate_handle_ops_gas: u64,
-    /// The maximum amount of verification gas that can be used during the simulation call
-    pub max_verification_gas: u64,
     /// The max duration of the custom javascript tracer. Must be in a format parseable by the
     /// ParseDuration function on an ethereum node. See Docs: https://pkg.go.dev/time#ParseDuration
     pub tracer_timeout: String,
@@ -179,18 +175,10 @@ pub struct Settings {
 
 impl Settings {
     /// Create new settings
-    pub fn new(
-        min_unstake_delay: u32,
-        min_stake_value: U256,
-        max_simulate_handle_ops_gas: u64,
-        max_verification_gas: u64,
-        tracer_timeout: String,
-    ) -> Self {
+    pub fn new(min_unstake_delay: u32, min_stake_value: U256, tracer_timeout: String) -> Self {
         Self {
             min_unstake_delay,
             min_stake_value,
-            max_simulate_handle_ops_gas,
-            max_verification_gas,
             tracer_timeout,
         }
     }
@@ -204,9 +192,6 @@ impl Default for Settings {
             min_unstake_delay: 84600,
             // 10^18 wei = 1 eth
             min_stake_value: uint!(1_000_000_000_000_000_000_U256),
-            // 550 million gas: currently the defaults for Alchemy eth_call
-            max_simulate_handle_ops_gas: 550_000_000,
-            max_verification_gas: 5_000_000,
             tracer_timeout: "10s".to_string(),
         }
     }

--- a/crates/sim/src/simulation/unsafe_sim.rs
+++ b/crates/sim/src/simulation/unsafe_sim.rs
@@ -19,9 +19,7 @@ use rundler_provider::{
 };
 use rundler_types::{pool::SimulationViolation, EntityInfos, UserOperation, ValidTimeRange};
 
-use crate::{
-    SimulationError, SimulationResult, SimulationSettings as Settings, Simulator, ViolationError,
-};
+use crate::{SimulationError, SimulationResult, Simulator, ViolationError};
 
 /// An unsafe simulator that can be used in place of a regular simulator
 /// to extract the information needed from simulation while avoiding the use
@@ -32,17 +30,15 @@ use crate::{
 pub struct UnsafeSimulator<UO, P, E> {
     provider: P,
     entry_point: E,
-    sim_settings: Settings,
     _uo_type: PhantomData<UO>,
 }
 
 impl<UO, P, E> UnsafeSimulator<UO, P, E> {
     /// Creates a new unsafe simulator
-    pub fn new(provider: P, entry_point: E, sim_settings: Settings) -> Self {
+    pub fn new(provider: P, entry_point: E) -> Self {
         Self {
             provider,
             entry_point,
-            sim_settings,
             _uo_type: PhantomData,
         }
     }
@@ -81,15 +77,10 @@ where
             }
         };
 
-        // TODO(danc): HERE
         // simulate the validation
         let validation_result = self
             .entry_point
-            .simulate_validation(
-                op.clone(),
-                self.sim_settings.max_verification_gas,
-                Some(block_hash.into()),
-            )
+            .simulate_validation(op.clone(), Some(block_hash.into()))
             .await?;
 
         let validation_result = match validation_result {
@@ -128,14 +119,9 @@ where
         let mut violations = vec![];
 
         let aggregator = if let Some(aggregator_info) = validation_result.aggregator_info {
-            // TODO(danc): HERE
             let agg_out = self
                 .entry_point
-                .validate_user_op_signature(
-                    aggregator_info.address,
-                    op,
-                    self.sim_settings.max_verification_gas,
-                )
+                .validate_user_op_signature(aggregator_info.address, op)
                 .await?;
 
             match agg_out {

--- a/crates/sim/src/simulation/v0_6/context.rs
+++ b/crates/sim/src/simulation/v0_6/context.rs
@@ -183,11 +183,9 @@ where
     /// Creates a new `ValidationContextProvider` for entry point v0.6 with the given provider and entry point.
     pub(crate) fn new(provider: P, entry_point: E, sim_settings: SimulationSettings) -> Self {
         Self {
-            // TODO(danc): HERE
             simulate_validation_tracer: SimulateValidationTracerImpl::new(
                 provider,
                 entry_point,
-                sim_settings.max_verification_gas,
                 sim_settings.tracer_timeout.clone(),
             ),
             sim_settings,

--- a/crates/sim/src/simulation/v0_6/tracer.rs
+++ b/crates/sim/src/simulation/v0_6/tracer.rs
@@ -51,7 +51,6 @@ pub(super) trait SimulateValidationTracer: Send + Sync {
 pub(crate) struct SimulateValidationTracerImpl<P, E> {
     provider: P,
     entry_point: E,
-    max_validation_gas: u64,
     tracer_timeout: String,
 }
 
@@ -71,7 +70,7 @@ where
     ) -> anyhow::Result<TracerOutput> {
         let (tx, state_override) = self
             .entry_point
-            .get_tracer_simulate_validation_call(op, self.max_validation_gas)
+            .get_tracer_simulate_validation_call(op)
             .context("should get simulate validation call")?;
 
         TracerOutput::try_from(
@@ -98,16 +97,10 @@ where
 
 impl<P, E> SimulateValidationTracerImpl<P, E> {
     /// Creates a new instance of the bundler's custom tracer.
-    pub(crate) fn new(
-        provider: P,
-        entry_point: E,
-        max_validation_gas: u64,
-        tracer_timeout: String,
-    ) -> Self {
+    pub(crate) fn new(provider: P, entry_point: E, tracer_timeout: String) -> Self {
         Self {
             provider,
             entry_point,
-            max_validation_gas,
             tracer_timeout,
         }
     }

--- a/crates/sim/src/simulation/v0_7/context.rs
+++ b/crates/sim/src/simulation/v0_7/context.rs
@@ -465,11 +465,9 @@ where
     pub(crate) fn new(provider: P, entry_point: E, sim_settings: SimulationSettings) -> Self {
         Self {
             entry_point_address: *entry_point.address(),
-            // TODO(danc): HERE
             simulate_validation_tracer: SimulateValidationTracerImpl::new(
                 provider,
                 entry_point,
-                sim_settings.max_verification_gas,
                 sim_settings.tracer_timeout.clone(),
             ),
             sim_settings,

--- a/crates/sim/src/simulation/v0_7/tracer.rs
+++ b/crates/sim/src/simulation/v0_7/tracer.rs
@@ -125,7 +125,6 @@ pub(super) trait SimulateValidationTracer: Send + Sync {
 pub(crate) struct SimulateValidationTracerImpl<P, E> {
     provider: P,
     entry_point: E,
-    max_validation_gas: u64,
     tracer_timeout: String,
 }
 
@@ -145,7 +144,7 @@ where
     ) -> anyhow::Result<TracerOutput> {
         let (tx, state_override) = self
             .entry_point
-            .get_tracer_simulate_validation_call(op, self.max_validation_gas)
+            .get_tracer_simulate_validation_call(op)
             .context("should get tracer simulate validation call")?;
 
         let out = self
@@ -173,16 +172,10 @@ where
 
 impl<P, E> SimulateValidationTracerImpl<P, E> {
     /// Creates a new instance of the bundler's custom tracer.
-    pub(crate) fn new(
-        provider: P,
-        entry_point: E,
-        max_validation_gas: u64,
-        tracer_timeout: String,
-    ) -> Self {
+    pub(crate) fn new(provider: P, entry_point: E, tracer_timeout: String) -> Self {
         Self {
             provider,
             entry_point,
-            max_validation_gas,
             tracer_timeout,
         }
     }

--- a/crates/types/src/user_operation/v0_6.rs
+++ b/crates/types/src/user_operation/v0_6.rs
@@ -453,7 +453,6 @@ impl UserOperationOptionalGas {
         let cgl = super::default_if_none_or_equal(self.call_gas_limit, max_call_gas, 0);
         let vgl =
             super::default_if_none_or_equal(self.verification_gas_limit, max_verification_gas, 0);
-        // TODO(danc): HERE
         let pvg = super::default_if_none_or_equal(self.pre_verification_gas, max_call_gas, 0);
 
         let required = UserOperationRequiredFields {

--- a/crates/types/src/user_operation/v0_7.rs
+++ b/crates/types/src/user_operation/v0_7.rs
@@ -429,7 +429,6 @@ impl UserOperationOptionalGas {
             max_paymaster_verification_gas,
             0,
         );
-        // TODO(danc): HERE
         let pvg = super::default_if_none_or_equal(self.pre_verification_gas, max_call_gas, 0);
 
         let mut builder = UserOperationBuilder::new(


### PR DESCRIPTION
Closes: #783 

## Proposed Changes

  - Move usage of `max_verification_gas` and `max_simulate_handle_ops_gas` as gas limits to the entry point providers
  - Add DA gas limit to the gas limit, where necessary 
  - Remove unneeded PVG checks
