### PR TITLE
feat(pool): add da tracking to pool

### DIFF
--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -333,6 +333,9 @@ impl BuilderArgs {
 
         let sender_args = self.sender_args(&chain_spec, &rpc_url)?;
 
+        let da_gas_tracking_enabled =
+            super::lint_da_gas_tracking(common.da_gas_tracking_enabled, &chain_spec);
+
         Ok(BuilderTaskArgs {
             entry_points,
             chain_spec,
@@ -353,6 +356,7 @@ impl BuilderArgs {
             max_cancellation_fee_increases: self.max_cancellation_fee_increases,
             max_replacement_underpriced_blocks: self.max_replacement_underpriced_blocks,
             remote_address,
+            da_gas_tracking_enabled,
         })
     }
 

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -201,7 +201,9 @@ impl PoolArgs {
         };
         tracing::info!("Mempool channel configs: {:?}", mempool_channel_configs);
 
-        let chain_id = chain_spec.id;
+        let da_gas_tracking_enabled =
+            super::lint_da_gas_tracking(common.da_gas_tracking_enabled, &chain_spec);
+
         let pool_config_base = PoolConfig {
             // update per entry point
             entry_point: Address::ZERO,
@@ -209,7 +211,7 @@ impl PoolArgs {
             num_shards: 0,
             mempool_channel_configs: HashMap::new(),
             // Base config
-            chain_id,
+            chain_spec: chain_spec.clone(),
             same_sender_mempool_count: self.same_sender_mempool_count,
             min_replacement_fee_increase_percentage: self.min_replacement_fee_increase_percentage,
             max_size_of_pool_bytes: self.max_size_in_bytes,
@@ -223,6 +225,7 @@ impl PoolArgs {
             paymaster_cache_length: self.paymaster_cache_length,
             reputation_tracking_enabled: self.reputation_tracking_enabled,
             drop_min_num_blocks: self.drop_min_num_blocks,
+            da_gas_tracking_enabled,
         };
 
         let mut pool_configs = vec![];

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -1018,7 +1018,7 @@ impl Trigger for BundleSenderTrigger {
                 a = self.bundle_action_receiver.recv() => {
                     match a {
                         Some(BundleSenderAction::ChangeMode(mode)) => {
-                            debug!("changing bundling mode to {mode:?}");
+                            info!("changing bundling mode to {mode:?}");
                             self.bundling_mode = mode;
                             continue;
                         },

--- a/crates/builder/src/task.rs
+++ b/crates/builder/src/task.rs
@@ -87,6 +87,8 @@ pub struct Args {
     pub remote_address: Option<SocketAddr>,
     /// Entry points to start builders for
     pub entry_points: Vec<EntryPointBuilderSettings>,
+    /// Enable DA tracking
+    pub da_gas_tracking_enabled: bool,
 }
 
 /// Builder settings for an entrypoint
@@ -360,6 +362,7 @@ where
             beneficiary,
             priority_fee_mode: self.args.priority_fee_mode,
             bundle_priority_fee_overhead_percent: self.args.bundle_priority_fee_overhead_percent,
+            da_gas_tracking_enabled: self.args.da_gas_tracking_enabled,
         };
 
         let transaction_sender = self

--- a/crates/pool/Cargo.toml
+++ b/crates/pool/Cargo.toml
@@ -47,6 +47,7 @@ mockall.workspace = true
 reth-tasks.workspace = true
 rundler-provider = { workspace = true, features = ["test-utils"] }
 rundler-sim = { workspace = true, features = ["test-utils"] }
+rundler-types = { workspace = true, features = ["test-utils"] }
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -153,6 +153,29 @@ message MempoolOp {
   bool account_is_staked = 7;
   // The entry point address of this operation
   bytes entry_point = 8;
+  // The DA gas data for the UO
+  DaGasUoData da_gas_data = 9;
+}
+
+// Data associated with a user operation for DA gas calculations
+message DaGasUoData {
+  oneof data {
+    EmptyUoData empty = 1;
+    NitroDaGasUoData nitro = 2;
+    BedrockDaGasUoData bedrock = 3;
+  }
+}
+
+message EmptyUoData {}
+
+// Data associated with a user operation for Nitro DA gas calculations
+message NitroDaGasUoData {
+  bytes uo_units = 1;
+}
+
+// Data associated with a user operation for Bedrock DA gas calculations
+message BedrockDaGasUoData {
+  uint64 uo_units = 1;
 }
 
 // Defines the gRPC endpoints for a UserOperation mempool service

--- a/crates/pool/src/emit.rs
+++ b/crates/pool/src/emit.rs
@@ -56,6 +56,17 @@ pub enum OpPoolEvent {
         /// The throttled entity
         entity: Entity,
     },
+    /// DA data was updated for an operation
+    UpdatedDAData {
+        /// The operation hash
+        op_hash: B256,
+        /// The DA data
+        eligible: bool,
+        /// The required pre_verification_gas
+        required_pvg: u128,
+        /// The actual pre_verification_gas
+        actual_pvg: u128,
+    },
 }
 
 /// Summary of the entities associated with an operation
@@ -191,6 +202,24 @@ impl Display for OpPoolEvent {
             }
             OpPoolEvent::ThrottledEntity { entity } => {
                 write!(f, concat!("Throttled entity.", "    Entity: {}",), entity,)
+            }
+            OpPoolEvent::UpdatedDAData {
+                op_hash,
+                eligible,
+                required_pvg,
+                actual_pvg,
+            } => {
+                write!(
+                    f,
+                    concat!(
+                        "Updated DA data for op: ",
+                        "Hash: {:?} ",
+                        "Eligible: {} ",
+                        "Required PVG: {} ",
+                        "Actual PVG: {}",
+                    ),
+                    op_hash, eligible, required_pvg, actual_pvg,
+                )
             }
         }
     }

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -33,6 +33,7 @@ use alloy_primitives::{Address, B256};
 use mockall::automock;
 use rundler_sim::{MempoolConfig, PrecheckSettings, SimulationSettings};
 use rundler_types::{
+    chain::ChainSpec,
     pool::{
         MempoolError, PaymasterMetadata, PoolOperation, Reputation, ReputationStatus, StakeStatus,
     },
@@ -124,12 +125,12 @@ pub trait Mempool: Send + Sync {
 /// Config for the mempool
 #[derive(Debug, Clone)]
 pub struct PoolConfig {
+    /// Chain specification
+    pub chain_spec: ChainSpec,
     /// Address of the entry point this pool targets
     pub entry_point: Address,
     /// Version of the entry point this pool targets
     pub entry_point_version: EntryPointVersion,
-    /// Chain ID this pool targets
-    pub chain_id: u64,
     /// The maximum number of operations an unstaked sender can have in the mempool
     pub same_sender_mempool_count: usize,
     /// The minimum fee bump required to replace an operation in the mempool
@@ -162,6 +163,8 @@ pub struct PoolConfig {
     pub paymaster_cache_length: u32,
     /// Boolean field used to toggle the operation of the reputation tracker
     pub reputation_tracking_enabled: bool,
+    /// Boolean field used to toggle the operation of the DA tracker
+    pub da_gas_tracking_enabled: bool,
     /// The minimum number of blocks a user operation must be in the mempool before it can be dropped
     pub drop_min_num_blocks: u64,
 }
@@ -227,6 +230,7 @@ mod tests {
                     is_staked: false,
                 }),
             },
+            da_gas_data: Default::default(),
         };
 
         let entities = po.entities().collect::<Vec<_>>();

--- a/crates/pool/src/mempool/paymaster.rs
+++ b/crates/pool/src/mempool/paymaster.rs
@@ -529,6 +529,7 @@ mod tests {
             sim_block_number: 0,
             account_is_staked: true,
             entity_infos: EntityInfos::default(),
+            da_gas_data: rundler_types::da::DAGasUOData::Empty,
         }
     }
 

--- a/crates/pool/src/task.rs
+++ b/crates/pool/src/task.rs
@@ -285,7 +285,7 @@ where
         chain_spec: ChainSpec,
         pool_config: &PoolConfig,
         event_sender: broadcast::Sender<WithEntryPoint<OpPoolEvent>>,
-        provider: P,
+        evm: P,
         ep: E,
         simulator: S,
     ) -> anyhow::Result<Arc<dyn Mempool + 'static>>
@@ -296,9 +296,9 @@ where
         E: EntryPointProvider<UO> + Clone + 'static,
         S: Simulator<UO = UO> + 'static,
     {
-        let fee_oracle = gas::get_fee_oracle(&chain_spec, provider.clone());
+        let fee_oracle = gas::get_fee_oracle(&chain_spec, evm.clone());
         let fee_estimator = FeeEstimatorImpl::new(
-            provider.clone(),
+            evm.clone(),
             fee_oracle,
             pool_config.precheck_settings.priority_fee_mode,
             pool_config
@@ -308,7 +308,7 @@ where
 
         let prechecker = PrecheckerImpl::new(
             chain_spec,
-            provider.clone(),
+            evm.clone(),
             ep.clone(),
             fee_estimator,
             pool_config.precheck_settings,
@@ -340,7 +340,8 @@ where
         let uo_pool = UoPool::new(
             pool_config.clone(),
             event_sender,
-            provider,
+            evm,
+            ep,
             prechecker,
             simulator,
             paymaster,

--- a/crates/rpc/src/eth/api.rs
+++ b/crates/rpc/src/eth/api.rs
@@ -216,6 +216,7 @@ mod tests {
             sim_block_number: 1000,
             account_is_staked: false,
             entity_infos: EntityInfos::default(),
+            da_gas_data: rundler_types::da::DAGasUOData::Empty,
         };
 
         let mut pool = MockPool::default();

--- a/crates/sim/src/lib.rs
+++ b/crates/sim/src/lib.rs
@@ -49,7 +49,8 @@ mod precheck;
 #[cfg(feature = "test-utils")]
 pub use precheck::MockPrechecker;
 pub use precheck::{
-    PrecheckError, Prechecker, PrecheckerImpl, Settings as PrecheckSettings, MIN_CALL_GAS_LIMIT,
+    PrecheckError, PrecheckReturn, Prechecker, PrecheckerImpl, Settings as PrecheckSettings,
+    MIN_CALL_GAS_LIMIT,
 };
 
 /// Simulation and violation checking

--- a/crates/types/src/da.rs
+++ b/crates/types/src/da.rs
@@ -16,7 +16,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Type of gas oracle contract for pricing calldata in preVerificationGas
-#[derive(Clone, Copy, Debug, Deserialize, Default, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Default, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum DAGasOracleContractType {
     /// No gas oracle contract

--- a/crates/types/src/pool/types.rs
+++ b/crates/types/src/pool/types.rs
@@ -15,7 +15,8 @@ use alloy_primitives::{Address, B256, U256};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
-    entity::EntityInfos, Entity, StakeInfo, UserOperation, UserOperationVariant, ValidTimeRange,
+    da::DAGasUOData, entity::EntityInfos, Entity, StakeInfo, UserOperation, UserOperationVariant,
+    ValidTimeRange,
 };
 
 /// The new head of the chain, as viewed by the pool
@@ -119,6 +120,8 @@ pub struct PoolOperation {
     pub account_is_staked: bool,
     /// Staking information about all the entities.
     pub entity_infos: EntityInfos,
+    /// The DA gas data for this operation
+    pub da_gas_data: DAGasUOData,
 }
 
 impl PoolOperation {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,6 +38,8 @@ See [chain spec](./architecture/chain_spec.md) for a detailed description of cha
   - env: *MIN_STAKE_VALUE*
 - `--min_unstake_delay`: Minimum unstake delay. (default: `84600`).
   - env: *MIN_UNSTAKE_DELAY*
+- `--tracer_timeout`: The timeout used for custom javascript tracers, the string must be in a valid parseable format that can be used in the `ParseDuration` function on an ethereum node. See Docs [Here](https://pkg.go.dev/time#ParseDuration). (default: `15s`)
+  - env: *TRACER_TIMEOUT*
 - `--user_operation_event_block_distance`: Number of blocks to search when calling `eth_getUserOperationByHash`. (default: all blocks)
   - env: *USER_OPERATION_EVENT_BLOCK_DISTANCE*
 - `--max_simulate_handle_ops_gas`: Maximum gas for simulating handle operations. (default: `20000000`).
@@ -71,8 +73,8 @@ See [chain spec](./architecture/chain_spec.md) for a detailed description of cha
   - env: *DISABLE_ENTRY_POINT_V0_7*
 - `--num_builders_v0_7`: The number of bundle builders to run on entry point v0.7 (default: `1`)
   - env: *NUM_BUILDERS_V0_7*
-- `--tracer_timeout`: The timeout used for custom javascript tracers, the string must be in a valid parseable format that can be used in the `ParseDuration` function on an ethereum node. See Docs [Here](https://pkg.go.dev/time#ParseDuration). (default: `15s`)
-  - env: *TRACER_TIMEOUT*
+- `--da_gas_tracking_enabled`: Enable the DA gas tracking feature of the mempool (default: `false`)
+  - env: *DA_GAS_TRACKING_ENABLED*
 
 ## Metrics Options
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,4 @@
 # A docker-compose for running a local geth node for testing
-version: "3.8"
 services:
   geth:
     image: ethereum/client-go:v1.10.26

--- a/test/spec-tests/launchers/rundler-launcher/docker-compose.yml
+++ b/test/spec-tests/launchers/rundler-launcher/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   rundler:
     image: alchemy-platform/rundler:$TAG

--- a/test/spec-tests/launchers/rundler-launcher/rundler-launcher.sh
+++ b/test/spec-tests/launchers/rundler-launcher/rundler-launcher.sh
@@ -10,13 +10,13 @@ case $1 in
 	;;
 
  start)
-	docker-compose up -d
+	docker compose up -d
   ./waitForServices.sh
 	cast send --from $(cast rpc eth_accounts | tail -n 1 | tr -d '[]"') --unlocked --value 1ether 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 > /dev/null
     cd ../../bundler-spec-tests/@account-abstraction && yarn deploy --network localhost
 	;;
  stop)
- 	docker-compose down -t 3
+ 	docker compose down -t 3
 	;;
 
  *)

--- a/test/spec-tests/local/docker-compose.yml
+++ b/test/spec-tests/local/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   geth:
     image: ethereum/client-go:release-1.14

--- a/test/spec-tests/local/launcher.sh
+++ b/test/spec-tests/local/launcher.sh
@@ -5,7 +5,7 @@ cd `dirname \`realpath $0\``
 case $1 in
 
  start)
-	docker-compose up -d
+	docker compose up -d
 	sleep 10
 	cast send --unlocked --from $(cast rpc eth_accounts | tail -n 1 | tr -d '[]"') --value 1000ether 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 > /dev/null
 	(cd ../$2/bundler-spec-tests/@account-abstraction && yarn deploy --network localhost)
@@ -14,7 +14,7 @@ case $1 in
 	;;
  stop)
 	pkill rundler
-	docker-compose down -t 3
+	docker compose down -t 3
 	;;
 
  *)

--- a/test/spec-tests/remote/docker-compose.yml
+++ b/test/spec-tests/remote/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   geth:
     image: ethereum/client-go:release-1.14

--- a/test/spec-tests/remote/launcher.sh
+++ b/test/spec-tests/remote/launcher.sh
@@ -27,12 +27,12 @@ usage:
 EOF
 		exit 1
 	esac
-	docker-compose up -d --wait
+	docker compose up -d --wait
 	cast send --unlocked --from $(cast rpc eth_accounts | tail -n 1 | tr -d '[]"') --value 1000ether 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 > /dev/null
 	cd ../$2/bundler-spec-tests/@account-abstraction && yarn deploy --network localhost
 	;;
  stop)
- 	docker-compose down -t 3
+ 	docker compose down -t 3
 	;;
 
  *)


### PR DESCRIPTION
Closes #744 

## Proposed Changes

  - Add `da_gas_tracking_enabled` CLI parameter.
  - Cache any returned DA UO data with each UO in the pool upon entry
  - If tracking is enabled, on each block, pull the block data, then sync calculate the required pvg of each UO to set eligibility
  - Only return eligible UOs to the builder when queried
  - Repeat the sync calc in the builder ~~(can this be removed?)~~

TODO
- [X] ~~Determine if we can remove the builder PVG check~~ Decided the builder must keep this, as it may raise the fees compared to the initial fees used by the mempool.
- [x] Performance check on the `do_maintenance` call on the pool when under heavy load
- [x] Doc updates
- [x] ~~More tests~~ https://github.com/alchemyplatform/rundler/issues/845