### PR TITLE
feat: cleanup uo interface to be safer to modifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 ##@ Test
 
-UNIT_TEST_ARGS := --locked --workspace --all-features
+UNIT_TEST_ARGS := --locked --workspace --all-features --no-fail-fast
 PROFILE ?= release
 DOCKER_IMAGE_NAME ?= alchemyplatform/rundler
 BIN_DIR = "dist/bin"

--- a/crates/aggregators/pbh/src/pbh.rs
+++ b/crates/aggregators/pbh/src/pbh.rs
@@ -21,7 +21,7 @@ use rundler_types::{
         AggregatorCosts, SignatureAggregator, SignatureAggregatorError, SignatureAggregatorResult,
     },
     v0_7::UserOperation,
-    UserOperationVariant,
+    UserOperation as _, UserOperationVariant,
 };
 
 sol! {
@@ -117,17 +117,17 @@ where
             }
             let uo: UserOperation = user_op.clone().into();
 
-            if uo.signature.len() < PBH_PROOF_LENGTH {
+            if uo.signature().len() < PBH_PROOF_LENGTH {
                 return Err(SignatureAggregatorError::InvalidUserOperation(format!(
                     "User operation signature is not the correct length: {} < {}",
-                    uo.signature.len(),
+                    uo.signature().len(),
                     PBH_PROOF_LENGTH
                 )));
             }
 
-            let proof_start = uo.signature.len() - PBH_PROOF_LENGTH;
+            let proof_start = uo.signature().len() - PBH_PROOF_LENGTH;
             agg_proofs.push(
-                PBHPayload::abi_decode(&uo.signature[proof_start..], true).map_err(|e| {
+                PBHPayload::abi_decode(&uo.signature()[proof_start..], true).map_err(|e| {
                     SignatureAggregatorError::InvalidUserOperation(format!(
                         "Malformed PBH proof: {}",
                         e

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -707,7 +707,7 @@ where
             bundle.rejected_ops.len(),
             bundle.entity_updates.len()
         );
-        let op_hashes: Vec<_> = bundle.iter_ops().map(|op| self.op_hash(op)).collect();
+        let op_hashes: Vec<_> = bundle.iter_ops().map(|op| op.hash()).collect();
 
         let mut tx = self.entry_point.get_send_bundle_transaction(
             bundle.ops_per_aggregator,
@@ -729,9 +729,7 @@ where
         self.pool
             .remove_ops(
                 *self.entry_point.address(),
-                ops.iter()
-                    .map(|op| op.hash(*self.entry_point.address(), self.chain_spec.id))
-                    .collect(),
+                ops.iter().map(|op| op.hash()).collect(),
             )
             .await
             .context("builder should remove rejected ops from pool")
@@ -749,10 +747,6 @@ where
             entry_point: *self.entry_point.address(),
             event,
         });
-    }
-
-    fn op_hash(&self, op: &UO) -> B256 {
-        op.hash(*self.entry_point.address(), self.chain_spec.id)
     }
 }
 

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -196,7 +196,8 @@ pub enum OperationOrigin {
 #[cfg(test)]
 mod tests {
     use rundler_types::{
-        v0_6::UserOperation, Entity, EntityInfo, EntityInfos, EntityType, ValidTimeRange,
+        v0_6::{UserOperationBuilder, UserOperationRequiredFields},
+        Entity, EntityInfo, EntityInfos, EntityType, ValidTimeRange,
     };
 
     use super::*;
@@ -209,12 +210,16 @@ mod tests {
         let factory = Address::random();
 
         let po = PoolOperation {
-            uo: UserOperation {
-                sender,
-                paymaster_and_data: paymaster.to_vec().into(),
-                init_code: factory.to_vec().into(),
-                ..Default::default()
-            }
+            uo: UserOperationBuilder::new(
+                &ChainSpec::default(),
+                UserOperationRequiredFields {
+                    sender,
+                    paymaster_and_data: paymaster.to_vec().into(),
+                    init_code: factory.to_vec().into(),
+                    ..Default::default()
+                },
+            )
+            .build()
             .into(),
             entry_point: Address::random(),
             aggregator: Some(aggregator),

--- a/crates/pool/src/mempool/paymaster.rs
+++ b/crates/pool/src/mempool/paymaster.rs
@@ -510,8 +510,9 @@ mod tests {
     use alloy_primitives::{Address, B256, U256};
     use rundler_provider::{DepositInfo, MockEntryPointV0_6};
     use rundler_types::{
+        chain::ChainSpec,
         pool::{PaymasterMetadata, PoolOperation},
-        v0_6::UserOperation,
+        v0_6::{UserOperation, UserOperationBuilder, UserOperationRequiredFields},
         EntityInfos, UserOperation as UserOperationTrait, UserOperationId, ValidTimeRange,
     };
 
@@ -540,15 +541,20 @@ mod tests {
 
         let paymaster = Address::random();
         let sender = Address::random();
-        let uo = UserOperation {
-            sender,
-            call_gas_limit: 10,
-            pre_verification_gas: 10,
-            paymaster_and_data: paymaster.to_vec().into(),
-            verification_gas_limit: 10,
-            max_fee_per_gas: 1,
-            ..Default::default()
-        };
+
+        let uo = UserOperationBuilder::new(
+            &ChainSpec::default(),
+            UserOperationRequiredFields {
+                sender,
+                call_gas_limit: 10,
+                pre_verification_gas: 10,
+                paymaster_and_data: paymaster.to_vec().into(),
+                verification_gas_limit: 10,
+                max_fee_per_gas: 1,
+                ..Default::default()
+            },
+        )
+        .build();
 
         let uo_max_cost = uo.clone().max_gas_cost();
 
@@ -580,15 +586,19 @@ mod tests {
 
         paymaster_tracker.add_new_paymaster(paymaster, confirmed_balance, paymaster_balance);
 
-        let uo = UserOperation {
-            sender,
-            call_gas_limit: 10,
-            paymaster_and_data: paymaster.to_vec().into(),
-            pre_verification_gas: 10,
-            verification_gas_limit: 10,
-            max_fee_per_gas: 1,
-            ..Default::default()
-        };
+        let uo = UserOperationBuilder::new(
+            &ChainSpec::default(),
+            UserOperationRequiredFields {
+                sender,
+                call_gas_limit: 10,
+                paymaster_and_data: paymaster.to_vec().into(),
+                pre_verification_gas: 10,
+                verification_gas_limit: 10,
+                max_fee_per_gas: 1,
+                ..Default::default()
+            },
+        )
+        .build();
 
         let po = demo_pool_op(uo);
 
@@ -606,14 +616,19 @@ mod tests {
         let sender = Address::random();
         let pending_op_cost = U256::from(5);
         let confirmed_balance = U256::from(5);
-        let uo = UserOperation {
-            sender,
-            call_gas_limit: 10,
-            pre_verification_gas: 10,
-            verification_gas_limit: 10,
-            max_fee_per_gas: 1,
-            ..Default::default()
-        };
+
+        let uo = UserOperationBuilder::new(
+            &ChainSpec::default(),
+            UserOperationRequiredFields {
+                sender,
+                call_gas_limit: 10,
+                pre_verification_gas: 10,
+                verification_gas_limit: 10,
+                max_fee_per_gas: 1,
+                ..Default::default()
+            },
+        )
+        .build();
 
         let po = demo_pool_op(uo);
 
@@ -638,15 +653,19 @@ mod tests {
             pending_paymaster_balance,
         );
 
-        let uo = UserOperation {
-            sender,
-            call_gas_limit: 100,
-            paymaster_and_data: paymaster.to_vec().into(),
-            pre_verification_gas: 100,
-            verification_gas_limit: 100,
-            max_fee_per_gas: 1,
-            ..Default::default()
-        };
+        let uo = UserOperationBuilder::new(
+            &ChainSpec::default(),
+            UserOperationRequiredFields {
+                sender,
+                call_gas_limit: 100,
+                paymaster_and_data: paymaster.to_vec().into(),
+                pre_verification_gas: 100,
+                verification_gas_limit: 100,
+                max_fee_per_gas: 1,
+                ..Default::default()
+            },
+        )
+        .build();
 
         let po = demo_pool_op(uo);
 
@@ -722,15 +741,20 @@ mod tests {
         );
 
         let sender = Address::random();
-        let uo = UserOperation {
-            sender,
-            call_gas_limit: 10,
-            pre_verification_gas: 10,
-            verification_gas_limit: 10,
-            paymaster_and_data: paymaster.to_vec().into(),
-            max_fee_per_gas: 1,
-            ..Default::default()
-        };
+
+        let uo = UserOperationBuilder::new(
+            &ChainSpec::default(),
+            UserOperationRequiredFields {
+                sender,
+                call_gas_limit: 10,
+                pre_verification_gas: 10,
+                verification_gas_limit: 10,
+                paymaster_and_data: paymaster.to_vec().into(),
+                max_fee_per_gas: 1,
+                ..Default::default()
+            },
+        )
+        .build();
 
         let uo_max_cost = uo.clone().max_gas_cost();
 
@@ -763,19 +787,25 @@ mod tests {
         let paymaster_balance_1 = U256::from(200000000);
 
         let sender = Address::random();
-        let uo = UserOperation {
-            sender,
-            call_gas_limit: 10,
-            pre_verification_gas: 10,
-            paymaster_and_data: paymaster_0.to_vec().into(),
-            verification_gas_limit: 10,
-            max_fee_per_gas: 1,
-            ..Default::default()
-        };
 
-        let mut uo_1 = uo.clone();
-        uo_1.max_fee_per_gas = 2;
-        uo_1.paymaster_and_data = paymaster_1.to_vec().into();
+        let uo = UserOperationBuilder::new(
+            &ChainSpec::default(),
+            UserOperationRequiredFields {
+                sender,
+                call_gas_limit: 10,
+                pre_verification_gas: 10,
+                paymaster_and_data: paymaster_0.to_vec().into(),
+                verification_gas_limit: 10,
+                max_fee_per_gas: 1,
+                ..Default::default()
+            },
+        )
+        .build();
+
+        let uo_1 = UserOperationBuilder::from_uo(uo.clone(), &ChainSpec::default())
+            .max_fee_per_gas(2)
+            .paymaster_and_data(paymaster_1.to_vec().into())
+            .build();
 
         let max_op_cost_0 = uo.max_gas_cost();
         let max_op_cost_1 = uo_1.max_gas_cost();
@@ -863,16 +893,20 @@ mod tests {
         paymaster_tracker.add_new_user_op(&existing_id, &meta, U256::from(30));
 
         // replacement_uo
-        let uo = UserOperation {
-            sender,
-            nonce,
-            call_gas_limit: 100,
-            pre_verification_gas: 100,
-            verification_gas_limit: 100,
-            paymaster_and_data: paymaster.to_vec().into(),
-            max_fee_per_gas: 1,
-            ..Default::default()
-        };
+        let uo = UserOperationBuilder::new(
+            &ChainSpec::default(),
+            UserOperationRequiredFields {
+                sender,
+                nonce,
+                call_gas_limit: 100,
+                pre_verification_gas: 100,
+                verification_gas_limit: 100,
+                paymaster_and_data: paymaster.to_vec().into(),
+                max_fee_per_gas: 1,
+                ..Default::default()
+            },
+        )
+        .build();
 
         let max_op_cost = uo.clone().max_gas_cost();
 

--- a/crates/provider/src/alloy/entry_point/mod.rs
+++ b/crates/provider/src/alloy/entry_point/mod.rs
@@ -25,7 +25,7 @@ fn max_bundle_transaction_data(
     to_address: Address,
     data: Bytes,
     gas_price: u128,
-    au: Option<Eip7702Auth>,
+    au: Option<&Eip7702Auth>,
 ) -> Bytes {
     // Fill in max values for unknown or varying fields
     let gas_price_ceil = gas_price.next_power_of_two() - 1; // max out bits of gas price, assume same power of 2

--- a/crates/rpc/src/eth/api.rs
+++ b/crates/rpc/src/eth/api.rs
@@ -192,7 +192,7 @@ mod tests {
     use rundler_sim::MockGasEstimator;
     use rundler_types::{
         pool::{MockPool, PoolOperation},
-        v0_6::UserOperation,
+        v0_6::{UserOperationBuilder, UserOperationRequiredFields},
         EntityInfos, UserOperation as UserOperationTrait, ValidTimeRange,
     };
 
@@ -204,8 +204,12 @@ mod tests {
     #[tokio::test]
     async fn test_get_user_op_by_hash_pending() {
         let ep = Address::random();
-        let uo = UserOperation::default();
-        let hash = uo.hash(ep, 1);
+        let cs = ChainSpec {
+            entry_point_address_v0_6: ep,
+            ..Default::default()
+        };
+        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
+        let hash = uo.hash();
 
         let po = PoolOperation {
             uo: uo.clone().into(),
@@ -253,8 +257,8 @@ mod tests {
             ..Default::default()
         };
         let ep = cs.entry_point_address_v0_6;
-        let uo = UserOperation::default();
-        let hash = uo.hash(ep, 1);
+        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
+        let hash = uo.hash();
         let block_number = 1000;
         let block_hash = B256::random();
 
@@ -327,9 +331,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_user_op_by_hash_not_found() {
-        let ep = Address::random();
-        let uo = UserOperation::default();
-        let hash = uo.hash(ep, 1);
+        let cs = ChainSpec {
+            id: 1,
+            ..Default::default()
+        };
+        let ep = cs.entry_point_address_v0_6;
+        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
+        let hash = uo.hash();
 
         let mut pool = MockPool::default();
         pool.expect_get_op_by_hash()

--- a/crates/rpc/src/eth/events/common.rs
+++ b/crates/rpc/src/eth/events/common.rs
@@ -100,7 +100,7 @@ where
             if ep_address == to || self.chain_spec.known_proxy_addresses().contains(&to) {
                 E::get_user_operations_from_tx_data(input.clone(), &self.chain_spec)
                     .into_iter()
-                    .find(|op| op.hash(ep_address, self.chain_spec.id) == hash)
+                    .find(|op| op.hash() == hash)
                     .context("matching user operation should be found in tx data")?
             } else {
                 tracing::debug!("Unknown entrypoint {to:?}, falling back to trace");
@@ -233,15 +233,15 @@ where
 
         while let Some(call_frame) = frame_queue.pop_front() {
             // check if the call is to an entrypoint, if not enqueue the child calls if any
-            if let Some(to) = call_frame
+            if call_frame
                 .to
-                .filter(|to| *to == E::address(&self.chain_spec))
+                .is_some_and(|to| to == E::address(&self.chain_spec))
             {
                 // check if the user operation is in the call frame
                 if let Some(uo) =
                     E::get_user_operations_from_tx_data(call_frame.input, &self.chain_spec)
                         .into_iter()
-                        .find(|op| op.hash(to, self.chain_spec.id) == user_op_hash)
+                        .find(|op| op.hash() == user_op_hash)
                 {
                     return Ok(Some(uo));
                 }

--- a/crates/rpc/src/eth/events/v0_6.rs
+++ b/crates/rpc/src/eth/events/v0_6.rs
@@ -19,7 +19,7 @@ use rundler_contracts::v0_6::IEntryPoint::{
 use rundler_provider::{Log, TransactionReceipt};
 use rundler_types::{
     chain::ChainSpec,
-    v0_6::{ExtendedUserOperation, UserOperation, UserOperationBuilder},
+    v0_6::{UserOperation, UserOperationBuilder},
 };
 
 use super::common::{EntryPointEvents, UserOperationEventProviderImpl};
@@ -87,16 +87,9 @@ impl EntryPointEvents for EntryPointFiltersV0_6 {
                 .ops
                 .into_iter()
                 .filter_map(|op| {
-                    UserOperationBuilder::from_contract(
-                        chain_spec,
-                        op,
-                        ExtendedUserOperation {
-                            authorization_tuple: None,
-                            aggregator: None,
-                        },
-                    )
-                    .ok()
-                    .map(|b| b.build())
+                    UserOperationBuilder::from_contract(chain_spec, op)
+                        .ok()
+                        .map(|b| b.build())
                 })
                 .collect(),
             IEntryPointCalls::handleAggregatedOps(handle_aggregated_ops_call) => {
@@ -105,16 +98,9 @@ impl EntryPointEvents for EntryPointFiltersV0_6 {
                     .into_iter()
                     .flat_map(|ops| {
                         ops.userOps.into_iter().filter_map(move |op| {
-                            UserOperationBuilder::from_contract(
-                                chain_spec,
-                                op,
-                                ExtendedUserOperation {
-                                    authorization_tuple: None,
-                                    aggregator: Some(ops.aggregator),
-                                },
-                            )
-                            .ok()
-                            .map(|b| b.build())
+                            UserOperationBuilder::from_contract(chain_spec, op)
+                                .ok()
+                                .map(|b| b.aggregator(ops.aggregator).build())
                         })
                     })
                     .collect()

--- a/crates/rpc/src/types/v0_7.rs
+++ b/crates/rpc/src/types/v0_7.rs
@@ -56,6 +56,8 @@ pub(crate) struct RpcUserOperation {
 
 impl From<UserOperation> for RpcUserOperation {
     fn from(op: UserOperation) -> Self {
+        let op = op.into_unstructured();
+
         let factory_data = if op.factory.is_some() {
             Some(op.factory_data)
         } else {

--- a/crates/sim/src/estimation/estimate_call_gas.rs
+++ b/crates/sim/src/estimation/estimate_call_gas.rs
@@ -107,7 +107,7 @@ where
 
         let callless_op = self.specialization.get_op_with_no_call_gas(op.clone());
 
-        if let Some(authorization_tuple) = op.authorization_tuple().clone() {
+        if let Some(authorization_tuple) = op.authorization_tuple() {
             let eip7702_auth_address = authorization_tuple.address;
             authorization_utils::apply_7702_overrides(
                 &mut state_override,

--- a/crates/sim/src/estimation/v0_7.rs
+++ b/crates/sim/src/estimation/v0_7.rs
@@ -136,11 +136,13 @@ where
         let call_gas_limit = call_gas_limit?;
 
         // check the total gas limit
-        let mut op_with_gas = full_op;
-        op_with_gas.pre_verification_gas = pre_verification_gas;
-        op_with_gas.call_gas_limit = call_gas_limit;
-        op_with_gas.verification_gas_limit = verification_gas_limit;
-        op_with_gas.paymaster_verification_gas_limit = paymaster_verification_gas_limit;
+        let op_with_gas = UserOperationBuilder::from_uo(full_op, &self.chain_spec)
+            .pre_verification_gas(pre_verification_gas)
+            .call_gas_limit(call_gas_limit)
+            .verification_gas_limit(verification_gas_limit)
+            .paymaster_verification_gas_limit(paymaster_verification_gas_limit)
+            .build();
+
         // require that this can fit in a bundle of size 1
         let gas_limit = op_with_gas.computation_gas_limit(&self.chain_spec, Some(1));
         if gas_limit > self.settings.max_total_execution_gas {

--- a/crates/sim/src/simulation/v0_6/context.rs
+++ b/crates/sim/src/simulation/v0_6/context.rs
@@ -54,7 +54,7 @@ where
         block_id: BlockId,
     ) -> Result<ValidationContext<Self::UO>, ViolationError<SimulationViolation>> {
         let factory_address = op.factory();
-        let sender_address = op.sender;
+        let sender_address = op.sender();
         let paymaster_address = op.paymaster();
         let tracer_out = self
             .simulate_validation_tracer
@@ -202,9 +202,7 @@ mod tests {
     use rundler_contracts::v0_6::IEntryPoint::FailedOp;
     use rundler_types::{
         chain::ChainSpec,
-        v0_6::{
-            ExtendedUserOperation, UserOperation, UserOperationBuilder, UserOperationRequiredFields,
-        },
+        v0_6::{UserOperation, UserOperationBuilder, UserOperationRequiredFields},
         Opcode,
     };
     use sim_context::ContractInfo;
@@ -327,23 +325,21 @@ mod tests {
             Ok(tracer_output)
         });
 
-        let user_operation = UserOperationBuilder::new(&ChainSpec::default(),UserOperationRequiredFields {
-            sender: address!("b856dbd4fa1a79a46d426f537455e7d3e79ab7c4"),
-            nonce: U256::from(264),
-            init_code: Bytes::default(),
-            call_data: bytes!("b61d27f6000000000000000000000000b856dbd4fa1a79a46d426f537455e7d3e79ab7c4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000004d087d28800000000000000000000000000000000000000000000000000000000"),
-            call_gas_limit: 9100,
-            verification_gas_limit: 64805,
-            pre_verification_gas: 46128,
-            max_fee_per_gas: 105000100,
-            max_priority_fee_per_gas: 105000000,
-            paymaster_and_data: Bytes::default(),
-            signature: bytes!("98f89993ce573172635b44ef3b0741bd0c19dd06909d3539159f6d66bef8c0945550cc858b1cf5921dfce0986605097ba34c2cf3fc279154dd25e161ea7b3d0f1c"),
-        },
-        ExtendedUserOperation {
-            authorization_tuple: None,
-            aggregator: None,
-        },
+        let user_operation = UserOperationBuilder::new(
+            &ChainSpec::default(),
+            UserOperationRequiredFields {
+                sender: address!("b856dbd4fa1a79a46d426f537455e7d3e79ab7c4"),
+                nonce: U256::from(264),
+                init_code: Bytes::default(),
+                call_data: bytes!("b61d27f6000000000000000000000000b856dbd4fa1a79a46d426f537455e7d3e79ab7c4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000004d087d28800000000000000000000000000000000000000000000000000000000"),
+                call_gas_limit: 9100,
+                verification_gas_limit: 64805,
+                pre_verification_gas: 46128,
+                max_fee_per_gas: 105000100,
+                max_priority_fee_per_gas: 105000000,
+                paymaster_and_data: Bytes::default(),
+                signature: bytes!("98f89993ce573172635b44ef3b0741bd0c19dd06909d3539159f6d66bef8c0945550cc858b1cf5921dfce0986605097ba34c2cf3fc279154dd25e161ea7b3d0f1c"),
+            }
         ).build();
 
         let context = ValidationContextProvider {


### PR DESCRIPTION
# Proposed Changes

  - Modify UO interfaces to remove all public members such that modifications must go through the builder.
  - This ensures that modifications update any cached values - hash, packed, calldata cost, etc.
  - Cleanup v0.6 builder pattern
  - Most of the PR changes are to tests, as these we're the biggest offenders of modifying UOs incorrectly.
