### PR TITLE
feat(chain): add a sync error count to reset in edge cases

### DIFF
--- a/crates/pool/src/chain.rs
+++ b/crates/pool/src/chain.rs
@@ -248,7 +248,7 @@ impl<P: EvmProvider> Chain<P> {
             return self.reset_and_initialize(new_head).await;
         }
 
-        if current_block_number < new_block_number + self.settings.history_size {
+        if current_block_number > new_block_number + self.settings.history_size {
             self.sync_error_count += 1;
             bail!(
             "new block number {new_block_number} should be greater than start of history (current block: {current_block_number})"

--- a/crates/pool/src/chain.rs
+++ b/crates/pool/src/chain.rs
@@ -451,11 +451,10 @@ impl<P: EvmProvider> Chain<P> {
                     Some(blocks[0].number - 1),
                 )?);
             } else {
-                warn!(
+                bail!(
                 "Unable to backtrack chain history beyond block number {} due to missing parent block.",
                 blocks[0].number
             );
-                break;
             }
         }
         Ok(blocks)

--- a/crates/pool/src/chain.rs
+++ b/crates/pool/src/chain.rs
@@ -244,12 +244,13 @@ impl<P: EvmProvider> Chain<P> {
         let current_block_number = current_block.number;
         let new_block_number = new_head.number;
 
-        if self.sync_error_count >= SYNC_ERROR_COUNT_MAX {
-            return self.reset_and_initialize(new_head).await;
-        }
-
         if current_block_number > new_block_number + self.settings.history_size {
             self.sync_error_count += 1;
+
+            if self.sync_error_count >= SYNC_ERROR_COUNT_MAX {
+                return self.reset_and_initialize(new_head).await;
+            }
+
             bail!(
             "new block number {new_block_number} should be greater than start of history (current block: {current_block_number})"
             )


### PR DESCRIPTION
## Proposed Changes
  - Add sync error counter to the chain tracker to catch the edge case where the chain will always get stopped at the `ensure!` macro where the current head is much larger than the new head
