### PR TITLE
chore: update rust 1.85, add unused crate deps lint, update dotenv

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-          toolchain: 1.83.0
+          toolchain: 1.85.0
       - name: Install toolchain (nightly)
         run: rustup toolchain add nightly --component rustfmt --profile minimal
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-          toolchain: 1.83.0
+          toolchain: 1.85.0
 
       - name: Install toolchain (nightly)
         run: rustup toolchain add nightly --component rustfmt --profile minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.7.3",
+ "alloy-serde",
  "alloy-trie",
  "auto_impl",
  "c-kzg",
@@ -83,7 +83,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.7.3",
+ "alloy-serde",
  "serde",
 ]
 
@@ -158,7 +158,7 @@ dependencies = [
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.7.3",
+ "alloy-serde",
  "c-kzg",
  "derive_more 1.0.0",
  "once_cell",
@@ -168,23 +168,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8429cf4554eed9b40feec7f4451113e76596086447550275e3def933faf47ce3"
-dependencies = [
- "alloy-primitives",
- "alloy-serde 0.4.2",
- "serde",
-]
-
-[[package]]
-name = "alloy-genesis"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeec8e6eab6e52b7c9f918748c9b811e87dbef7312a2e3a2ca1729a92966a6af"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.7.3",
+ "alloy-serde",
  "alloy-trie",
  "serde",
 ]
@@ -229,7 +218,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde 0.7.3",
+ "alloy-serde",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -249,25 +238,8 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "alloy-serde 0.7.3",
+ "alloy-serde",
  "serde",
-]
-
-[[package]]
-name = "alloy-node-bindings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1334a738aa1710cb8227441b3fcc319202ce78e967ef37406940242df4a454"
-dependencies = [
- "alloy-genesis 0.4.2",
- "alloy-primitives",
- "k256",
- "rand",
- "serde_json",
- "tempfile",
- "thiserror 1.0.69",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -276,7 +248,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bffcf33dd319f21cd6f066d81cbdef0326d4bdaaf7cfe91110bc090707858e9f"
 dependencies = [
- "alloy-genesis 0.7.3",
+ "alloy-genesis",
  "alloy-primitives",
  "k256",
  "rand",
@@ -328,7 +300,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-node-bindings 0.7.3",
+ "alloy-node-bindings",
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types-anvil",
@@ -412,7 +384,7 @@ checksum = "d33bc190844626c08e21897736dbd7956ab323c09e6f141b118d1c8b7aff689e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 0.7.3",
+ "alloy-serde",
  "serde",
 ]
 
@@ -424,7 +396,7 @@ checksum = "200661999b6e235d9840be5d60a6e8ae2f0af9eb2a256dd378786744660e36ec"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
- "alloy-serde 0.7.3",
+ "alloy-serde",
 ]
 
 [[package]]
@@ -449,7 +421,7 @@ dependencies = [
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.7.3",
+ "alloy-serde",
  "alloy-sol-types",
  "derive_more 1.0.0",
  "itertools 0.13.0",
@@ -465,21 +437,10 @@ checksum = "4e073ab0e67429c60be281e181731132fd07d82e091c10c29ace6935101034bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 0.7.3",
+ "alloy-serde",
  "serde",
  "serde_json",
  "thiserror 2.0.8",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dff0ab1cdd43ca001e324dc27ee0e8606bd2161d6623c63e0e0b8c4dfc13600"
-dependencies = [
- "alloy-primitives",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1087,32 +1048,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
-dependencies = [
- "aws-lc-sys",
- "paste",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8478a5c29ead3f3be14aff8a202ad965cf7da6856860041bfca271becf8ba48b"
-dependencies = [
- "bindgen 0.69.5",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "libc",
- "paste",
-]
-
-[[package]]
 name = "aws-runtime"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,29 +1447,6 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.90",
- "which",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
@@ -1676,12 +1588,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-husky"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
-
-[[package]]
 name = "cc"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,15 +1698,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "cmake"
-version = "0.1.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,12 +1803,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "constcat"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4938185353434999ef52c81753c8cca8955ed38042fc29913db3751916f3b7ab"
 
 [[package]]
 name = "convert_case"
@@ -2189,10 +2080,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast"
@@ -2403,12 +2294,6 @@ name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -2766,15 +2651,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3190,15 +3066,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -3481,12 +3348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3514,7 +3375,7 @@ version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78a09b56be5adbcad5aa1197371688dc6bb249a26da3bca2011ee2fb987ebfb"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen",
  "errno",
  "libc",
 ]
@@ -4763,7 +4624,7 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rundler"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4772,7 +4633,7 @@ dependencies = [
  "aws-sdk-s3",
  "clap",
  "config",
- "dotenv",
+ "dotenvy",
  "go-parse-duration",
  "http 1.2.0",
  "itertools 0.13.0",
@@ -4799,8 +4660,6 @@ dependencies = [
  "strum",
  "tokio",
  "tokio-metrics",
- "tokio-rustls 0.26.1",
- "tokio-util",
  "tracing",
  "tracing-appender",
  "tracing-log",
@@ -4809,15 +4668,15 @@ dependencies = [
 
 [[package]]
 name = "rundler-bindings-fastlz"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen",
  "cc",
 ]
 
 [[package]]
 name = "rundler-bls"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -4827,7 +4686,7 @@ dependencies = [
 
 [[package]]
 name = "rundler-builder"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4841,20 +4700,15 @@ dependencies = [
  "aws-sdk-kms",
  "enum_dispatch",
  "futures",
- "futures-timer",
  "futures-util",
  "jsonrpsee",
  "linked-hash-map",
  "metrics",
  "metrics-derive",
  "mockall",
- "num-traits",
- "parse-display",
- "pin-project",
  "prost",
  "reqwest",
  "rslock",
- "ruint",
  "rundler-provider",
  "rundler-sim",
  "rundler-task",
@@ -4865,7 +4719,6 @@ dependencies = [
  "strum",
  "thiserror 1.0.69",
  "tokio",
- "tokio-util",
  "tonic",
  "tonic-build",
  "tonic-health",
@@ -4875,7 +4728,7 @@ dependencies = [
 
 [[package]]
 name = "rundler-contracts"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -4887,7 +4740,7 @@ dependencies = [
 
 [[package]]
 name = "rundler-pbh"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4899,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "rundler-pool"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4925,30 +4778,24 @@ dependencies = [
  "rundler-task",
  "rundler-types",
  "rundler-utils",
- "serde",
  "serde_json",
- "strum",
- "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tonic",
  "tonic-build",
  "tonic-health",
  "tonic-reflection",
  "tracing",
- "url",
 ]
 
 [[package]]
 name = "rundler-provider"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-eips",
  "alloy-json-rpc",
- "alloy-node-bindings 0.4.2",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rlp",
@@ -4971,7 +4818,6 @@ dependencies = [
  "reth-tasks",
  "rundler-bindings-fastlz",
  "rundler-contracts",
- "rundler-provider",
  "rundler-types",
  "rundler-utils",
  "thiserror 1.0.69",
@@ -4984,12 +4830,11 @@ dependencies = [
 
 [[package]]
 name = "rundler-rpc"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-json-rpc",
- "alloy-network",
  "alloy-primitives",
  "alloy-sol-types",
  "anyhow",
@@ -5011,19 +4856,16 @@ dependencies = [
  "strum",
  "thiserror 1.0.69",
  "tokio",
- "tokio-util",
  "tonic",
  "tower 0.4.13",
  "tower-http",
  "tracing",
- "url",
 ]
 
 [[package]]
 name = "rundler-sim"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
- "alloy-eips",
  "alloy-primitives",
  "alloy-sol-types",
  "anyhow",
@@ -5031,35 +4873,27 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures-util",
- "indexmap 2.7.0",
  "mockall",
- "parse-display",
  "rand",
- "reqwest",
  "rundler-contracts",
  "rundler-provider",
- "rundler-sim",
  "rundler-types",
  "rundler-utils",
  "serde",
  "serde_json",
  "serde_with",
- "strum",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "url",
 ]
 
 [[package]]
 name = "rundler-task"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
  "async-trait",
- "futures",
- "metrics",
  "pin-project",
  "reth-tasks",
  "rundler-provider",
@@ -5067,7 +4901,6 @@ dependencies = [
  "rundler-utils",
  "thiserror 1.0.69",
  "tokio",
- "tokio-util",
  "tonic",
  "tower 0.4.13",
  "tracing",
@@ -5075,7 +4908,7 @@ dependencies = [
 
 [[package]]
 name = "rundler-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5083,19 +4916,14 @@ dependencies = [
  "anyhow",
  "async-trait",
  "auto_impl",
- "cargo-husky",
  "chrono",
- "const-hex",
- "constcat",
  "futures-util",
  "metrics",
  "metrics-derive",
  "mockall",
  "num_enum",
  "parse-display",
- "rand",
  "rundler-contracts",
- "rundler-types",
  "rundler-utils",
  "serde",
  "serde_json",
@@ -5105,20 +4933,18 @@ dependencies = [
 
 [[package]]
 name = "rundler-utils"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "anyhow",
  "derive_more 0.99.18",
- "futures",
  "itertools 0.13.0",
  "metrics",
  "rand",
  "schnellru",
  "tokio",
  "tracing",
- "url",
 ]
 
 [[package]]
@@ -5207,7 +5033,6 @@ version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5312,7 +5137,6 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6633,18 +6457,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ default-members = ["bin/rundler"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.85"
 license = "LGPL-3.0-only"
 repository = "https://github.com/alchemyplatform/rundler"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Adapted from https://github.com/paradigmxyz/reth/blob/main/Dockerfile
 # syntax=docker/dockerfile:1.4
 
-FROM rust:1.83.0 AS chef-builder
+FROM rust:1.85.0 AS chef-builder
 
 # Install system dependencies
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list

--- a/bin/rundler/Cargo.toml
+++ b/bin/rundler/Cargo.toml
@@ -30,7 +30,7 @@ aws-config.workspace = true
 aws-sdk-s3 = { version = "1.52", default-features = false }
 clap = { version = "4.5.16", features = ["derive", "env"] }
 config = "0.14.0"
-dotenv = "0.15.0"
+dotenvy = "0.15.7"
 go-parse-duration = "0.1"
 http.workspace = true
 itertools.workspace = true
@@ -47,8 +47,6 @@ sscanf = "0.4.2"
 strum = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync"] }
 tokio-metrics = "0.4.0"
-tokio-rustls = "0.26.0"
-tokio-util.workspace = true
 tracing.workspace = true
 tracing-appender = "0.2.3"
 tracing-log = "0.2.0"

--- a/bin/rundler/src/main.rs
+++ b/bin/rundler/src/main.rs
@@ -11,7 +11,15 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use dotenv::dotenv;
+#![warn(missing_docs, unused_crate_dependencies)]
+#![deny(unused_must_use, rust_2018_idioms)]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
+//! Main CLI entry point for Rundler
+
+use dotenvy::dotenv;
 mod cli;
 
 #[tokio::main]

--- a/crates/aggregators/bls/src/lib.rs
+++ b/crates/aggregators/bls/src/lib.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-#![warn(missing_docs, unreachable_pub)]
+#![warn(missing_docs, unreachable_pub, unused_crate_dependencies)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![doc(test(
     no_crate_inject,

--- a/crates/aggregators/pbh/src/lib.rs
+++ b/crates/aggregators/pbh/src/lib.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-#![warn(missing_docs, unreachable_pub)]
+#![warn(missing_docs, unreachable_pub, unused_crate_dependencies)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![doc(test(
     no_crate_inject,

--- a/crates/bindings/fastlz/src/lib.rs
+++ b/crates/bindings/fastlz/src/lib.rs
@@ -15,6 +15,13 @@
 
 // Credit to https://github.com/mvertescher/fastlz-rs/blob/master/src/lib.rs
 
+#![warn(unused_crate_dependencies)]
+#![deny(unused_must_use, rust_2018_idioms)]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
+
 use core::ffi::c_void;
 
 // This is a generated binding of the fastlz C library at commit

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -27,31 +27,23 @@ aws-config.workspace = true
 aws-sdk-kms = { version = "1.44", default-features = false }
 enum_dispatch = "0.3.13"
 futures.workspace = true
-futures-timer = "3.0.3"
 futures-util.workspace = true
 jsonrpsee = { workspace = true, features = [ "http-client" ] }
 linked-hash-map = "0.5.6"
 metrics.workspace = true
 metrics-derive.workspace = true
-num-traits = "0.2.19"
-parse-display.workspace = true
-pin-project.workspace = true
 prost.workspace = true
 reqwest = { workspace = true, default-features = false, features = ["json"] }
 rslock = "0.4.0"
-ruint = { version = "1.12.3", features = ["num-traits"] }
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-tokio-util.workspace = true
 tonic.workspace = true
 tonic-health.workspace = true
 tonic-reflection.workspace = true
 tracing.workspace = true
-
-mockall = { workspace = true, optional = true }
 
 [dev-dependencies]
 mockall.workspace = true

--- a/crates/builder/src/bundle_proposer.rs
+++ b/crates/builder/src/bundle_proposer.rs
@@ -1013,7 +1013,7 @@ where
                         .simulation
                         .entity_infos
                         .factory
-                        .map_or(false, |f| f.is_staked),
+                        .is_some_and(|f| f.is_staked),
                 )
                 .await;
             }
@@ -1032,7 +1032,7 @@ where
                         .simulation
                         .entity_infos
                         .paymaster
-                        .map_or(false, |p| p.is_staked),
+                        .is_some_and(|p| p.is_staked),
                 )
                 .await;
             }
@@ -1593,7 +1593,7 @@ impl<UO: UserOperation> ProposalContext<UO> {
 
         // In accordance with [EREP-015]/[EREP-020]/[EREP-030], responsibility for failures lies with the staked factory or account.
         // Paymasters should not be held accountable, so the paymaster's `opsSeen` count should be decremented accordingly.
-        let is_staked_factory = entity_infos.factory.map_or(false, |f| f.is_staked);
+        let is_staked_factory = entity_infos.factory.is_some_and(|f| f.is_staked);
         let is_staked_sender = entity_infos.sender.is_staked;
         if is_staked_factory || is_staked_sender {
             if let Some(paymaster) = entity_infos.paymaster {

--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-#![warn(missing_docs, unreachable_pub)]
+#![warn(missing_docs, unreachable_pub, unused_crate_dependencies)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![doc(test(
     no_crate_inject,

--- a/crates/contracts/src/v0_6.rs
+++ b/crates/contracts/src/v0_6.rs
@@ -161,10 +161,10 @@ sol!(
 );
 
 // https://etherscan.io/address/0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789#code
-const __ENTRY_POINT_V0_6_DEPLOYED_BYTECODE_HEX: &[u8] = include_bytes!(
+static __ENTRY_POINT_V0_6_DEPLOYED_BYTECODE_HEX: &[u8] = include_bytes!(
     "../contracts/bytecode/entrypoint/0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789_deployed.txt"
 );
-const __ENTRY_POINT_V0_6_DEPLOYED_BYTECODE: [u8; 23689] = {
+static __ENTRY_POINT_V0_6_DEPLOYED_BYTECODE: [u8; 23689] = {
     match const_hex::const_decode_to_array(__ENTRY_POINT_V0_6_DEPLOYED_BYTECODE_HEX) {
         Ok(a) => a,
         Err(_) => panic!("Failed to decode entrypoint hex"),

--- a/crates/contracts/src/v0_7.rs
+++ b/crates/contracts/src/v0_7.rs
@@ -244,11 +244,11 @@ sol!(
 );
 
 // EntryPointSimulations deployed bytecode
-const __ENTRY_POINT_SIMULATIONS_V0_7_DEPLOYED_BYTECODE_HEX: &[u8] = include_bytes!(
+static __ENTRY_POINT_SIMULATIONS_V0_7_DEPLOYED_BYTECODE_HEX: &[u8] = include_bytes!(
     "../contracts/out/v0_7/EntryPointSimulations.sol/EntryPointSimulations_deployedBytecode.txt"
 );
 
-const __ENTRY_POINT_SIMULATIONS_V0_7_DEPLOYED_BYTECODE: [u8; 16893] = {
+static __ENTRY_POINT_SIMULATIONS_V0_7_DEPLOYED_BYTECODE: [u8; 16893] = {
     match const_hex::const_decode_to_array(__ENTRY_POINT_SIMULATIONS_V0_7_DEPLOYED_BYTECODE_HEX) {
         Ok(a) => a,
         Err(_) => panic!("Failed to decode entry point simulations hex"),
@@ -259,11 +259,11 @@ pub static ENTRY_POINT_SIMULATIONS_V0_7_DEPLOYED_BYTECODE: Bytes =
     Bytes::from_static(&__ENTRY_POINT_SIMULATIONS_V0_7_DEPLOYED_BYTECODE);
 
 // CallGasEstimationProxy deployed bytecode
-const __CALL_GAS_ESTIMATION_PROXY_V0_7_DEPLOYED_BYTECODE_HEX: &[u8] = include_bytes!(
+static __CALL_GAS_ESTIMATION_PROXY_V0_7_DEPLOYED_BYTECODE_HEX: &[u8] = include_bytes!(
     "../contracts/out/v0_7/CallGasEstimationProxy.sol/CallGasEstimationProxy_deployedBytecode.txt"
 );
 
-const __CALL_GAS_ESTIMATION_PROXY_V0_7_DEPLOYED_BYTECODE: [u8; 3558] = {
+static __CALL_GAS_ESTIMATION_PROXY_V0_7_DEPLOYED_BYTECODE: [u8; 3558] = {
     match const_hex::const_decode_to_array(__CALL_GAS_ESTIMATION_PROXY_V0_7_DEPLOYED_BYTECODE_HEX) {
         Ok(a) => a,
         Err(_) => panic!("Failed to decode call gas estimation proxy hex"),

--- a/crates/pool/Cargo.toml
+++ b/crates/pool/Cargo.toml
@@ -8,7 +8,6 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-alloy-consensus.workspace = true
 rundler-contracts.workspace = true
 rundler-provider.workspace = true
 rundler-sim.workspace = true
@@ -29,21 +28,15 @@ metrics.workspace = true
 metrics-derive.workspace = true
 parking_lot = "0.12.3"
 prost.workspace = true
-serde.workspace = true
-strum.workspace = true
-thiserror.workspace = true
 tokio.workspace = true
 tokio-stream = { version = "0.1.12", features = ["sync"] }
-tokio-util.workspace = true
 tonic.workspace = true
 tonic-health.workspace = true
 tonic-reflection.workspace = true
 tracing.workspace = true
-url.workspace = true
-
-mockall = { workspace = true, optional = true }
 
 [dev-dependencies]
+alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true

--- a/crates/pool/src/lib.rs
+++ b/crates/pool/src/lib.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-#![warn(missing_docs, unreachable_pub)]
+#![warn(missing_docs, unreachable_pub, unused_crate_dependencies)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![doc(test(
     no_crate_inject,

--- a/crates/pool/src/mempool/uo_pool.rs
+++ b/crates/pool/src/mempool/uo_pool.rs
@@ -844,7 +844,6 @@ where
                         || (sender_num % U256::from(num_shards) == U256::from(shard_index)))
             })
             .take(max)
-            .map(Into::into)
             .collect())
     }
 

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -49,9 +49,7 @@ mockall = { workspace = true, optional = true }
 test-utils = ["mockall"]
 
 [dev-dependencies]
-alloy-node-bindings = "0.4.2"
 alloy-provider = { workspace = true, features = ["debug-api", "anvil-node"] }
 alloy-sol-macro.workspace = true
-rundler-provider = { workspace = true, features = ["test-utils"] }
 tiny_http.workspace = true
 tokio.workspace = true

--- a/crates/provider/src/alloy/provider_timeout.rs
+++ b/crates/provider/src/alloy/provider_timeout.rs
@@ -84,10 +84,7 @@ where
     type Future = ResponseFuture<S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        match self.service.poll_ready(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(r) => Poll::Ready(r.map_err(Into::into)),
-        }
+        self.service.poll_ready(cx)
     }
 
     fn call(&mut self, request: RequestPacket) -> Self::Future {
@@ -123,7 +120,7 @@ where
 
         // First, try polling the future
         match this.response.poll(cx) {
-            Poll::Ready(v) => return Poll::Ready(v.map_err(Into::into)),
+            Poll::Ready(v) => return Poll::Ready(v),
             Poll::Pending => {}
         }
         // Now check the sleep

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-#![warn(missing_docs, unreachable_pub)]
+#![warn(missing_docs, unreachable_pub, unused_crate_dependencies)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![doc(test(
     no_crate_inject,

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -32,18 +32,15 @@ metrics-derive.workspace = true
 serde.workspace = true
 strum.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
-tokio-util.workspace = true
 tonic.workspace = true
 tower.workspace = true
 tower-http = { workspace = true, features = ["cors"] }
 tracing.workspace = true
-url.workspace = true
 
 [dev-dependencies]
 alloy-consensus.workspace = true
-alloy-network.workspace = true
 mockall.workspace = true
 rundler-provider = { workspace = true, features = ["test-utils"] }
 rundler-sim = { workspace = true, features = ["test-utils"] }
 rundler-types = { workspace = true, features = ["test-utils"] }
+tokio.workspace = true

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-#![warn(missing_docs, unreachable_pub)]
+#![warn(missing_docs, unreachable_pub, unused_crate_dependencies)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![doc(test(
     no_crate_inject,

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -13,7 +13,6 @@ rundler-provider.workspace = true
 rundler-types.workspace = true
 rundler-utils.workspace = true
 
-alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 
@@ -22,18 +21,12 @@ arrayvec = "0.7.6"
 async-trait.workspace = true
 auto_impl.workspace = true
 futures-util.workspace = true
-indexmap = "2.4.0"
-parse-display.workspace = true
 rand.workspace = true
-reqwest.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 serde_with = "3.9.0"
-strum.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true
-url.workspace = true
 
 mockall = { workspace = true, optional = true }
 
@@ -41,8 +34,8 @@ mockall = { workspace = true, optional = true }
 alloy-primitives = { workspace = true, features = ["rand"] }
 mockall.workspace = true
 rundler-provider = { workspace = true, features = ["test-utils"] }
-rundler-sim = { workspace = true, features = ["test-utils"] }
 rundler-types = { workspace = true, features = ["test-utils"] }
+serde_json.workspace = true
 
 [features]
 test-utils = ["mockall"]

--- a/crates/sim/src/lib.rs
+++ b/crates/sim/src/lib.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-#![warn(missing_docs, unreachable_pub)]
+#![warn(missing_docs, unreachable_pub, unused_crate_dependencies)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![doc(test(
     no_crate_inject,

--- a/crates/task/Cargo.toml
+++ b/crates/task/Cargo.toml
@@ -16,13 +16,10 @@ alloy-primitives.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true
-futures.workspace = true
-metrics.workspace = true
 pin-project.workspace = true
 reth-tasks.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-tokio-util.workspace = true
 tonic.workspace = true
 tower.workspace = true
 tracing.workspace = true

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-#![warn(missing_docs, unreachable_pub)]
+#![warn(missing_docs, unreachable_pub, unused_crate_dependencies)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![doc(test(
     no_crate_inject,

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -19,16 +19,12 @@ anyhow.workspace = true
 async-trait.workspace = true
 auto_impl.workspace = true
 chrono = "0.4.38"
-const-hex.workspace = true
-constcat = "0.5.0"
 futures-util.workspace = true
 metrics.workspace = true
 metrics-derive.workspace = true
 num_enum = "0.7.3"
 parse-display.workspace = true
-rand.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 
@@ -36,8 +32,7 @@ mockall = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["rand"] }
-cargo-husky.workspace = true
-rundler-types = { workspace = true, features = ["test-utils"] }
+serde_json.workspace = true
 
 [features]
 test-utils = ["mockall"]

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-#![warn(missing_docs, unreachable_pub)]
+#![warn(missing_docs, unreachable_pub, unused_crate_dependencies)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![doc(test(
     no_crate_inject,

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -13,11 +13,9 @@ alloy-rpc-types-eth.workspace = true
 
 anyhow.workspace = true
 derive_more = "0.99.18"
-futures.workspace = true
 itertools.workspace = true
 metrics.workspace = true
 rand.workspace = true
 schnellru = "0.2.1"
 tokio.workspace = true
 tracing.workspace = true
-url.workspace = true

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-#![warn(missing_docs, unreachable_pub)]
+#![warn(missing_docs, unreachable_pub, unused_crate_dependencies)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![doc(test(
     no_crate_inject,

--- a/deny.toml
+++ b/deny.toml
@@ -14,7 +14,7 @@ deny = [
 [bans.workspace-dependencies]
 duplicates = 'deny'
 include-path-dependencies = true
-unused = 'deny'
+unused = 'allow'
 
 [licenses]
 version = 2
@@ -30,16 +30,13 @@ allow = [
     "ISC",
     "MPL-2.0",
     "Unicode-3.0",
-    "Unicode-DFS-2016",
     "Unlicense",
     "Zlib",
 ]
 
 exceptions = [
     { allow = ["CC0-1.0"], name = "tiny-keccak" },
-    { allow = ["Unicode-DFS-2016"], name = "unicode-ident" },
     { allow = ["OpenSSL"], name = "ring" },
-    { allow = ["OpenSSL"], name = "aws-lc-sys" }
 ]
 
 [[licenses.clarify]]

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -12,7 +12,7 @@ git submodule update --init --recursive
 
 2. Install prerequisites
 
-* [Rust/Cargo](https://www.rust-lang.org/tools/install): 1.83 or higher with nightly 
+* [Rust/Cargo](https://www.rust-lang.org/tools/install): 1.85 or higher with nightly 
 * [Cocogitto](https://github.com/cocogitto/cocogitto): Commit linting
 * [Docker](https://docs.docker.com/engine/install/): Run spec tests
 * [PDM](https://pdm.fming.dev/latest/#installation): Run spec tests

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.83"
+channel = "1.85"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
## Proposed Changes

  - Update rust to 1.85 and fix new lints
  - Add `unused_crate_dependencies` and remove all unused deps
  - Update dotenv to dotenvy due to this [security recommendation](https://rustsec.org/advisories/RUSTSEC-2021-0141.html)
  - Update version to v0.6.0
