### PR TITLE
feat: add permission for relaxed fee checking

### DIFF
--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -27,6 +27,8 @@ message UserOperation {
 message UserOperationPermissions {
   bool trusted = 1;
   optional uint64 max_allowed_in_pool_for_sender = 2;
+  optional uint32 underpriced_accept_pct = 3;
+  optional uint32 underpriced_bundle_pct = 4;
 }
 
 // Protocol Buffer representation of an 7702 authorization tuple. See the official 

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -285,11 +285,15 @@ where
                     op.uo().extra_data_len(bundle_size),
                 );
 
-                let required_pvg = op.uo().required_pre_verification_gas(
+                let mut required_pvg = op.uo().required_pre_verification_gas(
                     &self.config.chain_spec,
                     bundle_size,
                     required_da_gas,
                 );
+                if let Some(pct) = op.po.perms.underpriced_bundle_pct {
+                    required_pvg = math::percent_ceil(required_pvg, pct);
+                }
+
                 let actual_pvg = op.uo().pre_verification_gas();
 
                 if actual_pvg < required_pvg {

--- a/crates/pool/src/mempool/uo_pool.rs
+++ b/crates/pool/src/mempool/uo_pool.rs
@@ -580,7 +580,7 @@ where
         let precheck_ret = self
             .pool_providers
             .prechecker()
-            .check(&versioned_op, block_hash.into())
+            .check(&versioned_op, &perms, block_hash.into())
             .await?;
 
         // Only let ops with successful simulations through
@@ -2385,7 +2385,7 @@ mod tests {
             .returning(|| Ok(FeeUpdate::default()));
 
         for op in ops {
-            prechecker.expect_check().returning(move |_, _| {
+            prechecker.expect_check().returning(move |_, _, _| {
                 if let Some(error) = &op.precheck_error {
                     Err(PrecheckError::Violations(vec![error.clone()]))
                 } else {

--- a/crates/pool/src/server/remote/protos.rs
+++ b/crates/pool/src/server/remote/protos.rs
@@ -621,6 +621,8 @@ impl From<UserOperationPermissions> for RundlerUserOperationPermissions {
             max_allowed_in_pool_for_sender: permissions
                 .max_allowed_in_pool_for_sender
                 .map(|c| c as usize),
+            underpriced_accept_pct: permissions.underpriced_accept_pct,
+            underpriced_bundle_pct: permissions.underpriced_bundle_pct,
         }
     }
 }
@@ -632,6 +634,8 @@ impl From<RundlerUserOperationPermissions> for UserOperationPermissions {
             max_allowed_in_pool_for_sender: permissions
                 .max_allowed_in_pool_for_sender
                 .map(|c| c as u64),
+            underpriced_accept_pct: permissions.underpriced_accept_pct,
+            underpriced_bundle_pct: permissions.underpriced_bundle_pct,
         }
     }
 }

--- a/crates/rpc/src/eth/server.rs
+++ b/crates/rpc/src/eth/server.rs
@@ -39,13 +39,17 @@ where
         permissions: Option<RpcUserOperationPermissions>,
     ) -> RpcResult<B256> {
         // if permissions are not enabled, default them
-        let permissions = if self.permissions_enabled {
+        let mut permissions = if self.permissions_enabled {
             permissions
                 .map(|p| UserOperationPermissions::from_rpc(p, &self.chain_spec))
                 .unwrap_or_default()
         } else {
             UserOperationPermissions::default()
         };
+
+        // cap percentages at 100
+        permissions.underpriced_accept_pct = permissions.underpriced_accept_pct.map(|p| p.min(100));
+        permissions.underpriced_bundle_pct = permissions.underpriced_bundle_pct.map(|p| p.min(100));
 
         utils::safe_call_rpc_handler(
             "eth_sendUserOperation",

--- a/crates/rpc/src/types/permissions.rs
+++ b/crates/rpc/src/types/permissions.rs
@@ -27,6 +27,12 @@ pub(crate) struct RpcUserOperationPermissions {
     /// The maximum sender allowed in the pool
     #[serde(default)]
     pub(crate) max_allowed_in_pool_for_sender: Option<U64>,
+    /// The allowed percentage of underpriced fees that is accepted into the pool
+    #[serde(default)]
+    pub(crate) underpriced_accept_pct: Option<U64>,
+    /// The allowed percentage of fees underpriced that is bundled
+    #[serde(default)]
+    pub(crate) underpriced_bundle_pct: Option<U64>,
 }
 
 impl FromRpc<RpcUserOperationPermissions> for UserOperationPermissions {
@@ -34,6 +40,8 @@ impl FromRpc<RpcUserOperationPermissions> for UserOperationPermissions {
         UserOperationPermissions {
             trusted: rpc.trusted,
             max_allowed_in_pool_for_sender: rpc.max_allowed_in_pool_for_sender.map(|c| c.to()),
+            underpriced_accept_pct: rpc.underpriced_accept_pct.map(|c| c.to()),
+            underpriced_bundle_pct: rpc.underpriced_bundle_pct.map(|c| c.to()),
         }
     }
 }

--- a/crates/types/src/user_operation/permissions.rs
+++ b/crates/types/src/user_operation/permissions.rs
@@ -18,4 +18,8 @@ pub struct UserOperationPermissions {
     pub trusted: bool,
     /// The maximum number of user operations allowed for a sender in the mempool
     pub max_allowed_in_pool_for_sender: Option<usize>,
+    /// The allowed percentage of underpriced fees that is accepted into the pool
+    pub underpriced_accept_pct: Option<u32>,
+    /// The allowed percentage of fees underpriced that is bundled
+    pub underpriced_bundle_pct: Option<u32>,
 }

--- a/crates/utils/src/math.rs
+++ b/crates/utils/src/math.rs
@@ -68,6 +68,14 @@ where
     (n * T::from(percent)) / T::from(100)
 }
 
+/// Take a percentage of a number, rounding up
+pub fn percent_ceil<T>(n: T, percent: u32) -> T
+where
+    T: Add<Output = T> + Mul<Output = T> + Div<Output = T> + From<u32>,
+{
+    (n * T::from(percent) + T::from(99)) / T::from(100)
+}
+
 #[cfg(test)]
 mod tests {
     use alloy_primitives::U256;
@@ -105,5 +113,10 @@ mod tests {
     #[test]
     fn test_percent() {
         assert_eq!(percent(3123_u32, 10), 312);
+    }
+
+    #[test]
+    fn test_percent_ceil() {
+        assert_eq!(percent_ceil(3123_u32, 10), 313);
     }
 }

--- a/docs/architecture/rpc.md
+++ b/docs/architecture/rpc.md
@@ -369,8 +369,10 @@ When enabled, the `eth_sendUserOperation` request schema becomes:
     }
     "0x....", // entry point address 
     {
-      trusted: bool // true if the UO should be trusted and simulation should be skipped.
-      maxAllowedInPoolForSender: uint64 // the maximum number of UOs allowed in the mempool for this sender
+      trusted: bool,                      // optional, true if the UO should be trusted and simulation should be skipped.
+      maxAllowedInPoolForSender: uint64,  // optional, the maximum number of UOs allowed in the mempool for this sender
+      underpricedAcceptPct: uint64,       // optional, the percentage underpriced a UO may be while still allowed to enter the mempool
+      underpricedBundlePct: uint64,       // optional, the percentage underpriced a UO may be while still bundled
     }
   ]
 }
@@ -385,6 +387,16 @@ The `trusted` parameter on the UO permissions object causes the mempool to "trus
 #### `maxAllowedInPoolForSender`
 
 The `maxAllowedInPoolForSender` parameter on the UO permissions object sets the maximum number of UOs this particular sender is allowed to have in the mempool. If unset, this will default to `pool.same_sender_mempool_count` from the CLI parameters.
+
+#### `Underpriced`
+
+The `underpricedAcceptPct` and `underpricedBundlePct` permissions parameters can relax the bundler's fee checks.
+
+`underpricedAcceptPct` relaxes the fee check during precheck upon `eth_sendUserOperation`. It allows a UO to be X% of the current estimated fees and still accepted to the mempool. NOTE: setting this too low without also relaxing pricing on bundling can lead to stuck UOs and long time to mine.
+
+`underpricedBundlePct` relaxes the fee check during bundling. It allows a UO to be X% of the bundle fees and still added to a bundle. NOTE: this causes the bundler to lose funds. Only set this if the bundler is willing to "sponsor" a portion of the UOs fee in exchange for higher liveliness.
+
+NOTE: This fee relaxation only applies to `preVerificationGas` if `chain.da_pre_verification_gas` is true (i.e. PVG is dynamic). Else the UO must pay 100% of the static value.
 
 ## Gas Estimation
 


### PR DESCRIPTION
## Proposed Changes

  - Add two new permissions: one for relaxing fee check for acceptance to the pool, one for relaxing fee check for bundling

TODO
- [x] Unit tests
- [x] Local tests
- [x] Docs
