### PR TITLE
feat: better output error with inner root cause.

### DIFF
--- a/crates/rpc/src/eth/error.rs
+++ b/crates/rpc/src/eth/error.rs
@@ -376,7 +376,7 @@ impl From<SimulationViolation> for EthRpcError {
 
 impl From<EthRpcError> for ErrorObjectOwned {
     fn from(error: EthRpcError) -> Self {
-        let msg = error.to_string();
+        let msg = format!("{:#}", error);
 
         match error {
             EthRpcError::Internal(_) => rpc_err(INTERNAL_ERROR_CODE, msg),


### PR DESCRIPTION
[Closes/Fixes] #794

## Proposed Changes
  - change error display to "{:#}" ref: https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations
 
  -
  -
