### PR TITLE
refactor: use type erasure on types with lots of generics

### DIFF
--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -30,7 +30,7 @@ use rundler_types::{chain::ChainSpec, EntryPointVersion};
 use rundler_utils::emit::{self, WithEntryPoint, EVENT_CHANNEL_CAPACITY};
 use tokio::sync::broadcast;
 
-use super::{json::get_json_config, CommonArgs, RundlerProviders};
+use super::{json::get_json_config, CommonArgs};
 
 const REQUEST_CHANNEL_CAPACITY: usize = 1024;
 
@@ -459,20 +459,12 @@ pub async fn spawn_tasks<T: TaskSpawnerExt + 'static>(
     )
     .await?;
 
-    let RundlerProviders {
-        provider,
-        ep_v0_6,
-        ep_v0_7,
-    } = super::construct_providers(&common_args, &chain_spec)?;
-
     BuilderTask::new(
         task_args,
         event_sender,
         LocalBuilderBuilder::new(REQUEST_CHANNEL_CAPACITY),
         pool,
-        provider,
-        ep_v0_6,
-        ep_v0_7,
+        super::construct_providers(&common_args, &chain_spec)?,
     )
     .spawn(task_spawner)
     .await?;

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -23,7 +23,7 @@ use rundler_types::{chain::ChainSpec, EntryPointVersion};
 use rundler_utils::emit::{self, EVENT_CHANNEL_CAPACITY};
 use tokio::sync::broadcast;
 
-use super::{CommonArgs, RundlerProviders};
+use super::CommonArgs;
 use crate::cli::json::get_json_config;
 
 const REQUEST_CHANNEL_CAPACITY: usize = 1024;
@@ -301,19 +301,11 @@ pub async fn spawn_tasks<T: TaskSpawnerExt + 'static>(
         Box::pin(emit::receive_and_log_events_with_filter(event_rx, |_| true)),
     );
 
-    let RundlerProviders {
-        provider,
-        ep_v0_6,
-        ep_v0_7,
-    } = super::construct_providers(&common_args, &chain_spec)?;
-
     PoolTask::new(
         task_args,
         event_sender,
         LocalPoolBuilder::new(REQUEST_CHANNEL_CAPACITY, BLOCK_CHANNEL_CAPACITY),
-        provider,
-        ep_v0_6,
-        ep_v0_7,
+        super::construct_providers(&common_args, &chain_spec)?,
     )
     .spawn(task_spawner)
     .await?;

--- a/bin/rundler/src/cli/rpc.rs
+++ b/bin/rundler/src/cli/rpc.rs
@@ -22,7 +22,7 @@ use rundler_sim::{EstimationSettings, PrecheckSettings};
 use rundler_task::{server::connect_with_retries_shutdown, TaskSpawnerExt};
 use rundler_types::chain::ChainSpec;
 
-use super::{CommonArgs, RundlerProviders};
+use super::CommonArgs;
 
 /// CLI options for the RPC server
 #[derive(Args, Debug)]
@@ -79,7 +79,6 @@ pub struct RpcArgs {
 impl RpcArgs {
     /// Convert the CLI arguments into the arguments for the RPC server combining
     /// common and rpc specific arguments.
-    #[allow(clippy::too_many_arguments)]
     pub fn to_args(
         &self,
         chain_spec: ChainSpec,
@@ -176,15 +175,14 @@ pub async fn spawn_tasks<T: TaskSpawnerExt + 'static>(
     )
     .await?;
 
-    let RundlerProviders {
-        provider,
-        ep_v0_6,
-        ep_v0_7,
-    } = super::construct_providers(&common_args, &chain_spec)?;
-
-    RpcTask::new(task_args, pool, builder, provider, ep_v0_6, ep_v0_7)
-        .spawn(task_spawner)
-        .await?;
+    RpcTask::new(
+        task_args,
+        pool,
+        builder,
+        super::construct_providers(&common_args, &chain_spec)?,
+    )
+    .spawn(task_spawner)
+    .await?;
 
     Ok(())
 }

--- a/crates/builder/src/task.rs
+++ b/crates/builder/src/task.rs
@@ -15,7 +15,7 @@ use std::{collections::HashMap, net::SocketAddr, time::Duration};
 
 use alloy_primitives::{Address, B256};
 use anyhow::Context;
-use rundler_provider::{EntryPointProvider, EvmProvider};
+use rundler_provider::{Providers as ProvidersT, ProvidersWithEntryPointT};
 use rundler_sim::{
     gas::{self, FeeEstimatorImpl},
     simulation::{self, UnsafeSimulator},
@@ -23,9 +23,7 @@ use rundler_sim::{
 };
 use rundler_task::TaskSpawnerExt;
 use rundler_types::{
-    chain::ChainSpec, pool::Pool, v0_6::UserOperation as UserOperationV0_6,
-    v0_7::UserOperation as UserOperationV0_7, EntryPointVersion, UserOperation,
-    UserOperationVariant,
+    chain::ChainSpec, pool::Pool as PoolT, EntryPointVersion, UserOperation, UserOperationVariant,
 };
 use rundler_utils::emit::WithEntryPoint;
 use tokio::{
@@ -35,7 +33,7 @@ use tokio::{
 use tracing::info;
 
 use crate::{
-    bundle_proposer::{self, BundleProposerImpl},
+    bundle_proposer::{self, BundleProposerImpl, BundleProposerProviders},
     bundle_sender::{self, BundleSender, BundleSenderAction, BundleSenderImpl},
     emit::BuilderEvent,
     sender::TransactionSenderArgs,
@@ -107,46 +105,37 @@ pub struct EntryPointBuilderSettings {
 }
 
 /// Builder task
-#[derive(Debug)]
-pub struct BuilderTask<P, PR, E06, E07> {
+pub struct BuilderTask<Pool, Providers> {
     args: Args,
     event_sender: broadcast::Sender<WithEntryPoint<BuilderEvent>>,
     builder_builder: LocalBuilderBuilder,
-    pool: P,
-    provider: PR,
-    ep_06: Option<E06>,
-    ep_07: Option<E07>,
+    pool: Pool,
+    providers: Providers,
 }
 
-impl<P, PR, E06, E07> BuilderTask<P, PR, E06, E07> {
+impl<Pool, Providers> BuilderTask<Pool, Providers> {
     /// Create a new builder task
     pub fn new(
         args: Args,
         event_sender: broadcast::Sender<WithEntryPoint<BuilderEvent>>,
         builder_builder: LocalBuilderBuilder,
-        pool: P,
-        provider: PR,
-        ep_06: Option<E06>,
-        ep_07: Option<E07>,
+        pool: Pool,
+        providers: Providers,
     ) -> Self {
         Self {
             args,
             event_sender,
             builder_builder,
             pool,
-            provider,
-            ep_06,
-            ep_07,
+            providers,
         }
     }
 }
 
-impl<P, PR, E06, E07> BuilderTask<P, PR, E06, E07>
+impl<Pool, Providers> BuilderTask<Pool, Providers>
 where
-    P: Pool + Clone + 'static,
-    PR: EvmProvider + Clone + 'static,
-    E06: EntryPointProvider<UserOperationV0_6> + Clone + 'static,
-    E07: EntryPointProvider<UserOperationV0_7> + Clone + 'static,
+    Pool: PoolT + Clone + 'static,
+    Providers: ProvidersT + 'static,
 {
     /// Spawn the builder task on the given task spawner
     pub async fn spawn<T: TaskSpawnerExt>(self, task_spawner: T) -> anyhow::Result<()> {
@@ -215,8 +204,9 @@ where
         I: Iterator<Item = String>,
     {
         info!("Mempool config for ep v0.6: {:?}", ep.mempool_configs);
-        let ep_v0_6 = self
-            .ep_06
+        let ep_providers = self
+            .providers
+            .ep_v0_6_providers()
             .clone()
             .context("entry point v0.6 not supplied")?;
         let mut bundle_sender_actions = vec![];
@@ -225,9 +215,8 @@ where
                 self.create_bundle_builder(
                     task_spawner,
                     i + ep.bundle_builder_index_offset,
-                    self.provider.clone(),
-                    ep_v0_6.clone(),
-                    UnsafeSimulator::new(ep_v0_6.clone()),
+                    ep_providers.clone(),
+                    UnsafeSimulator::new(ep_providers.entry_point().clone()),
                     pk_iter,
                 )
                 .await?
@@ -235,11 +224,10 @@ where
                 self.create_bundle_builder(
                     task_spawner,
                     i + ep.bundle_builder_index_offset,
-                    self.provider.clone(),
-                    ep_v0_6.clone(),
+                    ep_providers.clone(),
                     simulation::new_v0_6_simulator(
-                        self.provider.clone(),
-                        ep_v0_6.clone(),
+                        ep_providers.evm().clone(),
+                        ep_providers.entry_point().clone(),
                         self.args.sim_settings.clone(),
                         ep.mempool_configs.clone(),
                     ),
@@ -263,8 +251,9 @@ where
         I: Iterator<Item = String>,
     {
         info!("Mempool config for ep v0.7: {:?}", ep.mempool_configs);
-        let ep_v0_7 = self
-            .ep_07
+        let ep_providers = self
+            .providers
+            .ep_v0_7_providers()
             .clone()
             .context("entry point v0.7 not supplied")?;
         let mut bundle_sender_actions = vec![];
@@ -273,9 +262,8 @@ where
                 self.create_bundle_builder(
                     task_spawner,
                     i + ep.bundle_builder_index_offset,
-                    self.provider.clone(),
-                    ep_v0_7.clone(),
-                    UnsafeSimulator::new(ep_v0_7.clone()),
+                    ep_providers.clone(),
+                    UnsafeSimulator::new(ep_providers.entry_point().clone()),
                     pk_iter,
                 )
                 .await?
@@ -283,11 +271,10 @@ where
                 self.create_bundle_builder(
                     task_spawner,
                     i + ep.bundle_builder_index_offset,
-                    self.provider.clone(),
-                    ep_v0_7.clone(),
+                    ep_providers.clone(),
                     simulation::new_v0_7_simulator(
-                        self.provider.clone(),
-                        ep_v0_7.clone(),
+                        ep_providers.evm().clone(),
+                        ep_providers.entry_point().clone(),
                         self.args.sim_settings.clone(),
                         ep.mempool_configs.clone(),
                     ),
@@ -300,12 +287,11 @@ where
         Ok(bundle_sender_actions)
     }
 
-    async fn create_bundle_builder<T, UO, E, S, I>(
+    async fn create_bundle_builder<T, UO, EP, S, I>(
         &self,
         task_spawner: &T,
         index: u64,
-        provider: PR,
-        entry_point: E,
+        ep_providers: EP,
         simulator: S,
         pk_iter: &mut I,
     ) -> anyhow::Result<mpsc::Sender<BundleSenderAction>>
@@ -313,7 +299,7 @@ where
         T: TaskSpawnerExt,
         UO: UserOperation + From<UserOperationVariant>,
         UserOperationVariant: AsRef<UO>,
-        E: EntryPointProvider<UO> + Clone + 'static,
+        EP: ProvidersWithEntryPointT + 'static,
         S: Simulator<UO = UO> + 'static,
         I: Iterator<Item = String>,
     {
@@ -324,7 +310,7 @@ where
             BundlerSigner::Local(
                 LocalSigner::connect(
                     &task_spawner,
-                    provider.clone(),
+                    self.providers.evm().clone(),
                     self.args.chain_spec.id,
                     pk.to_owned(),
                 )
@@ -340,7 +326,7 @@ where
                 Duration::from_millis(self.args.redis_lock_ttl_millis / 4),
                 KmsSigner::connect(
                     &task_spawner,
-                    provider.clone(),
+                    self.providers.evm().clone(),
                     self.args.chain_spec.id,
                     self.args.aws_kms_key_ids.clone(),
                     self.args.redis_uri.clone(),
@@ -376,7 +362,7 @@ where
         };
 
         let transaction_tracker = TransactionTrackerImpl::new(
-            provider.clone(),
+            ep_providers.evm().clone(),
             transaction_sender,
             tracker_settings,
             index,
@@ -389,9 +375,9 @@ where
             max_blocks_to_wait_for_mine: self.args.max_blocks_to_wait_for_mine,
         };
 
-        let fee_oracle = gas::get_fee_oracle(&self.args.chain_spec, provider.clone());
+        let fee_oracle = gas::get_fee_oracle(&self.args.chain_spec, ep_providers.evm().clone());
         let fee_estimator = FeeEstimatorImpl::new(
-            provider.clone(),
+            ep_providers.evm().clone(),
             fee_oracle,
             proposer_settings.priority_fee_mode,
             proposer_settings.bundle_priority_fee_overhead_percent,
@@ -399,11 +385,8 @@ where
 
         let proposer = BundleProposerImpl::new(
             index,
-            self.pool.clone(),
-            simulator,
-            entry_point.clone(),
-            provider.clone(),
-            fee_estimator,
+            ep_providers.clone(),
+            BundleProposerProviders::new(self.pool.clone(), simulator, fee_estimator),
             proposer_settings,
             self.event_sender.clone(),
         );
@@ -414,7 +397,7 @@ where
             self.args.chain_spec.clone(),
             beneficiary,
             proposer,
-            entry_point,
+            ep_providers.entry_point().clone(),
             transaction_tracker,
             self.pool.clone(),
             builder_settings,

--- a/crates/pool/src/chain.rs
+++ b/crates/pool/src/chain.rs
@@ -614,7 +614,6 @@ impl<P: EvmProvider> Chain<P> {
         self.blocks.get((number - earliest_number) as usize)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn new_update(
         &self,
         reorg_depth: u64,

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -40,7 +40,7 @@ use rundler_types::{
     EntityUpdate, EntryPointVersion, UserOperationId, UserOperationVariant,
 };
 use tonic::async_trait;
-pub(crate) use uo_pool::UoPool;
+pub(crate) use uo_pool::{UoPool, UoPoolProviders};
 
 use super::chain::ChainUpdate;
 

--- a/crates/pool/src/task.rs
+++ b/crates/pool/src/task.rs
@@ -15,18 +15,14 @@ use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::{bail, Context};
 use futures::FutureExt;
-use rundler_provider::{EntryPointProvider, EvmProvider};
+use rundler_provider::{Providers, ProvidersWithEntryPointT};
 use rundler_sim::{
     gas::{self, FeeEstimatorImpl},
     simulation::{self, UnsafeSimulator},
     PrecheckerImpl, Simulator,
 };
 use rundler_task::TaskSpawnerExt;
-use rundler_types::{
-    chain::ChainSpec, v0_6::UserOperation as UserOperationV0_6,
-    v0_7::UserOperation as UserOperationV0_7, EntryPointVersion, UserOperation,
-    UserOperationVariant,
-};
+use rundler_types::{chain::ChainSpec, EntryPointVersion, UserOperation, UserOperationVariant};
 use rundler_utils::emit::WithEntryPoint;
 use tokio::sync::broadcast;
 
@@ -36,6 +32,7 @@ use crate::{
     emit::OpPoolEvent,
     mempool::{
         AddressReputation, Mempool, PaymasterConfig, PaymasterTracker, ReputationParams, UoPool,
+        UoPoolProviders,
     },
     server::{self, LocalPoolBuilder},
 };
@@ -63,42 +60,33 @@ pub struct Args {
 }
 
 /// Mempool task.
-#[derive(Debug)]
-pub struct PoolTask<P, E06, E07> {
+pub struct PoolTask<P> {
     args: Args,
     event_sender: broadcast::Sender<WithEntryPoint<OpPoolEvent>>,
     pool_builder: LocalPoolBuilder,
-    provider: P,
-    ep_06: Option<E06>,
-    ep_07: Option<E07>,
+    providers: P,
 }
 
-impl<P, E06, E07> PoolTask<P, E06, E07> {
+impl<P> PoolTask<P> {
     /// Create a new pool task.
     pub fn new(
         args: Args,
         event_sender: broadcast::Sender<WithEntryPoint<OpPoolEvent>>,
         pool_builder: LocalPoolBuilder,
-        provider: P,
-        ep_06: Option<E06>,
-        ep_07: Option<E07>,
+        providers: P,
     ) -> Self {
         Self {
             args,
             event_sender,
             pool_builder,
-            provider,
-            ep_06,
-            ep_07,
+            providers,
         }
     }
 }
 
-impl<P, E06, E07> PoolTask<P, E06, E07>
+impl<P> PoolTask<P>
 where
-    P: EvmProvider + Clone + 'static,
-    E06: EntryPointProvider<UserOperationV0_6> + Clone + 'static,
-    E07: EntryPointProvider<UserOperationV0_7> + Clone + 'static,
+    P: Providers + 'static,
 {
     /// Spawns the mempool task on the given task spawner.
     pub async fn spawn<T: TaskSpawnerExt>(self, task_spawner: T) -> anyhow::Result<()> {
@@ -119,7 +107,7 @@ where
                 .collect(),
         };
 
-        let chain = Chain::new(self.provider.clone(), chain_settings);
+        let chain = Chain::new(self.providers.evm().clone(), chain_settings);
         let (update_sender, _) = broadcast::channel(self.args.chain_update_channel_capacity);
 
         task_spawner.spawn_critical_with_graceful_shutdown_signal("chain watcher", |shutdown| {
@@ -202,36 +190,35 @@ where
         unsafe_mode: bool,
         event_sender: broadcast::Sender<WithEntryPoint<OpPoolEvent>>,
     ) -> anyhow::Result<Arc<dyn Mempool + 'static>> {
-        let ep = self
-            .ep_06
+        let ep_providers = self
+            .providers
+            .ep_v0_6_providers()
             .clone()
             .context("entry point v0.6 not supplied")?;
 
         if unsafe_mode {
-            let simulator = UnsafeSimulator::new(ep.clone());
-            Self::create_mempool(
+            let simulator = UnsafeSimulator::new(ep_providers.entry_point().clone());
+            self.create_mempool(
                 task_spawner,
                 chain_spec,
                 pool_config,
                 event_sender,
-                self.provider.clone(),
-                ep.clone(),
+                ep_providers,
                 simulator,
             )
         } else {
             let simulator = simulation::new_v0_6_simulator(
-                self.provider.clone(),
-                ep.clone(),
+                ep_providers.evm().clone(),
+                ep_providers.entry_point().clone(),
                 pool_config.sim_settings.clone(),
                 pool_config.mempool_channel_configs.clone(),
             );
-            Self::create_mempool(
+            self.create_mempool(
                 task_spawner,
                 chain_spec,
                 pool_config,
                 event_sender,
-                self.provider.clone(),
-                ep.clone(),
+                ep_providers,
                 simulator,
             )
         }
@@ -245,60 +232,59 @@ where
         unsafe_mode: bool,
         event_sender: broadcast::Sender<WithEntryPoint<OpPoolEvent>>,
     ) -> anyhow::Result<Arc<dyn Mempool + 'static>> {
-        let ep = self
-            .ep_07
+        let ep_providers = self
+            .providers
+            .ep_v0_7_providers()
             .clone()
             .context("entry point v0.7 not supplied")?;
 
         if unsafe_mode {
-            let simulator = UnsafeSimulator::new(ep.clone());
-            Self::create_mempool(
+            let simulator = UnsafeSimulator::new(ep_providers.entry_point().clone());
+            self.create_mempool(
                 task_spawner,
                 chain_spec,
                 pool_config,
                 event_sender,
-                self.provider.clone(),
-                ep.clone(),
+                ep_providers,
                 simulator,
             )
         } else {
             let simulator = simulation::new_v0_7_simulator(
-                self.provider.clone(),
-                ep.clone(),
+                self.providers.evm().clone(),
+                ep_providers.entry_point().clone(),
                 pool_config.sim_settings.clone(),
                 pool_config.mempool_channel_configs.clone(),
             );
-            Self::create_mempool(
+            self.create_mempool(
                 task_spawner,
                 chain_spec,
                 pool_config,
                 event_sender,
-                self.provider.clone(),
-                ep.clone(),
+                ep_providers,
                 simulator,
             )
         }
     }
 
-    fn create_mempool<T, UO, E, S>(
+    fn create_mempool<T, UO, EP, S>(
+        &self,
         task_spawner: &T,
         chain_spec: ChainSpec,
         pool_config: &PoolConfig,
         event_sender: broadcast::Sender<WithEntryPoint<OpPoolEvent>>,
-        evm: P,
-        ep: E,
+        ep_providers: EP,
         simulator: S,
     ) -> anyhow::Result<Arc<dyn Mempool + 'static>>
     where
         T: TaskSpawnerExt,
         UO: UserOperation + From<UserOperationVariant> + Into<UserOperationVariant>,
         UserOperationVariant: From<UO>,
-        E: EntryPointProvider<UO> + Clone + 'static,
+        EP: ProvidersWithEntryPointT<UO = UO> + 'static,
         S: Simulator<UO = UO> + 'static,
     {
-        let fee_oracle = gas::get_fee_oracle(&chain_spec, evm.clone());
+        let fee_oracle = gas::get_fee_oracle(&chain_spec, self.providers.evm().clone());
         let fee_estimator = FeeEstimatorImpl::new(
-            evm.clone(),
+            self.providers.evm().clone(),
             fee_oracle,
             pool_config.precheck_settings.priority_fee_mode,
             pool_config
@@ -308,8 +294,8 @@ where
 
         let prechecker = PrecheckerImpl::new(
             chain_spec,
-            evm.clone(),
-            ep.clone(),
+            self.providers.evm().clone(),
+            ep_providers.entry_point().clone(),
             fee_estimator,
             pool_config.precheck_settings,
         );
@@ -328,7 +314,7 @@ where
         );
 
         let paymaster = PaymasterTracker::new(
-            ep.clone(),
+            ep_providers.entry_point().clone(),
             PaymasterConfig::new(
                 pool_config.sim_settings.min_stake_value,
                 pool_config.sim_settings.min_unstake_delay,
@@ -339,11 +325,9 @@ where
 
         let uo_pool = UoPool::new(
             pool_config.clone(),
+            ep_providers,
+            UoPoolProviders::new(simulator, prechecker),
             event_sender,
-            evm,
-            ep,
-            prechecker,
-            simulator,
             paymaster,
             reputation,
         );

--- a/crates/provider/src/alloy/da/arbitrum.rs
+++ b/crates/provider/src/alloy/da/arbitrum.rs
@@ -81,26 +81,4 @@ where
             DAGasBlockData::Empty,
         ))
     }
-
-    async fn block_data(&self, _block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData> {
-        Ok(DAGasBlockData::Empty)
-    }
-
-    async fn uo_data(
-        &self,
-        _uo_data: Bytes,
-        _to: Address,
-        _block: BlockHashOrNumber,
-    ) -> ProviderResult<DAGasUOData> {
-        Ok(DAGasUOData::Empty)
-    }
-
-    fn calc_da_gas_sync(
-        &self,
-        _uo_data: &DAGasUOData,
-        _block_data: &DAGasBlockData,
-        _gas_price: u128,
-    ) -> u128 {
-        panic!("ArbitrumNitroDAGasOracle does not support calc_da_gas_sync")
-    }
 }

--- a/crates/provider/src/alloy/da/local/nitro.rs
+++ b/crates/provider/src/alloy/da/local/nitro.rs
@@ -20,8 +20,8 @@ use rundler_utils::cache::LruMap;
 use tokio::sync::Mutex as TokioMutex;
 
 use crate::{
-    alloy::da::{arbitrum::NodeInterface::NodeInterfaceInstance, DAGasOracle},
-    BlockHashOrNumber, ProviderResult,
+    alloy::da::arbitrum::NodeInterface::NodeInterfaceInstance, BlockHashOrNumber, DAGasOracle,
+    DAGasOracleSync, ProviderResult,
 };
 
 /// Cached Arbitrum Nitro DA gas oracle
@@ -93,7 +93,14 @@ where
             }
         }
     }
+}
 
+#[async_trait::async_trait]
+impl<AP, T> DAGasOracleSync for CachedNitroDAGasOracle<AP, T>
+where
+    AP: AlloyProvider<T>,
+    T: Transport + Clone,
+{
     async fn block_data(&self, block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData> {
         let mut cache = self.block_data_cache.lock().await;
         match cache.get(&block) {

--- a/crates/provider/src/alloy/da/optimism.rs
+++ b/crates/provider/src/alloy/da/optimism.rs
@@ -81,26 +81,4 @@ where
             DAGasBlockData::Empty,
         ))
     }
-
-    async fn block_data(&self, _block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData> {
-        Ok(DAGasBlockData::Empty)
-    }
-
-    async fn uo_data(
-        &self,
-        _uo_data: Bytes,
-        _to: Address,
-        _block: BlockHashOrNumber,
-    ) -> ProviderResult<DAGasUOData> {
-        Ok(DAGasUOData::Empty)
-    }
-
-    fn calc_da_gas_sync(
-        &self,
-        _uo_data: &DAGasUOData,
-        _block_data: &DAGasBlockData,
-        _gas_price: u128,
-    ) -> u128 {
-        panic!("OptimismBedrockDAGasOracle does not support calc_da_gas_sync")
-    }
 }

--- a/crates/provider/src/alloy/entry_point/v0_7.rs
+++ b/crates/provider/src/alloy/entry_point/v0_7.rs
@@ -11,8 +11,6 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use std::sync::Arc;
-
 use alloy_contract::Error as ContractError;
 use alloy_json_rpc::ErrorPayload;
 use alloy_primitives::{Address, Bytes, U256};
@@ -45,7 +43,6 @@ use rundler_types::{
 };
 
 use crate::{
-    alloy::da::{self},
     AggregatorOut, AggregatorSimOut, BlockHashOrNumber, BundleHandler, DAGasOracle, DAGasProvider,
     DepositInfo, EntryPoint, EntryPointProvider as EntryPointProviderTrait, EvmCall,
     ExecutionResult, HandleOpsOut, ProviderResult, SignatureAggregator, SimulationProvider,
@@ -53,19 +50,19 @@ use crate::{
 
 /// Entry point provider for v0.7
 #[derive(Clone)]
-pub struct EntryPointProvider<'a, AP, T> {
+pub struct EntryPointProvider<AP, T, D> {
     i_entry_point: IEntryPointInstance<T, AP>,
-    da_gas_oracle: Arc<dyn DAGasOracle + 'a>,
+    da_gas_oracle: D,
     max_verification_gas: u64,
     max_simulate_handle_ops_gas: u64,
     max_aggregation_gas: u64,
     chain_spec: ChainSpec,
 }
 
-impl<'a, AP, T> EntryPointProvider<'a, AP, T>
+impl<AP, T, D> EntryPointProvider<AP, T, D>
 where
     T: Transport + Clone,
-    AP: AlloyProvider<T> + Clone + 'a,
+    AP: AlloyProvider<T> + Clone,
 {
     /// Create a new `EntryPoint` instance for v0.7
     pub fn new(
@@ -74,13 +71,14 @@ where
         max_simulate_handle_ops_gas: u64,
         max_aggregation_gas: u64,
         provider: AP,
+        da_gas_oracle: D,
     ) -> Self {
         Self {
             i_entry_point: IEntryPointInstance::new(
                 chain_spec.entry_point_address_v0_7,
                 provider.clone(),
             ),
-            da_gas_oracle: Arc::from(da::da_gas_oracle_for_chain(&chain_spec, provider)),
+            da_gas_oracle,
             max_verification_gas,
             max_simulate_handle_ops_gas,
             max_aggregation_gas,
@@ -90,10 +88,11 @@ where
 }
 
 #[async_trait::async_trait]
-impl<'a, AP, T> EntryPoint for EntryPointProvider<'a, AP, T>
+impl<AP, T, D> EntryPoint for EntryPointProvider<AP, T, D>
 where
     T: Transport + Clone,
     AP: AlloyProvider<T>,
+    D: Send + Sync,
 {
     fn address(&self) -> &Address {
         self.i_entry_point.address()
@@ -147,10 +146,11 @@ where
 }
 
 #[async_trait::async_trait]
-impl<'a, AP, T> SignatureAggregator for EntryPointProvider<'a, AP, T>
+impl<AP, T, D> SignatureAggregator for EntryPointProvider<AP, T, D>
 where
     T: Transport + Clone,
     AP: AlloyProvider<T>,
+    D: Send + Sync,
 {
     type UO = UserOperation;
 
@@ -227,10 +227,11 @@ where
 }
 
 #[async_trait::async_trait]
-impl<'a, AP, T> BundleHandler for EntryPointProvider<'a, AP, T>
+impl<AP, T, D> BundleHandler for EntryPointProvider<AP, T, D>
 where
     T: Transport + Clone,
     AP: AlloyProvider<T>,
+    D: Send + Sync,
 {
     type UO = UserOperation;
 
@@ -296,10 +297,11 @@ where
 }
 
 #[async_trait::async_trait]
-impl<'a, AP, T> DAGasProvider for EntryPointProvider<'a, AP, T>
+impl<AP, T, D> DAGasProvider for EntryPointProvider<AP, T, D>
 where
     T: Transport + Clone,
     AP: AlloyProvider<T>,
+    D: DAGasOracle,
 {
     type UO = UserOperation;
 
@@ -324,49 +326,14 @@ where
             .estimate_da_gas(bundle_data, *self.i_entry_point.address(), block, gas_price)
             .await
     }
-
-    async fn block_data(&self, block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData> {
-        self.da_gas_oracle.block_data(block).await
-    }
-
-    async fn uo_data(
-        &self,
-        uo: UserOperation,
-        block: BlockHashOrNumber,
-    ) -> ProviderResult<DAGasUOData> {
-        let gas_price = uo.max_fee_per_gas;
-        let data = self
-            .i_entry_point
-            .handleOps(vec![uo.pack()], Address::random())
-            .into_transaction_request()
-            .input
-            .into_input()
-            .unwrap();
-
-        let bundle_data =
-            super::max_bundle_transaction_data(*self.i_entry_point.address(), data, gas_price);
-
-        self.da_gas_oracle
-            .uo_data(bundle_data, *self.i_entry_point.address(), block)
-            .await
-    }
-
-    fn calc_da_gas_sync(
-        &self,
-        uo_data: &DAGasUOData,
-        block_data: &DAGasBlockData,
-        gas_price: u128,
-    ) -> u128 {
-        self.da_gas_oracle
-            .calc_da_gas_sync(uo_data, block_data, gas_price)
-    }
 }
 
 #[async_trait::async_trait]
-impl<'a, AP, T> SimulationProvider for EntryPointProvider<'a, AP, T>
+impl<AP, T, D> SimulationProvider for EntryPointProvider<AP, T, D>
 where
     T: Transport + Clone,
     AP: AlloyProvider<T>,
+    D: Send + Sync,
 {
     type UO = UserOperation;
 
@@ -489,10 +456,11 @@ where
     }
 }
 
-impl<'a, AP, T> EntryPointProviderTrait<UserOperation> for EntryPointProvider<'a, AP, T>
+impl<AP, T, D> EntryPointProviderTrait<UserOperation> for EntryPointProvider<AP, T, D>
 where
     T: Transport + Clone,
     AP: AlloyProvider<T>,
+    D: DAGasOracle,
 {
 }
 

--- a/crates/provider/src/alloy/mod.rs
+++ b/crates/provider/src/alloy/mod.rs
@@ -23,7 +23,8 @@ use url::Url;
 
 use crate::EvmProvider;
 
-pub(crate) mod da;
+mod da;
+pub use da::new_alloy_da_gas_oracle;
 pub(crate) mod entry_point;
 pub(crate) mod evm;
 pub(crate) mod metrics;

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -31,11 +31,13 @@ pub use alloy::{
         },
     },
     evm::AlloyEvmProvider,
-    new_alloy_evm_provider, new_alloy_provider,
+    new_alloy_da_gas_oracle, new_alloy_evm_provider, new_alloy_provider,
 };
 
 mod traits;
 // re-export alloy RPC types
+use std::marker::PhantomData;
+
 pub use alloy_json_rpc::{RpcParam, RpcReturn};
 pub use alloy_rpc_types_eth::{
     state::{AccountOverride, StateOverride},
@@ -50,6 +52,147 @@ pub use alloy_rpc_types_trace::geth::{
 };
 // re-export contract types
 pub use rundler_contracts::utils::GetGasUsed::GasUsedResult;
+use rundler_types::{
+    v0_6::UserOperation as UserOperationV0_6, v0_7::UserOperation as UserOperationV0_7,
+    UserOperation, UserOperationVariant,
+};
 #[cfg(any(test, feature = "test-utils"))]
 pub use traits::test_utils::*;
 pub use traits::*;
+
+/// A trait that provides access to various providers.
+pub trait Providers: Send + Sync + Clone {
+    /// The EVM provider.
+    type Evm: EvmProvider + Clone;
+
+    /// The entry point provider for v0.6.
+    type EntryPointV0_6: EntryPointProvider<UserOperationV0_6> + Clone;
+
+    /// The entry point provider for v0.7.
+    type EntryPointV0_7: EntryPointProvider<UserOperationV0_7> + Clone;
+
+    /// The DA gas oracle sync provider.
+    type DAGasOracleSync: DAGasOracleSync + Clone;
+
+    /// Returns the EVM provider.
+    fn evm(&self) -> &Self::Evm;
+
+    /// Returns the entry point provider for v0.6.
+    fn ep_v0_6(&self) -> &Option<Self::EntryPointV0_6>;
+
+    /// Returns the entry point provider for v0.7.
+    fn ep_v0_7(&self) -> &Option<Self::EntryPointV0_7>;
+
+    /// Returns the DA gas oracle sync provider.
+    fn da_gas_oracle_sync(&self) -> &Option<Self::DAGasOracleSync>;
+
+    /// Returns the providers with the entry point for v0.6.
+    #[allow(clippy::type_complexity)]
+    fn ep_v0_6_providers(
+        &self,
+    ) -> Option<
+        ProvidersWithEntryPoint<
+            UserOperationV0_6,
+            Self::Evm,
+            Self::EntryPointV0_6,
+            Self::DAGasOracleSync,
+        >,
+    > {
+        self.ep_v0_6().as_ref().map(|ep| ProvidersWithEntryPoint {
+            evm: self.evm().clone(),
+            ep: ep.clone(),
+            da_gas_oracle_sync: self.da_gas_oracle_sync().clone(),
+            _phantom: PhantomData,
+        })
+    }
+
+    /// Returns the providers with the entry point for v0.7.
+    #[allow(clippy::type_complexity)]
+    fn ep_v0_7_providers(
+        &self,
+    ) -> Option<
+        ProvidersWithEntryPoint<
+            UserOperationV0_7,
+            Self::Evm,
+            Self::EntryPointV0_7,
+            Self::DAGasOracleSync,
+        >,
+    > {
+        self.ep_v0_7().as_ref().map(|ep| ProvidersWithEntryPoint {
+            evm: self.evm().clone(),
+            ep: ep.clone(),
+            da_gas_oracle_sync: self.da_gas_oracle_sync().clone(),
+            _phantom: PhantomData,
+        })
+    }
+}
+
+/// Trait for providers with a specific entry point.
+pub trait ProvidersWithEntryPointT: Send + Sync + Clone {
+    /// User operation type.
+    type UO: UserOperation + From<UserOperationVariant> + Into<UserOperationVariant>;
+
+    /// The EVM provider.
+    type Evm: EvmProvider + Clone;
+
+    /// The entry point provider.
+    type EntryPoint: EntryPointProvider<Self::UO> + Clone;
+
+    /// The DA gas oracle sync provider.
+    type DAGasOracleSync: DAGasOracleSync + Clone;
+
+    /// Returns the EVM provider.
+    fn evm(&self) -> &Self::Evm;
+
+    /// Returns the entry point provider.
+    fn entry_point(&self) -> &Self::EntryPoint;
+
+    /// Returns the DA gas oracle sync provider.
+    fn da_gas_oracle_sync(&self) -> &Option<Self::DAGasOracleSync>;
+}
+
+/// Container for providers with a specific entry point.
+#[derive(Clone)]
+pub struct ProvidersWithEntryPoint<UO, E, EP, D> {
+    evm: E,
+    ep: EP,
+    da_gas_oracle_sync: Option<D>,
+    _phantom: PhantomData<UO>,
+}
+
+impl<UO, E, EP, D> ProvidersWithEntryPoint<UO, E, EP, D> {
+    /// Create a new ProvidersWithEntryPoint.
+    pub fn new(evm: E, ep: EP, da_gas_oracle_sync: Option<D>) -> Self {
+        Self {
+            evm,
+            ep,
+            da_gas_oracle_sync,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<UO, E, EP, D> ProvidersWithEntryPointT for ProvidersWithEntryPoint<UO, E, EP, D>
+where
+    UO: UserOperation + From<UserOperationVariant> + Into<UserOperationVariant>,
+    E: EvmProvider + Clone,
+    EP: EntryPointProvider<UO> + Clone,
+    D: DAGasOracleSync + Clone,
+{
+    type UO = UO;
+    type Evm = E;
+    type EntryPoint = EP;
+    type DAGasOracleSync = D;
+
+    fn evm(&self) -> &Self::Evm {
+        &self.evm
+    }
+
+    fn entry_point(&self) -> &Self::EntryPoint {
+        &self.ep
+    }
+
+    fn da_gas_oracle_sync(&self) -> &Option<Self::DAGasOracleSync> {
+        &self.da_gas_oracle_sync
+    }
+}

--- a/crates/provider/src/traits/da.rs
+++ b/crates/provider/src/traits/da.rs
@@ -16,10 +16,10 @@ use rundler_types::da::{DAGasBlockData, DAGasUOData};
 
 use crate::{BlockHashOrNumber, ProviderResult};
 
-// Trait for a DA gas oracle
+/// Trait for a DA gas oracle
 #[async_trait::async_trait]
 #[auto_impl::auto_impl(&, &mut, Rc, Arc, Box)]
-pub(crate) trait DAGasOracle: Send + Sync {
+pub trait DAGasOracle: Send + Sync {
     /// Estimate the DA gas for a given user operation's bytes
     ///
     /// Returns the estimated gas, as well as both the UO DA data and the block DA data.
@@ -32,7 +32,12 @@ pub(crate) trait DAGasOracle: Send + Sync {
         block: BlockHashOrNumber,
         gas_price: u128,
     ) -> ProviderResult<(u128, DAGasUOData, DAGasBlockData)>;
+}
 
+/// Trait for a DA gas oracle with a synchronous calculation method
+#[async_trait::async_trait]
+#[auto_impl::auto_impl(&, &mut, Rc, Arc, Box)]
+pub trait DAGasOracleSync: DAGasOracle {
     /// Retrieve the DA gas data for a given block. This value can change block to block and
     /// thus must be retrieved fresh from the DA for every block.
     async fn block_data(&self, block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData>;

--- a/crates/provider/src/traits/entry_point.rs
+++ b/crates/provider/src/traits/entry_point.rs
@@ -176,32 +176,6 @@ pub trait DAGasProvider: Send + Sync {
         block: BlockHashOrNumber,
         gas_price: u128,
     ) -> ProviderResult<(u128, DAGasUOData, DAGasBlockData)>;
-
-    /// Retrieve the DA gas data for a given block. This value can change block to block and
-    /// thus must be retrieved fresh from the DA for every block.
-    async fn block_data(&self, block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData>;
-
-    /// Retrieve the DA gas data for a given user operation's bytes
-    ///
-    /// This should not change block to block, but may change after underlying hard forks,
-    /// thus a block number is required.
-    ///
-    /// It is safe to calculate this once and re-use if the same UO is used for multiple calls within
-    /// a small time period (no hard forks impacting DA calculations)
-    async fn uo_data(&self, uo: Self::UO, block: BlockHashOrNumber) -> ProviderResult<DAGasUOData>;
-
-    /// Synchronously calculate the DA gas for a given user operation data and block data.
-    /// These values must have been previously retrieved from a DA provider of the same implementation
-    /// else this function will PANIC.
-    ///
-    /// This function is intended to allow synchronous DA gas calculation from a cached UO data and a
-    /// recently retrieved block data.
-    fn calc_da_gas_sync(
-        &self,
-        uo_data: &DAGasUOData,
-        block_data: &DAGasBlockData,
-        gas_price: u128,
-    ) -> u128;
 }
 
 /// Trait for simulating user operations on an entry point contract

--- a/crates/provider/src/traits/mod.rs
+++ b/crates/provider/src/traits/mod.rs
@@ -14,7 +14,7 @@
 //! Traits for the provider module.
 
 mod da;
-pub(crate) use da::DAGasOracle;
+pub use da::{DAGasOracle, DAGasOracleSync};
 
 mod error;
 pub use error::*;

--- a/crates/provider/src/traits/test_utils.rs
+++ b/crates/provider/src/traits/test_utils.rs
@@ -29,8 +29,8 @@ use rundler_types::{
 use super::error::ProviderResult;
 use crate::{
     AggregatorOut, BlockHashOrNumber, BundleHandler, DAGasProvider, DepositInfo, EntryPoint,
-    EvmCall, EvmProvider as EvmProviderTrait, ExecutionResult, HandleOpsOut, SignatureAggregator,
-    SimulationProvider,
+    EntryPointProvider, EvmCall, EvmProvider as EvmProviderTrait, ExecutionResult, HandleOpsOut,
+    SignatureAggregator, SimulationProvider,
 };
 
 mockall::mock! {
@@ -178,12 +178,6 @@ mockall::mock! {
             block: BlockHashOrNumber,
             gas_price: u128,
         ) -> ProviderResult<(u128, DAGasUOData, DAGasBlockData)>;
-
-        async fn block_data(&self, block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData>;
-
-        async fn uo_data(&self, uo: v0_6::UserOperation, block: BlockHashOrNumber) -> ProviderResult<DAGasUOData>;
-
-        fn calc_da_gas_sync(&self, uo_data: &DAGasUOData, block_data: &DAGasBlockData, gas_price: u128) -> u128;
     }
 
     #[async_trait::async_trait]
@@ -203,6 +197,8 @@ mockall::mock! {
             gas_fees: GasFees,
         ) -> TransactionRequest;
     }
+
+    impl EntryPointProvider<v0_6::UserOperation> for EntryPointV0_6 {}
 }
 
 mockall::mock! {
@@ -272,12 +268,6 @@ mockall::mock! {
             block: BlockHashOrNumber,
             gas_price: u128,
         ) -> ProviderResult<(u128, DAGasUOData, DAGasBlockData)>;
-
-        async fn block_data(&self, block: BlockHashOrNumber) -> ProviderResult<DAGasBlockData>;
-
-        async fn uo_data(&self, uo: v0_7::UserOperation, block: BlockHashOrNumber) -> ProviderResult<DAGasUOData>;
-
-        fn calc_da_gas_sync(&self, uo_data: &DAGasUOData, block_data: &DAGasBlockData, gas_price: u128) -> u128;
     }
 
     #[async_trait::async_trait]
@@ -297,4 +287,6 @@ mockall::mock! {
             gas_fees: GasFees,
         ) -> TransactionRequest;
     }
+
+    impl EntryPointProvider<v0_7::UserOperation> for EntryPointV0_7 {}
 }


### PR DESCRIPTION
Applies this pattern in 3 places:

- Providers for tasks (reused by all tasks)
- UO Pool
- Bundler Proposer

I like the first one, but the second two seem to bring out too much boilerplate and the types aren't reused. Want to see if I can simplify a bit using some sort of composition, but if I can't simplify I may just keep the first one.
