### PR TITLE
feat(ratelimit): adding github token to get past rate limits

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,8 @@ jobs:
       - name: Install protobuf
         if: contains( ${{ matrix.target }}, 'apple')
         uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # ==============================
       # Apple Silicon SDK setup


### PR DESCRIPTION
## Proposed Changes
  - add container github token so that we can bypass protoc rate limits
  - Got this information from https://github.com/arduino/setup-protoc/issues/6
 
