### PR TITLE
feat: add uo perms and trusted uo submission

### DIFF
--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -42,7 +42,6 @@ use rundler_provider::{
     AlloyEntryPointV0_6, AlloyEntryPointV0_7, AlloyEvmProvider, DAGasOracleSync,
     EntryPointProvider, EvmProvider, Providers,
 };
-use rundler_rpc::{EthApiSettings, RundlerApiSettings};
 use rundler_sim::{
     EstimationSettings, MempoolConfigs, PrecheckSettings, PriorityFeeMode, SimulationSettings,
     MIN_CALL_GAS_LIMIT,
@@ -531,26 +530,6 @@ impl TryFrom<&CommonArgs> for SimulationSettings {
             U256::from(value.min_stake_value),
             value.tracer_timeout.clone(),
         ))
-    }
-}
-
-impl From<&CommonArgs> for EthApiSettings {
-    fn from(value: &CommonArgs) -> Self {
-        Self::new(value.user_operation_event_block_distance)
-    }
-}
-
-impl TryFrom<&CommonArgs> for RundlerApiSettings {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &CommonArgs) -> Result<Self, Self::Error> {
-        Ok(Self {
-            priority_fee_mode: PriorityFeeMode::try_from(
-                value.priority_fee_mode_kind.as_str(),
-                value.priority_fee_mode_value,
-            )?,
-            bundle_priority_fee_overhead_percent: value.bundle_priority_fee_overhead_percent,
-        })
     }
 }
 

--- a/bin/rundler/src/cli/node/mod.rs
+++ b/bin/rundler/src/cli/node/mod.rs
@@ -81,14 +81,7 @@ pub async fn spawn_tasks<T: TaskSpawnerExt + 'static>(
             entry_point_builders,
         )
         .await?;
-    let rpc_task_args = rpc_args.to_args(
-        chain_spec.clone(),
-        &common_args,
-        (&common_args).try_into()?,
-        (&common_args).into(),
-        (&common_args).try_into()?,
-        (&common_args).try_into()?,
-    )?;
+    let rpc_task_args = rpc_args.to_args(chain_spec.clone(), &common_args)?;
 
     let (event_sender, event_rx) =
         broadcast::channel::<WithEntryPoint<Event>>(EVENT_CHANNEL_CAPACITY);

--- a/crates/builder/src/bundle_proposer.rs
+++ b/crates/builder/src/bundle_proposer.rs
@@ -499,6 +499,7 @@ where
             .simulator()
             .simulate_validation(
                 op.uo.clone().into(),
+                op.perms.trusted,
                 block_hash,
                 Some(op.expected_code_hash),
             )
@@ -1805,7 +1806,7 @@ mod tests {
         pool::{MockPool, SimulationViolation},
         proxy::MockSubmissionProxy,
         v0_6::{UserOperation, UserOperationBuilder, UserOperationRequiredFields},
-        UserOperation as _, ValidTimeRange,
+        UserOperation as _, UserOperationPermissions, ValidTimeRange,
     };
 
     use super::*;
@@ -1822,6 +1823,7 @@ mod tests {
         let bundle = simple_make_bundle(vec![MockOp {
             op: op.clone(),
             simulation_result: Box::new(|| Ok(SimulationResult::default())),
+            trusted: false,
         }])
         .await;
 
@@ -1856,6 +1858,7 @@ mod tests {
                     entity_infos: None,
                 })
             }),
+            trusted: false,
         }])
         .await;
         assert!(bundle.ops_per_aggregator.is_empty());
@@ -1873,6 +1876,7 @@ mod tests {
                     entity_infos: None,
                 })
             }),
+            trusted: false,
         }])
         .await;
         assert!(bundle.ops_per_aggregator.is_empty());
@@ -1892,6 +1896,7 @@ mod tests {
                     entity_infos: None,
                 })
             }),
+            trusted: false,
         }])
         .await;
         assert!(bundle.ops_per_aggregator.is_empty());
@@ -1914,6 +1919,7 @@ mod tests {
                         ..Default::default()
                     })
                 }),
+                trusted: false,
             }])
             .await;
             assert!(bundle.ops_per_aggregator.is_empty());
@@ -1934,6 +1940,7 @@ mod tests {
                         ..Default::default()
                     })
                 }),
+                trusted: false,
             },
             MockOp {
                 op: op2.clone(),
@@ -1943,6 +1950,7 @@ mod tests {
                         ..Default::default()
                     })
                 }),
+                trusted: false,
             },
         ])
         .await;
@@ -1969,10 +1977,12 @@ mod tests {
                 MockOp {
                     op: op1.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: op2.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
             ],
             vec![],
@@ -2008,10 +2018,12 @@ mod tests {
                 MockOp {
                     op: op1.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: op2.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
             ],
             vec![],
@@ -2057,10 +2069,12 @@ mod tests {
                 MockOp {
                     op: op1.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: op2.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
             ],
             vec![],
@@ -2116,18 +2130,22 @@ mod tests {
                 MockOp {
                     op: unaggregated_op.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: aggregated_op_a1.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: aggregated_op_a2.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: aggregated_op_b.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
             ],
             vec![
@@ -2213,18 +2231,22 @@ mod tests {
                 MockOp {
                     op: unaggregated_op.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: aggregated_op_a1.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: aggregated_op_a2.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: aggregated_op_b.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
             ],
             vec![
@@ -2286,26 +2308,32 @@ mod tests {
                 MockOp {
                     op: op1.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: op2.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: op3.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: op4.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: op5.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: op6.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
             ],
             vec![],
@@ -2377,6 +2405,7 @@ mod tests {
                         entity_infos: Some(entity_infos),
                     })
                 }),
+                trusted: false,
             }],
             vec![],
             vec![],
@@ -2438,6 +2467,7 @@ mod tests {
                         entity_infos: Some(entity_infos),
                     })
                 }),
+                trusted: false,
             }],
             vec![],
             vec![],
@@ -2519,6 +2549,7 @@ mod tests {
                             entity_infos: Some(entity_infos_1),
                         })
                     }),
+                    trusted: false,
                 },
                 MockOp {
                     op: op_2.clone(),
@@ -2537,6 +2568,7 @@ mod tests {
                             entity_infos: Some(entity_infos_2),
                         })
                     }),
+                    trusted: false,
                 },
             ],
             vec![],
@@ -2578,18 +2610,22 @@ mod tests {
                 MockOp {
                     op: op1.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: op2.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: op3.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: op4.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
             ],
             vec![],
@@ -2719,6 +2755,7 @@ mod tests {
             vec![MockOp {
                 op: op1.clone(),
                 simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                trusted: false,
             }],
             vec![],
             vec![HandleOpsOut::PostOpRevert, HandleOpsOut::PostOpRevert],
@@ -2746,10 +2783,12 @@ mod tests {
                 MockOp {
                     op: op1.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: op2.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
             ],
             vec![],
@@ -2798,14 +2837,17 @@ mod tests {
                 MockOp {
                     op: unaggregated_op.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: aggregated_op_a1.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
                 MockOp {
                     op: aggregated_op_a2.clone(),
                     simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
                 },
             ],
             vec![MockAggregator {
@@ -2859,6 +2901,7 @@ mod tests {
                         ..Default::default()
                     })
                 }),
+                trusted: false,
             }],
             vec![],
             vec![HandleOpsOut::Success],
@@ -2900,6 +2943,7 @@ mod tests {
                         ..Default::default()
                     })
                 }),
+                trusted: false,
             }],
             vec![],
             vec![HandleOpsOut::Success],
@@ -2935,6 +2979,7 @@ mod tests {
                         ..Default::default()
                     })
                 }),
+                trusted: false,
             }],
             vec![],
             vec![HandleOpsOut::Success],
@@ -2973,6 +3018,7 @@ mod tests {
                             ..Default::default()
                         })
                     }),
+                    trusted: false,
                 },
                 MockOp {
                     op: op1.clone(),
@@ -2982,6 +3028,7 @@ mod tests {
                             ..Default::default()
                         })
                     }),
+                    trusted: false,
                 },
             ],
             vec![],
@@ -3019,6 +3066,7 @@ mod tests {
             vec![MockOp {
                 op: op.clone(),
                 simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                trusted: false,
             }],
             vec![],
             vec![HandleOpsOut::Success],
@@ -3061,6 +3109,7 @@ mod tests {
             vec![MockOp {
                 op: op.clone(),
                 simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                trusted: false,
             }],
             vec![],
             vec![HandleOpsOut::Revert(bytes)],
@@ -3102,6 +3151,7 @@ mod tests {
                             ..Default::default()
                         })
                     }),
+                    trusted: false,
                 },
                 MockOp {
                     op: op1.clone(),
@@ -3111,6 +3161,7 @@ mod tests {
                             ..Default::default()
                         })
                     }),
+                    trusted: false,
                 },
             ],
             vec![],
@@ -3140,9 +3191,80 @@ mod tests {
         assert_eq!(bundle.expected_storage.0, expected_storage1_clone.0);
     }
 
+    #[tokio::test]
+    async fn test_trusted_op() {
+        let op = default_op();
+        let bundle = mock_make_bundle(
+            vec![MockOp {
+                op: op.clone(),
+                simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                trusted: true,
+            }],
+            vec![],
+            vec![HandleOpsOut::Success],
+            vec![],
+            0,
+            0,
+            false,
+            ExpectedStorage::default(),
+            false,
+            vec![],
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            bundle.ops_per_aggregator,
+            vec![UserOpsPerAggregator {
+                user_ops: vec![op],
+                ..Default::default()
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_trusted_untrusted_ops() {
+        let op0 = op_with_sender(address(1));
+        let op1 = op_with_sender(address(2));
+        let bundle = mock_make_bundle(
+            vec![
+                MockOp {
+                    op: op0.clone(),
+                    simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: true,
+                },
+                MockOp {
+                    op: op1.clone(),
+                    simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    trusted: false,
+                },
+            ],
+            vec![],
+            vec![HandleOpsOut::Success],
+            vec![],
+            0,
+            0,
+            false,
+            ExpectedStorage::default(),
+            false,
+            vec![],
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            bundle.ops_per_aggregator,
+            vec![UserOpsPerAggregator {
+                user_ops: vec![op0, op1],
+                ..Default::default()
+            }]
+        );
+    }
+
     struct MockOp {
         op: UserOperation,
         simulation_result: Box<dyn Fn() -> Result<SimulationResult, SimulationError> + Send + Sync>,
+        trusted: bool,
     }
 
     struct MockAggregator {
@@ -3194,7 +3316,7 @@ mod tests {
         let proxy_address = proxy.as_ref().map(|p| p.address());
         let ops: Vec<_> = mock_ops
             .iter()
-            .map(|MockOp { op, .. }| PoolOperation {
+            .map(|MockOp { op, trusted, .. }| PoolOperation {
                 uo: op.clone().into(),
                 expected_code_hash,
                 entry_point: chain_spec.entry_point_address_v0_6,
@@ -3206,6 +3328,7 @@ mod tests {
                 aggregator: None,
                 da_gas_data: Default::default(),
                 filter_id: None,
+                perms: UserOperationPermissions { trusted: *trusted },
             })
             .collect();
 
@@ -3214,17 +3337,25 @@ mod tests {
             .expect_get_ops()
             .returning(move |_, _, _, _| Ok(ops.clone()));
 
-        let simulations_by_op: HashMap<_, _> = mock_ops
-            .into_iter()
-            .map(|op| (op.op.hash(), op.simulation_result))
-            .collect();
+        let simulations_by_op: Arc<HashMap<B256, MockOp>> = Arc::from(
+            mock_ops
+                .into_iter()
+                .map(|op| (op.op.hash(), op))
+                .collect::<HashMap<_, _>>(),
+        );
+        let simulations_by_op_cloned: Arc<HashMap<_, _>> = Arc::clone(&simulations_by_op);
+
         let mut simulator = MockSimulator::new();
         simulator
             .expect_simulate_validation()
-            .withf(move |_, &block_hash, &code_hash| {
-                block_hash == current_block_hash && code_hash == Some(expected_code_hash)
+            .withf(move |op, &trusted, &block_hash, &code_hash| {
+                block_hash == current_block_hash
+                    && code_hash == Some(expected_code_hash)
+                    && simulations_by_op_cloned[&op.hash()].trusted == trusted
             })
-            .returning(move |op, _, _| simulations_by_op[&op.hash()]());
+            .returning(move |op, _, _, _| {
+                simulations_by_op[&op.hash()].simulation_result.as_ref()()
+            });
         let mut entry_point = MockEntryPointV0_6::new();
         entry_point
             .expect_address()

--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -24,6 +24,10 @@ message UserOperation {
   }
 }
 
+message UserOperationPermissions {
+  bool trusted = 1;
+}
+
 // Protocol Buffer representation of an 7702 authorization tuple. See the official 
 // specification at https://eips.ethereum.org/EIPS/eip-7702
 message AuthorizationTuple {
@@ -180,6 +184,8 @@ message MempoolOp {
   DaGasUoData da_gas_data = 9;
   // The filter ID to apply to the UserOperation
   string filter_id = 10;
+  // The permissions for the UserOperation
+  UserOperationPermissions permissions = 11;
 }
 
 // Data associated with a user operation for DA gas calculations
@@ -269,10 +275,10 @@ message GetSupportedEntryPointsResponse {
 }
 
 message AddOpRequest {
-  // The serialized entry point address via which the UserOperation is being submitted
-  bytes entry_point = 1;
   // The UserOperation to add to the mempool
-  UserOperation op = 2;
+  UserOperation op = 1;
+  // The permissions to use for the UserOperation
+  UserOperationPermissions permissions = 2;
 }
 message AddOpResponse {
   oneof result {

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -38,7 +38,8 @@ use rundler_types::{
     pool::{
         MempoolError, PaymasterMetadata, PoolOperation, Reputation, ReputationStatus, StakeStatus,
     },
-    EntityUpdate, EntryPointVersion, UserOperationId, UserOperationVariant,
+    EntityUpdate, EntryPointVersion, UserOperationId, UserOperationPermissions,
+    UserOperationVariant,
 };
 use tonic::async_trait;
 pub(crate) use uo_pool::{UoPool, UoPoolProviders};
@@ -65,6 +66,7 @@ pub trait Mempool: Send + Sync {
         &self,
         origin: OperationOrigin,
         op: UserOperationVariant,
+        perms: UserOperationPermissions,
     ) -> MempoolResult<B256>;
 
     /// Removes a set of operations from the pool.
@@ -251,6 +253,7 @@ mod tests {
             },
             da_gas_data: Default::default(),
             filter_id: None,
+            perms: UserOperationPermissions::default(),
         };
 
         let entities = po.entities().collect::<Vec<_>>();

--- a/crates/pool/src/mempool/paymaster.rs
+++ b/crates/pool/src/mempool/paymaster.rs
@@ -520,7 +520,8 @@ mod tests {
         chain::ChainSpec,
         pool::{PaymasterMetadata, PoolOperation},
         v0_6::{UserOperation, UserOperationBuilder, UserOperationRequiredFields},
-        EntityInfos, UserOperation as UserOperationTrait, UserOperationId, ValidTimeRange,
+        EntityInfos, UserOperation as UserOperationTrait, UserOperationId,
+        UserOperationPermissions, ValidTimeRange,
     };
 
     use super::*;
@@ -539,6 +540,7 @@ mod tests {
             entity_infos: EntityInfos::default(),
             da_gas_data: rundler_types::da::DAGasUOData::Empty,
             filter_id: None,
+            perms: UserOperationPermissions::default(),
         }
     }
 

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -801,7 +801,8 @@ mod tests {
     use rundler_provider::MockDAGasOracleSync;
     use rundler_types::{
         v0_6::{UserOperationBuilder, UserOperationRequiredFields},
-        EntityInfo, EntityInfos, GasFees, UserOperation as UserOperationTrait, ValidTimeRange,
+        EntityInfo, EntityInfos, GasFees, UserOperation as UserOperationTrait,
+        UserOperationPermissions, ValidTimeRange,
     };
 
     use super::*;
@@ -1612,6 +1613,7 @@ mod tests {
             account_is_staked: false,
             da_gas_data: Default::default(),
             filter_id: None,
+            perms: UserOperationPermissions::default(),
         }
     }
 

--- a/crates/pool/src/server/remote/client.rs
+++ b/crates/pool/src/server/remote/client.rs
@@ -27,7 +27,7 @@ use rundler_types::{
         NewHead, PaymasterMetadata, Pool, PoolError, PoolOperation, PoolResult, Reputation,
         ReputationStatus, StakeStatus,
     },
-    EntityUpdate, UserOperationId, UserOperationVariant,
+    EntityUpdate, UserOperationId, UserOperationPermissions, UserOperationVariant,
 };
 use rundler_utils::retry::{self, UnlimitedRetryOpts};
 use tokio::sync::mpsc;
@@ -152,13 +152,17 @@ impl Pool for RemotePoolClient {
             .map_err(anyhow::Error::from)?)
     }
 
-    async fn add_op(&self, entry_point: Address, op: UserOperationVariant) -> PoolResult<B256> {
+    async fn add_op(
+        &self,
+        op: UserOperationVariant,
+        perms: UserOperationPermissions,
+    ) -> PoolResult<B256> {
         let res = self
             .op_pool_client
             .clone()
             .add_op(AddOpRequest {
-                entry_point: entry_point.to_vec(),
                 op: Some(protos::UserOperation::from(&op)),
+                permissions: Some(protos::UserOperationPermissions::from(perms)),
             })
             .await
             .map_err(anyhow::Error::from)?

--- a/crates/pool/src/server/remote/protos.rs
+++ b/crates/pool/src/server/remote/protos.rs
@@ -28,7 +28,9 @@ use rundler_types::{
     },
     v0_6, v0_7, Entity as RundlerEntity, EntityInfos, EntityType as RundlerEntityType,
     EntityUpdate as RundlerEntityUpdate, EntityUpdateType as RundlerEntityUpdateType,
-    StakeInfo as RundlerStakeInfo, UserOperation as _, UserOperationVariant, ValidTimeRange,
+    StakeInfo as RundlerStakeInfo, UserOperation as _,
+    UserOperationPermissions as RundlerUserOperationPermissions, UserOperationVariant,
+    ValidTimeRange,
 };
 
 tonic::include_proto!("op_pool");
@@ -436,6 +438,7 @@ impl From<&PoolOperation> for MempoolOp {
             account_is_staked: op.account_is_staked,
             da_gas_data: Some(DaGasUoData::from(&op.da_gas_data)),
             filter_id: op.filter_id.clone().unwrap_or_default(),
+            permissions: Some(op.perms.clone().into()),
         }
     }
 }
@@ -522,6 +525,7 @@ impl TryUoFromProto<MempoolOp> for PoolOperation {
                 .context("DA gas data should be set")?
                 .try_into()?,
             filter_id,
+            perms: op.permissions.context("Permissions should be set")?.into(),
         })
     }
 }
@@ -564,6 +568,22 @@ impl From<PoolPaymasterMetadata> for PaymasterBalance {
             address: paymaster_metadata.address.to_vec(),
             confirmed_balance: paymaster_metadata.confirmed_balance.to_proto_bytes(),
             pending_balance: paymaster_metadata.pending_balance.to_proto_bytes(),
+        }
+    }
+}
+
+impl From<UserOperationPermissions> for RundlerUserOperationPermissions {
+    fn from(permissions: UserOperationPermissions) -> Self {
+        Self {
+            trusted: permissions.trusted,
+        }
+    }
+}
+
+impl From<RundlerUserOperationPermissions> for UserOperationPermissions {
+    fn from(permissions: RundlerUserOperationPermissions) -> Self {
+        Self {
+            trusted: permissions.trusted,
         }
     }
 }

--- a/crates/rpc/src/eth/mod.rs
+++ b/crates/rpc/src/eth/mod.rs
@@ -13,7 +13,6 @@
 
 mod api;
 pub(crate) use api::EthApi;
-pub use api::Settings as EthApiSettings;
 
 mod router;
 pub(crate) use router::*;
@@ -30,7 +29,7 @@ use rundler_provider::StateOverride;
 
 use crate::types::{
     RpcGasEstimate, RpcUserOperation, RpcUserOperationByHash, RpcUserOperationOptionalGas,
-    RpcUserOperationReceipt,
+    RpcUserOperationPermissions, RpcUserOperationReceipt,
 };
 
 /// Eth API
@@ -43,6 +42,7 @@ pub trait EthApi {
         &self,
         op: RpcUserOperation,
         entry_point: Address,
+        permissions: Option<RpcUserOperationPermissions>,
     ) -> RpcResult<B256>;
 
     /// Estimates the gas fields for a user operation.
@@ -75,4 +75,13 @@ pub trait EthApi {
     /// Returns the chain ID
     #[method(name = "chainId")]
     async fn chain_id(&self) -> RpcResult<U64>;
+}
+
+/// Settings for the `eth_` API
+#[derive(Copy, Clone, Debug)]
+pub struct EthApiSettings {
+    /// The number of blocks to look back for user operation events
+    pub user_operation_event_block_distance: Option<u64>,
+    /// If external permissions are allowed
+    pub permissions_enabled: bool,
 }

--- a/crates/rpc/src/task.rs
+++ b/crates/rpc/src/task.rs
@@ -183,7 +183,12 @@ where
         let router = router_builder.build();
 
         let mut module = RpcModule::new(());
-        self.attach_namespaces(router, fee_estimator, &mut module)?;
+        self.attach_namespaces(
+            self.args.eth_api_settings.permissions_enabled,
+            router,
+            fee_estimator,
+            &mut module,
+        )?;
 
         let servers: Vec<Box<dyn HealthCheck>> =
             vec![Box::new(self.pool.clone()), Box::new(self.builder.clone())];
@@ -256,6 +261,7 @@ where
 
     fn attach_namespaces<F: FeeEstimator + 'static>(
         &self,
+        permissions_enabled: bool,
         entry_point_router: EntryPointRouter,
         fee_estimator: F,
         module: &mut RpcModule<()>,
@@ -266,6 +272,7 @@ where
                     self.args.chain_spec.clone(),
                     entry_point_router.clone(),
                     self.pool.clone(),
+                    permissions_enabled,
                 )
                 .into_rpc(),
             )?

--- a/crates/rpc/src/types/mod.rs
+++ b/crates/rpc/src/types/mod.rs
@@ -22,6 +22,9 @@ use rundler_types::{
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+mod permissions;
+pub(crate) use permissions::RpcUserOperationPermissions;
+
 mod v0_6;
 pub(crate) use v0_6::{
     RpcGasEstimate as RpcGasEstimateV0_6, RpcUserOperation as RpcUserOperationV0_6,

--- a/crates/rpc/src/types/permissions.rs
+++ b/crates/rpc/src/types/permissions.rs
@@ -1,0 +1,34 @@
+// This file is part of Rundler.
+//
+// Rundler is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Rundler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Rundler.
+// If not, see https://www.gnu.org/licenses/.
+
+use rundler_types::{chain::ChainSpec, UserOperationPermissions};
+use serde::{Deserialize, Serialize};
+
+use super::FromRpc;
+
+/// User operation permissions
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RpcUserOperationPermissions {
+    /// Whether the user operation is trusted, allowing the bundler to skip untrusted simulation
+    #[serde(default)]
+    pub(crate) trusted: bool,
+}
+
+impl FromRpc<RpcUserOperationPermissions> for UserOperationPermissions {
+    fn from_rpc(rpc: RpcUserOperationPermissions, _chain_spec: &ChainSpec) -> Self {
+        UserOperationPermissions {
+            trusted: rpc.trusted,
+        }
+    }
+}

--- a/crates/rpc/src/types/v0_6.rs
+++ b/crates/rpc/src/types/v0_6.rs
@@ -22,6 +22,7 @@ use rundler_types::{
 use serde::{Deserialize, Serialize};
 
 use super::{rpc_authorization::RpcEip7702Auth, FromRpc, RpcAddress};
+
 /// User operation definition for RPC
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/crates/sim/src/simulation/mod.rs
+++ b/crates/sim/src/simulation/mod.rs
@@ -140,6 +140,7 @@ pub trait Simulator: Send + Sync {
     async fn simulate_validation(
         &self,
         op: Self::UO,
+        trusted: bool,
         block_hash: B256,
         expected_code_hash: Option<B256>,
     ) -> Result<SimulationResult, SimulationError>;

--- a/crates/sim/src/simulation/unsafe_sim.rs
+++ b/crates/sim/src/simulation/unsafe_sim.rs
@@ -14,7 +14,7 @@
 use std::marker::PhantomData;
 
 use alloy_primitives::{Address, B256};
-use rundler_provider::{EntryPoint, SignatureAggregator, SimulationProvider};
+use rundler_provider::{EntryPoint, SimulationProvider};
 use rundler_types::{pool::SimulationViolation, UserOperation, ValidTimeRange};
 
 use super::Settings;
@@ -26,6 +26,7 @@ use crate::{simulation::context, SimulationError, SimulationResult, Simulator, V
 ///
 /// WARNING: This is "unsafe" for a reason. None of the ERC-7562 checks are
 /// performed.
+#[derive(Debug)]
 pub struct UnsafeSimulator<UO, E> {
     entry_point: E,
     settings: Settings,
@@ -47,7 +48,7 @@ impl<UO, E> UnsafeSimulator<UO, E> {
 impl<UO, E> Simulator for UnsafeSimulator<UO, E>
 where
     UO: UserOperation,
-    E: EntryPoint + SimulationProvider<UO = UO> + SignatureAggregator<UO = UO> + Clone,
+    E: EntryPoint + SimulationProvider<UO = UO>,
 {
     type UO = UO;
 
@@ -57,6 +58,7 @@ where
     async fn simulate_validation(
         &self,
         op: UO,
+        _trusted: bool,
         block_hash: B256,
         _expected_code_hash: Option<B256>,
     ) -> Result<SimulationResult, SimulationError> {

--- a/crates/types/src/pool/traits.rs
+++ b/crates/types/src/pool/traits.rs
@@ -22,7 +22,7 @@ use super::{
     error::PoolError,
     types::{NewHead, PaymasterMetadata, PoolOperation, Reputation, ReputationStatus, StakeStatus},
 };
-use crate::{EntityUpdate, UserOperationId, UserOperationVariant};
+use crate::{EntityUpdate, UserOperationId, UserOperationPermissions, UserOperationVariant};
 
 /// Result type for pool server operations.
 pub type PoolResult<T> = std::result::Result<T, PoolError>;
@@ -35,7 +35,11 @@ pub trait Pool: Send + Sync {
     async fn get_supported_entry_points(&self) -> PoolResult<Vec<Address>>;
 
     /// Add an operation to the pool
-    async fn add_op(&self, entry_point: Address, op: UserOperationVariant) -> PoolResult<B256>;
+    async fn add_op(
+        &self,
+        op: UserOperationVariant,
+        perms: UserOperationPermissions,
+    ) -> PoolResult<B256>;
 
     /// Get operations from the pool
     async fn get_ops(

--- a/crates/types/src/pool/types.rs
+++ b/crates/types/src/pool/types.rs
@@ -16,7 +16,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
     da::DAGasUOData, entity::EntityInfos, Entity, EntityType, StakeInfo, UserOperation,
-    UserOperationVariant, ValidTimeRange,
+    UserOperationPermissions, UserOperationVariant, ValidTimeRange,
 };
 
 /// The new head of the chain, as viewed by the pool
@@ -124,6 +124,8 @@ pub struct PoolOperation {
     pub da_gas_data: DAGasUOData,
     /// The matched filter ID for this operation
     pub filter_id: Option<String>,
+    /// Permissions for this operation
+    pub perms: UserOperationPermissions,
 }
 
 impl PoolOperation {

--- a/crates/types/src/user_operation/mod.rs
+++ b/crates/types/src/user_operation/mod.rs
@@ -16,6 +16,10 @@ use std::{fmt::Debug, time::Duration};
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_sol_types::SolValue;
 
+/// User operation permissions
+mod permissions;
+pub use permissions::UserOperationPermissions;
+
 /// User Operation types for Entry Point v0.6
 pub mod v0_6;
 /// User Operation types for Entry Point v0.7

--- a/crates/types/src/user_operation/permissions.rs
+++ b/crates/types/src/user_operation/permissions.rs
@@ -1,0 +1,19 @@
+// This file is part of Rundler.
+//
+// Rundler is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Rundler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Rundler.
+// If not, see https://www.gnu.org/licenses/.
+
+/// User operation permissions
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UserOperationPermissions {
+    /// Whether the user operation is trusted, allowing the bundler to skip untrusted simulation
+    pub trusted: bool,
+}

--- a/crates/types/src/user_operation/v0_7.rs
+++ b/crates/types/src/user_operation/v0_7.rs
@@ -414,6 +414,27 @@ impl UserOperation {
     }
 }
 
+#[cfg(feature = "test-utils")]
+impl Default for UserOperation {
+    fn default() -> Self {
+        UserOperationBuilder::new(
+            &ChainSpec::default(),
+            UserOperationRequiredFields {
+                sender: Address::ZERO,
+                nonce: U256::ZERO,
+                call_data: Bytes::new(),
+                signature: Bytes::new(),
+                call_gas_limit: 0,
+                verification_gas_limit: 0,
+                pre_verification_gas: 0,
+                max_fee_per_gas: 0,
+                max_priority_fee_per_gas: 0,
+            },
+        )
+        .build()
+    }
+}
+
 impl From<UserOperationVariant> for UserOperation {
     /// Converts a UserOperationVariant to a UserOperation 0.7
     ///

--- a/docs/architecture/rpc.md
+++ b/docs/architecture/rpc.md
@@ -15,7 +15,7 @@ It also supports a health check endpoint.
 
 ### `eth_` Namespace
 
-Methods defined by the [ERC-4337 spec](https://eips.ethereum.org/EIPS/eip-4337#rpc-methods-eth-namespace).
+Methods defined by the [ERC-7769 spec](https://eips.ethereum.org/EIPS/eip-7769#rpc-methods-eth-namespace).
 
 | Method | Supported |
 | ------ | :-----------: |
@@ -28,7 +28,7 @@ Methods defined by the [ERC-4337 spec](https://eips.ethereum.org/EIPS/eip-4337#r
 
 ### `debug_` Namespace
 
-Method defined by the [ERC-4337 spec](https://eips.ethereum.org/EIPS/eip-4337#rpc-methods-debug-namespace). Used only for debugging/testing and should be disabled on production APIs.
+Method defined by the [ERC-7769 spec](https://eips.ethereum.org/EIPS/eip-7769#rpc-methods-debug-namespace). Used only for debugging/testing and should be disabled on production APIs.
 
 | Method | Supported | Non-Standard |
 | ------ | :-----------: | :--: |
@@ -42,6 +42,8 @@ Method defined by the [ERC-4337 spec](https://eips.ethereum.org/EIPS/eip-4337#rp
 | [`debug_bundler_getStakeStatus`](#debug_bundler_getstakestatus) | ✅ | ✅ |
 | [`debug_bundler_clearMempool`](#debug_bundler_clearMempool) | ✅ | ✅
 | [`debug_bundler_dumpPaymasterBalances`](#debug_bundler_dumpPaymasterBalances) | ✅ | ✅
+
+Non standard API definitions:
 
 #### `debug_bundler_getStakeStatus`
 
@@ -307,6 +309,38 @@ Currently, it simply queries each the `Pool` and the `Builder` servers to check 
 | ------ | :-----------: | ---- |
 | Healthy | 200 | `ok` |
 | Unhealthy | 500 | JSON-RPC formatted error message | 
+
+## User Operation Permissions
+
+Rundler supports a non-standard 3rd positional parameter on `eth_sendUserOperation` to enabled special permissions on a per-user operation basis. If `rpc.permissions_enabled` is set, these permissions will be sent to the mempool. If disabled, the permissions will be ignored.
+
+These permissions are meant to be used only by trusted connections. For example, an internal proxy that has a trusted relationship with a sender can tag that user operation as `trusted` and skip complex untrusted simulation.
+
+When enabled, the `eth_sendUserOperation` request schema becomes:
+
+```
+# Request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "eth_sendUserOperation",
+  "params": [
+    {
+      ... // user operation fields
+    }
+    "0x....", // entry point address 
+    {
+      trusted: bool // true if the UO should be trusted and simulation should be skipped.
+    }
+  ]
+}
+```
+
+### Available Permissions
+
+#### `trusted`
+
+The `trusted` parameter on the UO permissions object causes the mempool to "trust" that the user operation will not cause a DOS attack on the bundler. With this trust, the bundler can skip applying the ERC-7562 simulation rules on the user operation, skipping the costly debug trace call.
 
 
 ## Gas Estimation

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -148,6 +148,9 @@ List of command line options for configuring the RPC API.
 - `--rpc.builder_url`:	Builder URL for RPC (default: `http://localhost:50052`)
   - env: *RPC_BUILDER_URL*
   - *Only required when running in distributed mode* 
+- `--rpc.permissions_enabled`: True if user operation permissions are enabled on the RPC API (default: `false`)
+  - env: *RPC_PERMISSIONS_ENABLED
+  - **NOTE: Do not enable this on a public API - for internal, trusted connections only.**
 
 ## Pool Options
 


### PR DESCRIPTION
## Proposed Changes
  - Add an optional field to the end of `eth_sendUserOperation` to represent user operation permissions
  - Add the first permission, trusted, which allows the UO to use unsafe simulation
 
 TODO:
- [x] Unit tests
- [x] Local testing
- [x] Docs
