### PR TITLE
feat(Rundler): Add cors to the server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2717,7 +2717,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -3236,7 +3236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4518,6 +4518,7 @@ dependencies = [
  "config",
  "dotenv",
  "go-parse-duration",
+ "http 1.1.0",
  "itertools 0.13.0",
  "metrics",
  "metrics-derive",
@@ -4721,6 +4722,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tower 0.4.13",
+ "tower-http",
  "tracing",
  "url",
 ]
@@ -5892,6 +5894,20 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "http 1.1.0",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ tonic-health = "0.12.3"
 tonic-reflection = "0.12.3"
 tonic-types = "0.12.3"
 tower = { version = "0.4.13", features = ["timeout"] }
+tower-http = { version = "0.6.2", features = ["cors"] }
 tracing = "0.1.40"
 strum = { version = "0.26.3", features = ["derive"] }
 url = "2.5.2"

--- a/bin/rundler/Cargo.toml
+++ b/bin/rundler/Cargo.toml
@@ -29,6 +29,7 @@ clap = { version = "4.5.16", features = ["derive", "env"] }
 config = "0.14.0"
 dotenv = "0.15.0"
 go-parse-duration = "0.1"
+http = "1.1.0"
 itertools = "0.13.0"
 metrics = "0.23.0"
 metrics-derive.workspace = true

--- a/bin/rundler/src/cli/rpc.rs
+++ b/bin/rundler/src/cli/rpc.rs
@@ -74,6 +74,22 @@ pub struct RpcArgs {
         default_value = "100"
     )]
     max_connections: u32,
+
+    /// Cors domains seperated by a comma, * is the wildcard
+    ///
+    /// # Examples
+    ///.env
+    /// ```env
+    /// RPC_CORSDOMAIN=*
+    /// RPC_CORSDOMAIN=https://site1.fake,https:://sub.site1.fake
+    /// ```
+    #[arg(
+        long = "rpc.corsdomain",
+        name = "rpc.corsdomain",
+        env = "RPC_CORSDOMAIN",
+        value_delimiter = ','
+    )]
+    pub corsdomain: Option<Vec<http::HeaderValue>>,
 }
 
 impl RpcArgs {
@@ -109,6 +125,7 @@ impl RpcArgs {
             max_connections: self.max_connections,
             entry_point_v0_6_enabled: !common.disable_entry_point_v0_6,
             entry_point_v0_7_enabled: !common.disable_entry_point_v0_7,
+            corsdomain: self.corsdomain.clone(),
         })
     }
 }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -34,6 +34,7 @@ tokio.workspace = true
 tokio-util.workspace = true
 tonic.workspace = true
 tower.workspace = true
+tower-http = { workspace = true, features = ["cors"] }
 tracing.workspace = true
 url.workspace = true
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -116,6 +116,8 @@ List of command line options for configuring the RPC API.
   - env: *RPC_TIMEOUT_SECONDS*
 - `--rpc.max_connections`:	Maximum number of concurrent connections (default: `100`)
   - env: *RPC_MAX_CONNECTIONS*
+- `--rpc.corsdomain`: Enable the cors functionality on the server (default: None and therefore corsdomain is disabled).
+  - env: *RPC_CORSDOMAIN*
 - `--rpc.pool_url`:	Pool URL for RPC (default: `http://localhost:50051`)
   - env: *RPC_POOL_URL*
   - *Only required when running in distributed mode* 


### PR DESCRIPTION
[Closes/Fixes] #579 

## Proposed Changes

* Implementing the cors that is already written for tower-http.

## Proof it works

This is before the cors implementation

![image](https://github.com/user-attachments/assets/34a5fd7a-c168-4b51-960d-01d88ec0e616)

Then adding the `RPC_CORSDOMAIN=*` fix we get

![image](https://github.com/user-attachments/assets/e313c72e-ec84-4c44-8161-2be712bb7303)

This is from 127.0.0.1:3000, notice no cors in response
![image](https://github.com/user-attachments/assets/d7fe018a-479d-462a-8b3d-4e6f7bd4c5bd)

This is from localhost:3000, notice again cors
![image](https://github.com/user-attachments/assets/b849de63-ae13-4d75-9d99-a8ab99f78e1e)

Then we set the `RPC_CORSDOMAIN=http://127.0.0.1:3000`
![image](https://github.com/user-attachments/assets/5abcf9d8-8dc7-4f0e-b8f7-06b3bb1dd12b)


Then we set the `RPC_CORSDOMAIN=http://127.0.0.1:3000,http://localhost:3000` Testing list of domains
![image](https://github.com/user-attachments/assets/cec49be4-f7af-4487-b20c-22d190a8d85f)

And when we add a wildcard at the end `RPC_CORSDOMAIN=http://127.0.0.1:3000,http://localhost:3000,*`
we throw on reading the env
![image](https://github.com/user-attachments/assets/30a82170-6d0d-4df4-9433-8975e0d947b8)


And with corsdomain as localhost
```js
fetch("http://127.0.0.1:3000/", {
            method: 'POST',
            mode: 'cors',
            headers: { 'Content-Type': 'application/json' },
            body: JSON.stringify({
                jsonrpc: '2.0',
                method: 'system_health',
                id: 1
            })
        }).then(res => {
            console.log("Response:", res);
            return res.text()
        }).then(body => {
            console.log("Response Body:", body)
        });
```

