### PR TITLE
feat(ci): fix release runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@1.83.0
+      - uses: dtolnay/rust-toolchain@1.82.0
         with:
           target: ${{ matrix.target }}
       - uses: taiki-e/install-action@cross

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
             os: ubuntu-20.04
             profile: release
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13
             profile: release
           - target: aarch64-apple-darwin
             os: macos-latest
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@1.82.0
+      - uses: dtolnay/rust-toolchain@1.83.0
         with:
           target: ${{ matrix.target }}
       - uses: taiki-e/install-action@cross

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.83.0
         with:
           target: ${{ matrix.target }}
       - uses: taiki-e/install-action@cross


### PR DESCRIPTION
## Proposed Changes

  - Pin rust version
  - Update the macos runner for x86 runners
  
  turns out github made a change and now the `macos-latest` runner only supports arm64 as all their new apple machines are arm. I changed the intel runner to `macos-13` to fix the bug when trying to install the rust std lib.
  
  https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
