### PR TITLE
refactor: refactor da gas provider/oracle interfaces

### DIFF
--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -463,6 +463,7 @@ pub async fn spawn_tasks<T: TaskSpawnerExt + 'static>(
         provider,
         ep_v0_6,
         ep_v0_7,
+        da_gas_oracle_sync,
     } = super::construct_providers(&common_args, &chain_spec)?;
 
     BuilderTask::new(
@@ -473,6 +474,7 @@ pub async fn spawn_tasks<T: TaskSpawnerExt + 'static>(
         provider,
         ep_v0_6,
         ep_v0_7,
+        da_gas_oracle_sync,
     )
     .spawn(task_spawner)
     .await?;

--- a/bin/rundler/src/cli/node/mod.rs
+++ b/bin/rundler/src/cli/node/mod.rs
@@ -114,6 +114,7 @@ pub async fn spawn_tasks<T: TaskSpawnerExt + 'static>(
         provider,
         ep_v0_6,
         ep_v0_7,
+        da_gas_oracle_sync,
     } = super::construct_providers(&common_args, &chain_spec)?;
 
     PoolTask::new(
@@ -123,6 +124,7 @@ pub async fn spawn_tasks<T: TaskSpawnerExt + 'static>(
         provider.clone(),
         ep_v0_6.clone(),
         ep_v0_7.clone(),
+        da_gas_oracle_sync.clone(),
     )
     .spawn(task_spawner.clone())
     .await?;
@@ -135,6 +137,7 @@ pub async fn spawn_tasks<T: TaskSpawnerExt + 'static>(
         provider.clone(),
         ep_v0_6.clone(),
         ep_v0_7.clone(),
+        da_gas_oracle_sync,
     )
     .spawn(task_spawner.clone())
     .await?;

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -305,6 +305,7 @@ pub async fn spawn_tasks<T: TaskSpawnerExt + 'static>(
         provider,
         ep_v0_6,
         ep_v0_7,
+        da_gas_oracle_sync,
     } = super::construct_providers(&common_args, &chain_spec)?;
 
     PoolTask::new(
@@ -314,6 +315,7 @@ pub async fn spawn_tasks<T: TaskSpawnerExt + 'static>(
         provider,
         ep_v0_6,
         ep_v0_7,
+        da_gas_oracle_sync,
     )
     .spawn(task_spawner)
     .await?;

--- a/bin/rundler/src/cli/rpc.rs
+++ b/bin/rundler/src/cli/rpc.rs
@@ -180,6 +180,7 @@ pub async fn spawn_tasks<T: TaskSpawnerExt + 'static>(
         provider,
         ep_v0_6,
         ep_v0_7,
+        ..
     } = super::construct_providers(&common_args, &chain_spec)?;
 
     RpcTask::new(task_args, pool, builder, provider, ep_v0_6, ep_v0_7)

--- a/crates/provider/src/alloy/da/arbitrum.rs
+++ b/crates/provider/src/alloy/da/arbitrum.rs
@@ -81,26 +81,4 @@ where
             DAGasBlockData::Empty,
         ))
     }
-
-    async fn block_data(&self, _block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData> {
-        Ok(DAGasBlockData::Empty)
-    }
-
-    async fn uo_data(
-        &self,
-        _uo_data: Bytes,
-        _to: Address,
-        _block: BlockHashOrNumber,
-    ) -> ProviderResult<DAGasUOData> {
-        Ok(DAGasUOData::Empty)
-    }
-
-    fn calc_da_gas_sync(
-        &self,
-        _uo_data: &DAGasUOData,
-        _block_data: &DAGasBlockData,
-        _gas_price: u128,
-    ) -> u128 {
-        panic!("ArbitrumNitroDAGasOracle does not support calc_da_gas_sync")
-    }
 }

--- a/crates/provider/src/alloy/da/local/nitro.rs
+++ b/crates/provider/src/alloy/da/local/nitro.rs
@@ -20,8 +20,8 @@ use rundler_utils::cache::LruMap;
 use tokio::sync::Mutex as TokioMutex;
 
 use crate::{
-    alloy::da::{arbitrum::NodeInterface::NodeInterfaceInstance, DAGasOracle},
-    BlockHashOrNumber, ProviderResult,
+    alloy::da::arbitrum::NodeInterface::NodeInterfaceInstance, BlockHashOrNumber, DAGasOracle,
+    DAGasOracleSync, ProviderResult,
 };
 
 /// Cached Arbitrum Nitro DA gas oracle
@@ -93,7 +93,14 @@ where
             }
         }
     }
+}
 
+#[async_trait::async_trait]
+impl<AP, T> DAGasOracleSync for CachedNitroDAGasOracle<AP, T>
+where
+    AP: AlloyProvider<T>,
+    T: Transport + Clone,
+{
     async fn block_data(&self, block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData> {
         let mut cache = self.block_data_cache.lock().await;
         match cache.get(&block) {

--- a/crates/provider/src/alloy/da/optimism.rs
+++ b/crates/provider/src/alloy/da/optimism.rs
@@ -81,26 +81,4 @@ where
             DAGasBlockData::Empty,
         ))
     }
-
-    async fn block_data(&self, _block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData> {
-        Ok(DAGasBlockData::Empty)
-    }
-
-    async fn uo_data(
-        &self,
-        _uo_data: Bytes,
-        _to: Address,
-        _block: BlockHashOrNumber,
-    ) -> ProviderResult<DAGasUOData> {
-        Ok(DAGasUOData::Empty)
-    }
-
-    fn calc_da_gas_sync(
-        &self,
-        _uo_data: &DAGasUOData,
-        _block_data: &DAGasBlockData,
-        _gas_price: u128,
-    ) -> u128 {
-        panic!("OptimismBedrockDAGasOracle does not support calc_da_gas_sync")
-    }
 }

--- a/crates/provider/src/alloy/entry_point/v0_7.rs
+++ b/crates/provider/src/alloy/entry_point/v0_7.rs
@@ -11,8 +11,6 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use std::sync::Arc;
-
 use alloy_contract::Error as ContractError;
 use alloy_json_rpc::ErrorPayload;
 use alloy_primitives::{Address, Bytes, U256};
@@ -45,7 +43,6 @@ use rundler_types::{
 };
 
 use crate::{
-    alloy::da::{self},
     AggregatorOut, AggregatorSimOut, BlockHashOrNumber, BundleHandler, DAGasOracle, DAGasProvider,
     DepositInfo, EntryPoint, EntryPointProvider as EntryPointProviderTrait, EvmCall,
     ExecutionResult, HandleOpsOut, ProviderResult, SignatureAggregator, SimulationProvider,
@@ -53,19 +50,19 @@ use crate::{
 
 /// Entry point provider for v0.7
 #[derive(Clone)]
-pub struct EntryPointProvider<'a, AP, T> {
+pub struct EntryPointProvider<AP, T, D> {
     i_entry_point: IEntryPointInstance<T, AP>,
-    da_gas_oracle: Arc<dyn DAGasOracle + 'a>,
+    da_gas_oracle: D,
     max_verification_gas: u64,
     max_simulate_handle_ops_gas: u64,
     max_aggregation_gas: u64,
     chain_spec: ChainSpec,
 }
 
-impl<'a, AP, T> EntryPointProvider<'a, AP, T>
+impl<AP, T, D> EntryPointProvider<AP, T, D>
 where
     T: Transport + Clone,
-    AP: AlloyProvider<T> + Clone + 'a,
+    AP: AlloyProvider<T> + Clone,
 {
     /// Create a new `EntryPoint` instance for v0.7
     pub fn new(
@@ -74,13 +71,14 @@ where
         max_simulate_handle_ops_gas: u64,
         max_aggregation_gas: u64,
         provider: AP,
+        da_gas_oracle: D,
     ) -> Self {
         Self {
             i_entry_point: IEntryPointInstance::new(
                 chain_spec.entry_point_address_v0_7,
                 provider.clone(),
             ),
-            da_gas_oracle: Arc::from(da::da_gas_oracle_for_chain(&chain_spec, provider)),
+            da_gas_oracle,
             max_verification_gas,
             max_simulate_handle_ops_gas,
             max_aggregation_gas,
@@ -90,10 +88,11 @@ where
 }
 
 #[async_trait::async_trait]
-impl<'a, AP, T> EntryPoint for EntryPointProvider<'a, AP, T>
+impl<AP, T, D> EntryPoint for EntryPointProvider<AP, T, D>
 where
     T: Transport + Clone,
     AP: AlloyProvider<T>,
+    D: Send + Sync,
 {
     fn address(&self) -> &Address {
         self.i_entry_point.address()
@@ -147,10 +146,11 @@ where
 }
 
 #[async_trait::async_trait]
-impl<'a, AP, T> SignatureAggregator for EntryPointProvider<'a, AP, T>
+impl<AP, T, D> SignatureAggregator for EntryPointProvider<AP, T, D>
 where
     T: Transport + Clone,
     AP: AlloyProvider<T>,
+    D: Send + Sync,
 {
     type UO = UserOperation;
 
@@ -227,10 +227,11 @@ where
 }
 
 #[async_trait::async_trait]
-impl<'a, AP, T> BundleHandler for EntryPointProvider<'a, AP, T>
+impl<AP, T, D> BundleHandler for EntryPointProvider<AP, T, D>
 where
     T: Transport + Clone,
     AP: AlloyProvider<T>,
+    D: Send + Sync,
 {
     type UO = UserOperation;
 
@@ -296,10 +297,11 @@ where
 }
 
 #[async_trait::async_trait]
-impl<'a, AP, T> DAGasProvider for EntryPointProvider<'a, AP, T>
+impl<AP, T, D> DAGasProvider for EntryPointProvider<AP, T, D>
 where
     T: Transport + Clone,
     AP: AlloyProvider<T>,
+    D: DAGasOracle,
 {
     type UO = UserOperation;
 
@@ -324,49 +326,14 @@ where
             .estimate_da_gas(bundle_data, *self.i_entry_point.address(), block, gas_price)
             .await
     }
-
-    async fn block_data(&self, block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData> {
-        self.da_gas_oracle.block_data(block).await
-    }
-
-    async fn uo_data(
-        &self,
-        uo: UserOperation,
-        block: BlockHashOrNumber,
-    ) -> ProviderResult<DAGasUOData> {
-        let gas_price = uo.max_fee_per_gas;
-        let data = self
-            .i_entry_point
-            .handleOps(vec![uo.pack()], Address::random())
-            .into_transaction_request()
-            .input
-            .into_input()
-            .unwrap();
-
-        let bundle_data =
-            super::max_bundle_transaction_data(*self.i_entry_point.address(), data, gas_price);
-
-        self.da_gas_oracle
-            .uo_data(bundle_data, *self.i_entry_point.address(), block)
-            .await
-    }
-
-    fn calc_da_gas_sync(
-        &self,
-        uo_data: &DAGasUOData,
-        block_data: &DAGasBlockData,
-        gas_price: u128,
-    ) -> u128 {
-        self.da_gas_oracle
-            .calc_da_gas_sync(uo_data, block_data, gas_price)
-    }
 }
 
 #[async_trait::async_trait]
-impl<'a, AP, T> SimulationProvider for EntryPointProvider<'a, AP, T>
+impl<AP, T, D> SimulationProvider for EntryPointProvider<AP, T, D>
 where
     T: Transport + Clone,
     AP: AlloyProvider<T>,
+    D: Send + Sync,
 {
     type UO = UserOperation;
 
@@ -489,10 +456,11 @@ where
     }
 }
 
-impl<'a, AP, T> EntryPointProviderTrait<UserOperation> for EntryPointProvider<'a, AP, T>
+impl<AP, T, D> EntryPointProviderTrait<UserOperation> for EntryPointProvider<AP, T, D>
 where
     T: Transport + Clone,
     AP: AlloyProvider<T>,
+    D: DAGasOracle,
 {
 }
 

--- a/crates/provider/src/alloy/mod.rs
+++ b/crates/provider/src/alloy/mod.rs
@@ -23,7 +23,8 @@ use url::Url;
 
 use crate::EvmProvider;
 
-pub(crate) mod da;
+mod da;
+pub use da::new_alloy_da_gas_oracle;
 pub(crate) mod entry_point;
 pub(crate) mod evm;
 pub(crate) mod metrics;

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -31,7 +31,7 @@ pub use alloy::{
         },
     },
     evm::AlloyEvmProvider,
-    new_alloy_evm_provider, new_alloy_provider,
+    new_alloy_da_gas_oracle, new_alloy_evm_provider, new_alloy_provider,
 };
 
 mod traits;

--- a/crates/provider/src/traits/da.rs
+++ b/crates/provider/src/traits/da.rs
@@ -16,10 +16,10 @@ use rundler_types::da::{DAGasBlockData, DAGasUOData};
 
 use crate::{BlockHashOrNumber, ProviderResult};
 
-// Trait for a DA gas oracle
+/// Trait for a DA gas oracle
 #[async_trait::async_trait]
 #[auto_impl::auto_impl(&, &mut, Rc, Arc, Box)]
-pub(crate) trait DAGasOracle: Send + Sync {
+pub trait DAGasOracle: Send + Sync {
     /// Estimate the DA gas for a given user operation's bytes
     ///
     /// Returns the estimated gas, as well as both the UO DA data and the block DA data.
@@ -32,7 +32,12 @@ pub(crate) trait DAGasOracle: Send + Sync {
         block: BlockHashOrNumber,
         gas_price: u128,
     ) -> ProviderResult<(u128, DAGasUOData, DAGasBlockData)>;
+}
 
+/// Trait for a DA gas oracle with a synchronous calculation method
+#[async_trait::async_trait]
+#[auto_impl::auto_impl(&, &mut, Rc, Arc, Box)]
+pub trait DAGasOracleSync: DAGasOracle {
     /// Retrieve the DA gas data for a given block. This value can change block to block and
     /// thus must be retrieved fresh from the DA for every block.
     async fn block_data(&self, block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData>;

--- a/crates/provider/src/traits/entry_point.rs
+++ b/crates/provider/src/traits/entry_point.rs
@@ -176,32 +176,6 @@ pub trait DAGasProvider: Send + Sync {
         block: BlockHashOrNumber,
         gas_price: u128,
     ) -> ProviderResult<(u128, DAGasUOData, DAGasBlockData)>;
-
-    /// Retrieve the DA gas data for a given block. This value can change block to block and
-    /// thus must be retrieved fresh from the DA for every block.
-    async fn block_data(&self, block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData>;
-
-    /// Retrieve the DA gas data for a given user operation's bytes
-    ///
-    /// This should not change block to block, but may change after underlying hard forks,
-    /// thus a block number is required.
-    ///
-    /// It is safe to calculate this once and re-use if the same UO is used for multiple calls within
-    /// a small time period (no hard forks impacting DA calculations)
-    async fn uo_data(&self, uo: Self::UO, block: BlockHashOrNumber) -> ProviderResult<DAGasUOData>;
-
-    /// Synchronously calculate the DA gas for a given user operation data and block data.
-    /// These values must have been previously retrieved from a DA provider of the same implementation
-    /// else this function will PANIC.
-    ///
-    /// This function is intended to allow synchronous DA gas calculation from a cached UO data and a
-    /// recently retrieved block data.
-    fn calc_da_gas_sync(
-        &self,
-        uo_data: &DAGasUOData,
-        block_data: &DAGasBlockData,
-        gas_price: u128,
-    ) -> u128;
 }
 
 /// Trait for simulating user operations on an entry point contract

--- a/crates/provider/src/traits/mod.rs
+++ b/crates/provider/src/traits/mod.rs
@@ -14,7 +14,7 @@
 //! Traits for the provider module.
 
 mod da;
-pub(crate) use da::DAGasOracle;
+pub use da::{DAGasOracle, DAGasOracleSync};
 
 mod error;
 pub use error::*;

--- a/crates/provider/src/traits/test_utils.rs
+++ b/crates/provider/src/traits/test_utils.rs
@@ -178,12 +178,6 @@ mockall::mock! {
             block: BlockHashOrNumber,
             gas_price: u128,
         ) -> ProviderResult<(u128, DAGasUOData, DAGasBlockData)>;
-
-        async fn block_data(&self, block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData>;
-
-        async fn uo_data(&self, uo: v0_6::UserOperation, block: BlockHashOrNumber) -> ProviderResult<DAGasUOData>;
-
-        fn calc_da_gas_sync(&self, uo_data: &DAGasUOData, block_data: &DAGasBlockData, gas_price: u128) -> u128;
     }
 
     #[async_trait::async_trait]
@@ -272,12 +266,6 @@ mockall::mock! {
             block: BlockHashOrNumber,
             gas_price: u128,
         ) -> ProviderResult<(u128, DAGasUOData, DAGasBlockData)>;
-
-        async fn block_data(&self, block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData>;
-
-        async fn uo_data(&self, uo: v0_7::UserOperation, block: BlockHashOrNumber) -> ProviderResult<DAGasUOData>;
-
-        fn calc_da_gas_sync(&self, uo_data: &DAGasUOData, block_data: &DAGasBlockData, gas_price: u128) -> u128;
     }
 
     #[async_trait::async_trait]


### PR DESCRIPTION
Closes #850 

## Proposed Changes
  - Split `DAGasOracle` into 2 traits
  - Entrypoint only provides access to `DAGasOracle` thats typed on the UO
  - `DAGasOracleSync` passed, optionally, to tasks if the chain spec supports it
