### PR TITLE
feat(paymaster): look at enabled flag on check

### DIFF
--- a/crates/pool/src/mempool/paymaster.rs
+++ b/crates/pool/src/mempool/paymaster.rs
@@ -253,13 +253,13 @@ impl PaymasterTrackerInner {
                 .pending_balance
                 .saturating_add(prev.max_op_cost);
 
-            if reset_balance.lt(&max_op_cost) {
+            if reset_balance.lt(&max_op_cost) && self.tracker_enabled {
                 return Err(MempoolError::PaymasterBalanceTooLow(
                     max_op_cost,
                     reset_balance,
                 ));
             }
-        } else if paymaster_metadata.pending_balance.lt(&max_op_cost) {
+        } else if paymaster_metadata.pending_balance.lt(&max_op_cost) && self.tracker_enabled {
             return Err(MempoolError::PaymasterBalanceTooLow(
                 max_op_cost,
                 paymaster_metadata.pending_balance,


### PR DESCRIPTION
## Proposed Changes

  - make sure we check that the paymaster tracker is enabled when calling the `check_operation_cost` function
