### PR TITLE
feat: add max uo per sender permission

### DIFF
--- a/crates/builder/src/bundle_proposer.rs
+++ b/crates/builder/src/bundle_proposer.rs
@@ -3328,7 +3328,10 @@ mod tests {
                 aggregator: None,
                 da_gas_data: Default::default(),
                 filter_id: None,
-                perms: UserOperationPermissions { trusted: *trusted },
+                perms: UserOperationPermissions {
+                    trusted: *trusted,
+                    ..Default::default()
+                },
             })
             .collect();
 

--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -26,6 +26,7 @@ message UserOperation {
 
 message UserOperationPermissions {
   bool trusted = 1;
+  optional uint64 max_allowed_in_pool_for_sender = 2;
 }
 
 // Protocol Buffer representation of an 7702 authorization tuple. See the official 

--- a/crates/pool/src/server/remote/protos.rs
+++ b/crates/pool/src/server/remote/protos.rs
@@ -576,6 +576,9 @@ impl From<UserOperationPermissions> for RundlerUserOperationPermissions {
     fn from(permissions: UserOperationPermissions) -> Self {
         Self {
             trusted: permissions.trusted,
+            max_allowed_in_pool_for_sender: permissions
+                .max_allowed_in_pool_for_sender
+                .map(|c| c as usize),
         }
     }
 }
@@ -584,6 +587,9 @@ impl From<RundlerUserOperationPermissions> for UserOperationPermissions {
     fn from(permissions: RundlerUserOperationPermissions) -> Self {
         Self {
             trusted: permissions.trusted,
+            max_allowed_in_pool_for_sender: permissions
+                .max_allowed_in_pool_for_sender
+                .map(|c| c as u64),
         }
     }
 }

--- a/crates/rpc/src/types/permissions.rs
+++ b/crates/rpc/src/types/permissions.rs
@@ -11,6 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
+use alloy_primitives::U64;
 use rundler_types::{chain::ChainSpec, UserOperationPermissions};
 use serde::{Deserialize, Serialize};
 
@@ -23,12 +24,16 @@ pub(crate) struct RpcUserOperationPermissions {
     /// Whether the user operation is trusted, allowing the bundler to skip untrusted simulation
     #[serde(default)]
     pub(crate) trusted: bool,
+    /// The maximum sender allowed in the pool
+    #[serde(default)]
+    pub(crate) max_allowed_in_pool_for_sender: Option<U64>,
 }
 
 impl FromRpc<RpcUserOperationPermissions> for UserOperationPermissions {
     fn from_rpc(rpc: RpcUserOperationPermissions, _chain_spec: &ChainSpec) -> Self {
         UserOperationPermissions {
             trusted: rpc.trusted,
+            max_allowed_in_pool_for_sender: rpc.max_allowed_in_pool_for_sender.map(|c| c.to()),
         }
     }
 }

--- a/crates/types/src/user_operation/permissions.rs
+++ b/crates/types/src/user_operation/permissions.rs
@@ -16,4 +16,6 @@
 pub struct UserOperationPermissions {
     /// Whether the user operation is trusted, allowing the bundler to skip untrusted simulation
     pub trusted: bool,
+    /// The maximum number of user operations allowed for a sender in the mempool
+    pub max_allowed_in_pool_for_sender: Option<usize>,
 }

--- a/docs/architecture/rpc.md
+++ b/docs/architecture/rpc.md
@@ -331,6 +331,7 @@ When enabled, the `eth_sendUserOperation` request schema becomes:
     "0x....", // entry point address 
     {
       trusted: bool // true if the UO should be trusted and simulation should be skipped.
+      maxAllowedInPoolForSender: uint64 // the maximum number of UOs allowed in the mempool for this sender
     }
   ]
 }
@@ -342,6 +343,9 @@ When enabled, the `eth_sendUserOperation` request schema becomes:
 
 The `trusted` parameter on the UO permissions object causes the mempool to "trust" that the user operation will not cause a DOS attack on the bundler. With this trust, the bundler can skip applying the ERC-7562 simulation rules on the user operation, skipping the costly debug trace call.
 
+#### `maxAllowedInPoolForSender`
+
+The `maxAllowedInPoolForSender` parameter on the UO permissions object sets the maximum number of UOs this particular sender is allowed to have in the mempool. If unset, this will default to `pool.same_sender_mempool_count` from the CLI parameters.
 
 ## Gas Estimation
 


### PR DESCRIPTION
## Proposed Changes

  - Add a new permissions to allow more max allowed UOs in the pool for trusted senders

TODO:
- [x] Docs
- [x] Local testing
