### PR TITLE
feat(pool): reject UOs below configurable gas limit efficiency

### DIFF
--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -171,6 +171,14 @@ pub struct PoolArgs {
         default_value = "10"
     )]
     pub drop_min_num_blocks: u64,
+
+    #[arg(
+        long = "pool.gas_limit_efficiency_reject_threshold",
+        name = "pool.gas_limit_efficiency_reject_threshold",
+        env = "POOL_GAS_LIMIT_EFFICIENCY_REJECT_THRESHOLD",
+        default_value = "0.0"
+    )]
+    pub gas_limit_efficiency_reject_threshold: f32,
 }
 
 impl PoolArgs {
@@ -226,6 +234,7 @@ impl PoolArgs {
             reputation_tracking_enabled: self.reputation_tracking_enabled,
             drop_min_num_blocks: self.drop_min_num_blocks,
             da_gas_tracking_enabled,
+            gas_limit_efficiency_reject_threshold: self.gas_limit_efficiency_reject_threshold,
         };
 
         let mut pool_configs = vec![];

--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -511,6 +511,8 @@ message MempoolError {
     AssociatedStorageIsAlternateSender associated_storage_is_alternate_sender = 14;
     PaymasterBalanceTooLow paymaster_balance_too_low = 15;
     OperationDropTooSoon operation_drop_too_soon = 16;
+    PreOpGasLimitEfficiencyTooLow pre_op_gas_limit_efficiency_too_low = 17;
+    CallGasLimitEfficiencyTooLow call_gas_limit_efficiency_too_low = 18;
   }
 }
 
@@ -561,6 +563,16 @@ message OperationDropTooSoon {
   uint64 added_at = 1;
   uint64 attempted_at = 2;
   uint64 must_wait = 3;
+}
+
+message PreOpGasLimitEfficiencyTooLow {
+  float required = 1;
+  float actual = 2;
+}
+
+message CallGasLimitEfficiencyTooLow {
+  float required = 1;
+  float actual = 2;
 }
 
 // PRECHECK VIOLATIONS

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -167,6 +167,10 @@ pub struct PoolConfig {
     pub da_gas_tracking_enabled: bool,
     /// The minimum number of blocks a user operation must be in the mempool before it can be dropped
     pub drop_min_num_blocks: u64,
+    /// Reject user operations with gas limit efficiency below this threshold.
+    /// Gas limit efficiency is defined as the ratio of the gas limit to the gas used.
+    /// This applies to all the verification, call, and paymaster gas limits.
+    pub gas_limit_efficiency_reject_threshold: f32,
 }
 
 /// Origin of an operation.

--- a/crates/pool/src/server/remote/error.rs
+++ b/crates/pool/src/server/remote/error.rs
@@ -24,21 +24,22 @@ use rundler_types::{
 use super::protos::{
     mempool_error, precheck_violation_error, simulation_violation_error, validation_revert,
     AccessedUndeployedContract, AccessedUnsupportedContractType, AggregatorValidationFailed,
-    AssociatedStorageDuringDeploy, AssociatedStorageIsAlternateSender, CallGasLimitTooLow,
-    CallHadValue, CalledBannedEntryPointMethod, CodeHashChanged, DidNotRevert,
-    DiscardedOnInsertError, Entity, EntityThrottledError, EntityType, EntryPointRevert,
-    ExistingSenderWithInitCode, FactoryCalledCreate2Twice, FactoryIsNotContract,
-    InvalidAccountSignature, InvalidPaymasterSignature, InvalidSignature, InvalidStorageAccess,
-    InvalidTimeRange, MaxFeePerGasTooLow, MaxOperationsReachedError, MaxPriorityFeePerGasTooLow,
-    MempoolError as ProtoMempoolError, MultipleRolesViolation, NotStaked,
-    OperationAlreadyKnownError, OperationDropTooSoon, OperationRevert, OutOfGas, PanicRevert,
-    PaymasterBalanceTooLow, PaymasterDepositTooLow, PaymasterIsNotContract,
-    PreVerificationGasTooLow, PrecheckViolationError as ProtoPrecheckViolationError,
-    ReplacementUnderpricedError, SenderAddressUsedAsAlternateEntity, SenderFundsTooLow,
-    SenderIsNotContractAndNoInitCode, SimulationViolationError as ProtoSimulationViolationError,
-    TotalGasLimitTooHigh, UnintendedRevert, UnintendedRevertWithMessage, UnknownEntryPointError,
-    UnknownRevert, UnstakedAggregator, UnstakedPaymasterContext, UnsupportedAggregatorError,
-    UsedForbiddenOpcode, UsedForbiddenPrecompile, ValidationRevert as ProtoValidationRevert,
+    AssociatedStorageDuringDeploy, AssociatedStorageIsAlternateSender,
+    CallGasLimitEfficiencyTooLow, CallGasLimitTooLow, CallHadValue, CalledBannedEntryPointMethod,
+    CodeHashChanged, DidNotRevert, DiscardedOnInsertError, Entity, EntityThrottledError,
+    EntityType, EntryPointRevert, ExistingSenderWithInitCode, FactoryCalledCreate2Twice,
+    FactoryIsNotContract, InvalidAccountSignature, InvalidPaymasterSignature, InvalidSignature,
+    InvalidStorageAccess, InvalidTimeRange, MaxFeePerGasTooLow, MaxOperationsReachedError,
+    MaxPriorityFeePerGasTooLow, MempoolError as ProtoMempoolError, MultipleRolesViolation,
+    NotStaked, OperationAlreadyKnownError, OperationDropTooSoon, OperationRevert, OutOfGas,
+    PanicRevert, PaymasterBalanceTooLow, PaymasterDepositTooLow, PaymasterIsNotContract,
+    PreOpGasLimitEfficiencyTooLow, PreVerificationGasTooLow,
+    PrecheckViolationError as ProtoPrecheckViolationError, ReplacementUnderpricedError,
+    SenderAddressUsedAsAlternateEntity, SenderFundsTooLow, SenderIsNotContractAndNoInitCode,
+    SimulationViolationError as ProtoSimulationViolationError, TotalGasLimitTooHigh,
+    UnintendedRevert, UnintendedRevertWithMessage, UnknownEntryPointError, UnknownRevert,
+    UnstakedAggregator, UnstakedPaymasterContext, UnsupportedAggregatorError, UsedForbiddenOpcode,
+    UsedForbiddenPrecompile, ValidationRevert as ProtoValidationRevert,
     VerificationGasLimitBufferTooLow, VerificationGasLimitTooHigh, WrongNumberOfPhases,
 };
 
@@ -125,6 +126,12 @@ impl TryFrom<ProtoMempoolError> for MempoolError {
             }
             Some(mempool_error::Error::OperationDropTooSoon(e)) => {
                 MempoolError::OperationDropTooSoon(e.added_at, e.attempted_at, e.must_wait)
+            }
+            Some(mempool_error::Error::PreOpGasLimitEfficiencyTooLow(e)) => {
+                MempoolError::PreOpGasLimitEfficiencyTooLow(e.required, e.actual)
+            }
+            Some(mempool_error::Error::CallGasLimitEfficiencyTooLow(e)) => {
+                MempoolError::CallGasLimitEfficiencyTooLow(e.required, e.actual)
             }
             None => bail!("unknown proto mempool error"),
         })
@@ -230,6 +237,16 @@ impl From<MempoolError> for ProtoMempoolError {
                     )),
                 }
             }
+            MempoolError::PreOpGasLimitEfficiencyTooLow(required, actual) => ProtoMempoolError {
+                error: Some(mempool_error::Error::PreOpGasLimitEfficiencyTooLow(
+                    PreOpGasLimitEfficiencyTooLow { required, actual },
+                )),
+            },
+            MempoolError::CallGasLimitEfficiencyTooLow(required, actual) => ProtoMempoolError {
+                error: Some(mempool_error::Error::CallGasLimitEfficiencyTooLow(
+                    CallGasLimitEfficiencyTooLow { required, actual },
+                )),
+            },
         }
     }
 }

--- a/crates/rpc/src/eth/error.rs
+++ b/crates/rpc/src/eth/error.rs
@@ -311,6 +311,12 @@ impl From<MempoolError> for EthRpcError {
                 Self::EntryPointValidationRejected(format!("unknown entry point: {}", a))
             }
             MempoolError::OperationDropTooSoon(_, _, _) => Self::InvalidParams(value.to_string()),
+            MempoolError::PreOpGasLimitEfficiencyTooLow(_, _) => {
+                Self::InvalidParams(value.to_string())
+            }
+            MempoolError::CallGasLimitEfficiencyTooLow(_, _) => {
+                Self::InvalidParams(value.to_string())
+            }
         }
     }
 }

--- a/crates/types/src/pool/error.rs
+++ b/crates/types/src/pool/error.rs
@@ -94,6 +94,12 @@ pub enum MempoolError {
     /// The operation drop attempt too soon after being added to the pool
     #[error("Operation drop attempt too soon after being added to the pool. Added at {0}, attempted to drop at {1}, must wait {2} blocks.")]
     OperationDropTooSoon(u64, u64, u64),
+    /// Pre-op gas limit efficiency too low
+    #[error("Pre-op gas limit efficiency too low. Required: {0}, Actual: {1}")]
+    PreOpGasLimitEfficiencyTooLow(f32, f32),
+    /// Call gas limit efficiency too low
+    #[error("Call gas limit efficiency too low. Required: {0}, Actual: {1}")]
+    CallGasLimitEfficiencyTooLow(f32, f32),
 }
 
 /// Precheck violation enumeration

--- a/crates/types/src/user_operation/mod.rs
+++ b/crates/types/src/user_operation/mod.rs
@@ -104,6 +104,12 @@ pub trait UserOperation: Debug + Clone + Send + Sync + 'static {
     /// Returns the maximum cost, in wei, of this user operation
     fn max_gas_cost(&self) -> U256;
 
+    /// Returns the gas price for this UO given the base fee
+    fn gas_price(&self, base_fee: u128) -> u128 {
+        self.max_fee_per_gas()
+            .min(base_fee + self.max_priority_fee_per_gas())
+    }
+
     /*
      * Enhanced functions
      */
@@ -132,6 +138,11 @@ pub trait UserOperation: Debug + Clone + Send + Sync + 'static {
     /// minus the call gas limit. The entry point will check for this buffer before
     /// executing the user operation.
     fn required_pre_execution_buffer(&self) -> u128;
+
+    /// Returns the limit of gas that may be used used prior to the execution of the user operation
+    fn pre_op_gas_limit(&self) -> u128 {
+        self.pre_verification_gas() + self.total_verification_gas_limit()
+    }
 
     /// Returns the pre-verification gas
     fn pre_verification_gas(&self) -> u128;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -159,6 +159,8 @@ List of command line options for configuring the Pool.
   - env: *POOL_REPUTATION_TRACKING_ENABLED*
 - `--pool.drop_min_num_blocks`: The minimum number of blocks that a UO must stay in the mempool before it can be requested to be dropped by the user (default: `10`)
   - env: *POOL_DROP_MIN_NUM_BLOCKS*
+- `--pool.gas_limit_efficiency_reject_threshold`: The ratio of gas used to gas limit under which to reject UOs upon entry to the mempool (default: `0.0` disabled)
+  - env: *POOL_GAS_LIMIT_EFFICIENCY_REJECT_THRESHOLD*
 
 ## Builder Options
 


### PR DESCRIPTION
Closes #791 

## Proposed Changes

  - Add a configuration option `pool.gas_limit_efficiency_reject_threshold`. If set > 0.0, the pool will check both the pre-op, and call gas limit efficiency ratios and reject if below the threshold.
  - A gas limit efficiency ratio is gas used / gas limit
  - Pre op gas is PVG + validation gas + paymaster validation gas. 
