### PR TITLE
feat(builder): remove offending UOs after onchain revert

### DIFF
--- a/bin/rundler/src/cli/proxy.rs
+++ b/bin/rundler/src/cli/proxy.rs
@@ -34,8 +34,8 @@ impl SubmissionProxy for PassThroughProxy {
 
     async fn process_revert(
         &self,
-        _revert_data: Bytes,
-        _ops: Vec<UserOpsPerAggregator<UserOperationVariant>>,
+        _revert_data: &Bytes,
+        _ops: &[UserOpsPerAggregator<UserOperationVariant>],
     ) -> Vec<B256> {
         vec![]
     }

--- a/crates/aggregators/pbh/src/proxy.rs
+++ b/crates/aggregators/pbh/src/proxy.rs
@@ -28,8 +28,8 @@ impl SubmissionProxy for PbhSubmissionProxy {
 
     async fn process_revert(
         &self,
-        revert_data: Bytes,
-        _ops: Vec<UserOpsPerAggregator<UserOperationVariant>>,
+        revert_data: &Bytes,
+        _ops: &[UserOpsPerAggregator<UserOperationVariant>],
     ) -> Vec<B256> {
         tracing::info!(
             "PBH submission proxy received revert data, processing unimplemented: {revert_data:?}"

--- a/crates/builder/src/bundle_proposer.rs
+++ b/crates/builder/src/bundle_proposer.rs
@@ -899,8 +899,8 @@ where
                         .to_ops_per_aggregator()
                         .into_iter()
                         .map(|uo| uo.into_uo_variants())
-                        .collect();
-                    let to_remove = proxy.process_revert(revert_data.clone(), ops).await;
+                        .collect::<Vec<_>>();
+                    let to_remove = proxy.process_revert(&revert_data, &ops).await;
                     let mut removed = false;
                     for hash in to_remove {
                         removed |= self.reject_hash(context, hash).await;

--- a/crates/builder/src/task.rs
+++ b/crates/builder/src/task.rs
@@ -448,7 +448,7 @@ where
             sender_eoa,
             submission_proxy.cloned(),
             proposer,
-            ep_providers.entry_point().clone(),
+            ep_providers.clone(),
             transaction_tracker,
             self.pool.clone(),
             sender_settings,

--- a/crates/contracts/src/v0_7.rs
+++ b/crates/contracts/src/v0_7.rs
@@ -126,7 +126,7 @@ sol!(
 
         event BeforeExecution();
 
-    event SignatureAggregatorChanged(address indexed aggregator);
+        event SignatureAggregatorChanged(address indexed aggregator);
 
         error FailedOp(uint256 opIndex, string reason);
 

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -24,8 +24,12 @@
 mod alloy;
 pub use alloy::{
     entry_point::{
-        v0_6::EntryPointProvider as AlloyEntryPointV0_6,
+        v0_6::{
+            decode_ops_from_calldata as decode_v0_6_ops_from_calldata,
+            EntryPointProvider as AlloyEntryPointV0_6,
+        },
         v0_7::{
+            decode_ops_from_calldata as decode_v0_7_ops_from_calldata,
             decode_validation_revert as decode_v0_7_validation_revert,
             EntryPointProvider as AlloyEntryPointV0_7,
         },
@@ -47,6 +51,7 @@ pub use alloy_rpc_types_eth::{
     TransactionRequest,
 };
 pub use alloy_rpc_types_trace::geth::{
+    CallConfig as GethDebugTracerCallConfig, CallFrame as GethDebugTracerCallFrame,
     GethDebugBuiltInTracerType, GethDebugTracerType, GethDebugTracingCallOptions,
     GethDebugTracingOptions, GethTrace,
 };

--- a/crates/provider/src/traits/entry_point.rs
+++ b/crates/provider/src/traits/entry_point.rs
@@ -13,6 +13,7 @@
 
 use alloy_primitives::{Address, Bytes, U256};
 use rundler_types::{
+    chain::ChainSpec,
     da::{DAGasBlockData, DAGasUOData},
     GasFees, Timestamp, UserOperation, UserOpsPerAggregator, ValidationOutput, ValidationRevert,
 };
@@ -155,6 +156,15 @@ pub trait BundleHandler: Send + Sync {
         gas_fees: GasFees,
         proxy: Option<Address>,
     ) -> TransactionRequest;
+
+    /// Decode the revert data from a call to `handleOps`
+    fn decode_handle_ops_revert(message: &str, revert_data: &Bytes) -> HandleOpsOut;
+
+    /// Decode user ops from calldata
+    fn decode_ops_from_calldata(
+        chain_spec: &ChainSpec,
+        calldata: &Bytes,
+    ) -> Vec<UserOpsPerAggregator<Self::UO>>;
 }
 
 /// Trait for calculating Data Availability (DA) gas costs for user operations

--- a/crates/provider/src/traits/test_utils.rs
+++ b/crates/provider/src/traits/test_utils.rs
@@ -22,6 +22,7 @@ use alloy_rpc_types_trace::geth::{
 };
 use rundler_contracts::utils::GetGasUsed::GasUsedResult;
 use rundler_types::{
+    chain::ChainSpec,
     da::{DAGasBlockData, DAGasUOData},
     v0_6, v0_7, GasFees, UserOpsPerAggregator, ValidationOutput, ValidationRevert,
 };
@@ -200,6 +201,11 @@ mockall::mock! {
             gas_fees: GasFees,
             proxy: Option<Address>,
         ) -> TransactionRequest;
+        fn decode_handle_ops_revert(message: &str, revert_data: &Bytes) -> HandleOpsOut;
+        fn decode_ops_from_calldata(
+            chain_spec: &ChainSpec,
+            calldata: &Bytes,
+        ) -> Vec<UserOpsPerAggregator<v0_6::UserOperation>>;
     }
 
     impl EntryPointProvider<v0_6::UserOperation> for EntryPointV0_6 {}
@@ -294,6 +300,11 @@ mockall::mock! {
             gas_fees: GasFees,
             proxy: Option<Address>,
         ) -> TransactionRequest;
+        fn decode_handle_ops_revert(message: &str, revert_data: &Bytes) -> HandleOpsOut;
+        fn decode_ops_from_calldata(
+            chain_spec: &ChainSpec,
+            calldata: &Bytes,
+        ) -> Vec<UserOpsPerAggregator<v0_7::UserOperation>>;
     }
 
     impl EntryPointProvider<v0_7::UserOperation> for EntryPointV0_7 {}

--- a/crates/rpc/src/eth/events/v0_7.rs
+++ b/crates/rpc/src/eth/events/v0_7.rs
@@ -12,15 +12,9 @@
 // If not, see https://www.gnu.org/licenses/.
 
 use alloy_primitives::{ruint::UintTryFrom, Address, Bytes, B256, U128};
-use alloy_sol_types::SolInterface;
-use rundler_contracts::v0_7::IEntryPoint::{
-    IEntryPointCalls, UserOperationEvent, UserOperationRevertReason,
-};
+use rundler_contracts::v0_7::IEntryPoint::{UserOperationEvent, UserOperationRevertReason};
 use rundler_provider::{Log, TransactionReceipt};
-use rundler_types::{
-    chain::ChainSpec,
-    v0_7::{UserOperation, UserOperationBuilder},
-};
+use rundler_types::{chain::ChainSpec, v0_7::UserOperation};
 
 use super::common::{EntryPointEvents, UserOperationEventProviderImpl};
 use crate::types::RpcUserOperationReceipt;
@@ -77,36 +71,12 @@ impl EntryPointEvents for EntryPointFiltersV0_7 {
     }
 
     fn get_user_operations_from_tx_data(tx_data: Bytes, chain_spec: &ChainSpec) -> Vec<Self::UO> {
-        let entry_point_calls = match IEntryPointCalls::abi_decode(&tx_data, false) {
-            Ok(entry_point_calls) => entry_point_calls,
-            Err(_) => return vec![],
-        };
+        let uos_per_agg = rundler_provider::decode_v0_7_ops_from_calldata(chain_spec, &tx_data);
 
-        match entry_point_calls {
-            IEntryPointCalls::handleOps(handle_ops_call) => handle_ops_call
-                .ops
-                .into_iter()
-                .filter_map(|op| {
-                    UserOperationBuilder::from_packed(op, chain_spec)
-                        .ok()
-                        .map(|uo| uo.build())
-                })
-                .collect(),
-            IEntryPointCalls::handleAggregatedOps(handle_aggregated_ops_call) => {
-                handle_aggregated_ops_call
-                    .opsPerAggregator
-                    .into_iter()
-                    .flat_map(|ops| {
-                        ops.userOps.into_iter().filter_map(|op| {
-                            UserOperationBuilder::from_packed(op, chain_spec)
-                                .ok()
-                                .map(|uo| uo.build())
-                        })
-                    })
-                    .collect()
-            }
-            _ => vec![],
-        }
+        uos_per_agg
+            .into_iter()
+            .flat_map(|uos_per_agg| uos_per_agg.user_ops)
+            .collect()
     }
 
     fn address(chain_spec: &ChainSpec) -> Address {

--- a/crates/types/src/proxy.rs
+++ b/crates/types/src/proxy.rs
@@ -29,8 +29,8 @@ pub trait SubmissionProxy: Sync + Send + Debug {
     /// Process a revert from a submission proxy and return the hashes of ops that should be rejected
     async fn process_revert(
         &self,
-        revert_data: Bytes,
-        ops: Vec<UserOpsPerAggregator<UserOperationVariant>>,
+        revert_data: &Bytes,
+        ops: &[UserOpsPerAggregator<UserOperationVariant>],
     ) -> Vec<B256>;
 }
 
@@ -45,8 +45,8 @@ mockall::mock! {
 
         async fn process_revert(
             &self,
-            revert_data: Bytes,
-            ops: Vec<UserOpsPerAggregator<UserOperationVariant>>,
+            revert_data: &Bytes,
+            ops: &[UserOpsPerAggregator<UserOperationVariant>],
         ) -> Vec<B256>;
     }
 }


### PR DESCRIPTION
Closes #990 

## Proposed Changes

  - Get the revert data from reverted transactions using debug_traceTransaction
  - Decode the revert data and the UOs from the transaction
  - Figure out which UO caused the revert and remove, if cannot determine, remove all UOs

TODO:
- [x] Unit tests

