### PR TITLE
feat(builder): process reverts through proxies, removing ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4767,6 +4767,7 @@ version = "0.5.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
+ "async-trait",
  "aws-config",
  "aws-sdk-s3",
  "clap",
@@ -4893,6 +4894,7 @@ dependencies = [
  "async-trait",
  "rundler-provider",
  "rundler-types",
+ "tracing",
 ]
 
 [[package]]

--- a/bin/rundler/Cargo.toml
+++ b/bin/rundler/Cargo.toml
@@ -25,6 +25,7 @@ rundler-utils.workspace = true
 alloy-primitives.workspace = true
 
 anyhow.workspace = true
+async-trait.workspace = true
 aws-config.workspace = true
 aws-sdk-s3 = { version = "1.52", default-features = false }
 clap = { version = "4.5.16", features = ["derive", "env"] }

--- a/bin/rundler/src/cli/proxy.rs
+++ b/bin/rundler/src/cli/proxy.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, Bytes, B256};
 use rundler_types::{proxy::SubmissionProxy, UserOperationVariant, UserOpsPerAggregator};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString)]
@@ -26,16 +26,17 @@ pub(crate) struct PassThroughProxy {
     address: Address,
 }
 
+#[async_trait::async_trait]
 impl SubmissionProxy for PassThroughProxy {
     fn address(&self) -> Address {
         self.address
     }
 
-    fn process_revert(
+    async fn process_revert(
         &self,
         _revert_data: Bytes,
-        _ops: UserOpsPerAggregator<UserOperationVariant>,
-    ) -> Vec<U256> {
+        _ops: Vec<UserOpsPerAggregator<UserOperationVariant>>,
+    ) -> Vec<B256> {
         vec![]
     }
 }

--- a/crates/aggregators/pbh/Cargo.toml
+++ b/crates/aggregators/pbh/Cargo.toml
@@ -14,4 +14,4 @@ rundler-types.workspace = true
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 async-trait.workspace = true
-
+tracing.workspace = true

--- a/crates/aggregators/pbh/src/proxy.rs
+++ b/crates/aggregators/pbh/src/proxy.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, Bytes, B256};
 use rundler_types::{proxy::SubmissionProxy, UserOperationVariant, UserOpsPerAggregator};
 
 /// Submission proxy for the PBH aggregator
@@ -20,16 +20,20 @@ pub struct PbhSubmissionProxy {
     address: Address,
 }
 
+#[async_trait::async_trait]
 impl SubmissionProxy for PbhSubmissionProxy {
     fn address(&self) -> Address {
         self.address
     }
 
-    fn process_revert(
+    async fn process_revert(
         &self,
-        _revert_data: Bytes,
-        _ops: UserOpsPerAggregator<UserOperationVariant>,
-    ) -> Vec<U256> {
+        revert_data: Bytes,
+        _ops: Vec<UserOpsPerAggregator<UserOperationVariant>>,
+    ) -> Vec<B256> {
+        tracing::info!(
+            "PBH submission proxy received revert data, processing unimplemented: {revert_data:?}"
+        );
         vec![]
     }
 }

--- a/crates/provider/src/alloy/entry_point/v0_6.rs
+++ b/crates/provider/src/alloy/entry_point/v0_6.rs
@@ -291,6 +291,8 @@ where
                         }
                         _ => Err(TransportError::ErrorResp(resp).into()),
                     }
+                } else if let Some(revert_data) = resp.as_revert_data() {
+                    Ok(HandleOpsOut::Revert(revert_data))
                 } else {
                     Err(TransportError::ErrorResp(resp).into())
                 }

--- a/crates/provider/src/alloy/entry_point/v0_7.rs
+++ b/crates/provider/src/alloy/entry_point/v0_7.rs
@@ -284,6 +284,8 @@ where
                         }
                         _ => Err(TransportError::ErrorResp(resp).into()),
                     }
+                } else if let Some(revert_data) = resp.as_revert_data() {
+                    Ok(HandleOpsOut::Revert(revert_data))
                 } else {
                     Err(TransportError::ErrorResp(resp).into())
                 }

--- a/crates/provider/src/traits/entry_point.rs
+++ b/crates/provider/src/traits/entry_point.rs
@@ -51,6 +51,8 @@ pub enum HandleOpsOut {
     /// Call failed due to a bug in the 0.6 entry point contract https://github.com/eth-infinitism/account-abstraction/pull/325.
     /// Special handling is required to remove the offending operation from the bundle.
     PostOpRevert,
+    /// Call reverted
+    Revert(Bytes),
 }
 
 /// Deposit info for an address from the entry point contract

--- a/crates/types/src/proxy.rs
+++ b/crates/types/src/proxy.rs
@@ -15,7 +15,7 @@
 
 use std::fmt::Debug;
 
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, Bytes, B256};
 
 use crate::{UserOperationVariant, UserOpsPerAggregator};
 
@@ -27,11 +27,11 @@ pub trait SubmissionProxy: Sync + Send + Debug {
     fn address(&self) -> Address;
 
     /// Process a revert from a submission proxy and return the hashes of ops that should be rejected
-    fn process_revert(
+    async fn process_revert(
         &self,
         revert_data: Bytes,
-        ops: UserOpsPerAggregator<UserOperationVariant>,
-    ) -> Vec<U256>;
+        ops: Vec<UserOpsPerAggregator<UserOperationVariant>>,
+    ) -> Vec<B256>;
 }
 
 #[cfg(feature = "test-utils")]
@@ -43,10 +43,10 @@ mockall::mock! {
     impl SubmissionProxy for SubmissionProxy {
         fn address(&self) -> Address;
 
-        fn process_revert(
+        async fn process_revert(
             &self,
             revert_data: Bytes,
-            ops: UserOpsPerAggregator<UserOperationVariant>,
-        ) -> Vec<U256>;
+            ops: Vec<UserOpsPerAggregator<UserOperationVariant>>,
+        ) -> Vec<B256>;
     }
 }

--- a/crates/types/src/user_operation/mod.rs
+++ b/crates/types/src/user_operation/mod.rs
@@ -728,6 +728,17 @@ pub struct UserOpsPerAggregator<UO: UserOperation> {
     pub signature: Bytes,
 }
 
+impl<UO: UserOperation + Into<UserOperationVariant>> UserOpsPerAggregator<UO> {
+    /// Convert the user operations to a vector of user operation variants
+    pub fn into_uo_variants(self) -> UserOpsPerAggregator<UserOperationVariant> {
+        UserOpsPerAggregator {
+            user_ops: self.user_ops.into_iter().map(|uo| uo.into()).collect(),
+            aggregator: self.aggregator,
+            signature: self.signature,
+        }
+    }
+}
+
 pub(crate) fn op_calldata_gas_cost<UO: SolValue>(
     uo: &UO,
     zero_byte_cost: u128,

--- a/docs/architecture/builder.md
+++ b/docs/architecture/builder.md
@@ -146,10 +146,6 @@ If deploying multiple builder nodes all targeting the same mempool, users must e
 
 Most deployments of Rundler should be able to use the configuration above. Rundler does support more detailed configuration for certain use cases. See [`EntryPointBuilderConfigs`](../../bin/rundler/src/cli/builder.rs) for the exact schema of the custom configuration file. Set the path for this file via `--entry_point_builders_path`. When this feature is used the normal CLI-based configuration options are ignored and Rundler will configure builders according to the file.
 
-Currently, this covers the following use cases:
-
-* Entry point submission proxies: Set a separate contract address that the builder should submit bundles through. The contract at this address MUST have the same ABI as `IEntryPoint` for all methods used: `handleOps` and `handleAggregatedOps` if using non-aggregated/aggregated ops respectively.
-
 Example:
 
 ```
@@ -172,3 +168,13 @@ Example:
 #### Affinity
 
 Builders may specify a `filterId` in their custom configuration in order to only receive user operations that match a [mempool filter](./pool.md#filtering). Each mempool filter that is defined must have a matching builder - else the user operations matching that filter will not be mined.
+
+#### Proxies
+
+Set a separate contract address, via the `proxy` config, that the builder should submit bundles through. The contract at this address MUST have the same ABI as `IEntryPoint` for all methods used: `handleOps` and `handleAggregatedOps` if using non-aggregated/aggregated ops respectively.
+
+If the proxy contract has custom errors that need to be handled during bundle simulation, a `SubmissionProxy` implementation must be supported. To associate the `proxy` with its implementation, use the configuration `proxyType`.
+
+Supported types:
+* `passthrough` (default): no logic
+* `pbh`: support for the PBH entrypoint proxy. Implements special handling for its revert reasons.


### PR DESCRIPTION
## Proposed Changes

  - Pass non-entrypoint revert data to proxies, if they exist
  - Remove UOs from the pool if notified by proxy
  - Else, remove all UOs from the pool if the fault is not attributable to avoid infinite failure loops
