### PR TITLE
feat(provider): use anynetwork, add get full block/get balances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4840,7 +4840,6 @@ dependencies = [
 name = "rundler-pool"
 version = "0.6.0"
 dependencies = [
- "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-signer",
@@ -4888,7 +4887,7 @@ dependencies = [
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
- "alloy-sol-macro",
+ "alloy-serde",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ alloy-provider = { version = "0.7.3", default-features = false, features = ["req
 alloy-rpc-client = "0.7.3"
 alloy-rpc-types-eth = "0.7.3"
 alloy-rpc-types-trace = "0.7.3"
+alloy-serde = "0.7.3"
 alloy-signer = "0.7.3"
 alloy-signer-aws = "0.7.3"
 alloy-signer-local = { version = "0.7.3" }

--- a/crates/contracts/contracts/src/utils/GetBalances.sol
+++ b/crates/contracts/contracts/src/utils/GetBalances.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.13;
+
+// From eth-infinitism/bundler. A helper contract for hashing together the code
+// hashes of multiple contracts at once.
+//
+// Not intended to be deployed on-chain.. Instead use state overrides to deploy the bytecode and call it.
+
+contract GetBalances {
+    /**
+     * Contract should not be deployed
+     */
+    constructor() {
+        require(block.number < 100, "should not be deployed");
+    }
+
+    function getBalances(
+        address[] memory addresses
+    ) public view returns (uint256[] memory balances) {
+        balances = new uint256[](addresses.length);
+        for (uint i = 0; i < addresses.length; i++) {
+            balances[i] = addresses[i].balance;
+        }
+        return balances;
+    }
+}

--- a/crates/contracts/src/utils.rs
+++ b/crates/contracts/src/utils.rs
@@ -33,3 +33,10 @@ sol!(
     StorageLoader,
     "contracts/out/utils/StorageLoader.sol/StorageLoader.json"
 );
+
+sol!(
+    #[allow(missing_docs)]
+    #[sol(rpc)]
+    GetBalances,
+    "contracts/out/utils/GetBalances.sol/GetBalances.json"
+);

--- a/crates/pool/Cargo.toml
+++ b/crates/pool/Cargo.toml
@@ -36,7 +36,6 @@ tonic-reflection.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true

--- a/crates/pool/src/chain.rs
+++ b/crates/pool/src/chain.rs
@@ -768,7 +768,7 @@ mod tests {
     use alloy_primitives::{address, Log as PrimitiveLog, LogData};
     use parking_lot::RwLock;
     use rundler_provider::{
-        BlockHeader, BlockId, FilterBlockOption, MockEvmProvider, RpcBlockHash,
+        AnyHeader, BlockHeader, BlockId, FilterBlockOption, MockEvmProvider, RpcBlockHash,
     };
 
     use super::*;
@@ -851,10 +851,11 @@ mod tests {
             } else {
                 B256::ZERO
             };
+
             Some(Block {
                 header: BlockHeader {
                     hash,
-                    inner: alloy_consensus::Header {
+                    inner: AnyHeader {
                         parent_hash,
                         number: number as u64,
                         ..Default::default()

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -23,6 +23,7 @@ alloy-rlp.workspace = true
 alloy-rpc-client.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-types-trace.workspace = true
+alloy-serde.workspace = true
 alloy-sol-types.workspace = true
 alloy-transport.workspace = true
 alloy-transport-http.workspace = true
@@ -50,6 +51,5 @@ test-utils = ["mockall"]
 
 [dev-dependencies]
 alloy-provider = { workspace = true, features = ["debug-api", "anvil-node"] }
-alloy-sol-macro.workspace = true
 tiny_http.workspace = true
 tokio.workspace = true

--- a/crates/provider/src/alloy/da/arbitrum.rs
+++ b/crates/provider/src/alloy/da/arbitrum.rs
@@ -12,7 +12,7 @@
 // If not, see https://www.gnu.org/licenses/.
 
 use alloy_primitives::{Address, Bytes};
-use alloy_provider::Provider as AlloyProvider;
+use alloy_provider::network::AnyNetwork;
 use alloy_sol_types::sol;
 use alloy_transport::Transport;
 use rundler_types::da::{DAGasBlockData, DAGasUOData};
@@ -20,7 +20,7 @@ use tracing::instrument;
 use NodeInterface::NodeInterfaceInstance;
 
 use super::DAGasOracle;
-use crate::{BlockHashOrNumber, ProviderResult};
+use crate::{AlloyProvider, BlockHashOrNumber, ProviderResult};
 
 // From https://github.com/OffchainLabs/nitro-contracts/blob/fbbcef09c95f69decabaced3da683f987902f3e2/src/node-interface/NodeInterface.sol#L112
 sol! {
@@ -42,7 +42,7 @@ sol! {
 }
 
 pub(super) struct ArbitrumNitroDAGasOracle<AP, T> {
-    node_interface: NodeInterfaceInstance<T, AP>,
+    node_interface: NodeInterfaceInstance<T, AP, AnyNetwork>,
 }
 
 impl<AP, T> ArbitrumNitroDAGasOracle<AP, T>

--- a/crates/provider/src/alloy/da/local/bedrock.rs
+++ b/crates/provider/src/alloy/da/local/bedrock.rs
@@ -12,7 +12,7 @@
 // If not, see https://www.gnu.org/licenses/.
 
 use alloy_primitives::{Address, Bytes};
-use alloy_provider::Provider as AlloyProvider;
+use alloy_provider::network::AnyNetwork;
 use alloy_rpc_types_eth::state::{AccountOverride, StateOverride};
 use alloy_transport::Transport;
 use anyhow::Context;
@@ -28,7 +28,7 @@ use crate::{
         baseFeeScalarCall, blobBaseFeeCall, blobBaseFeeScalarCall, l1BaseFeeCall,
         GasPriceOracleCalls, GasPriceOracleInstance,
     },
-    BlockHashOrNumber, DAGasOracle, DAGasOracleSync, ProviderResult,
+    AlloyProvider, BlockHashOrNumber, DAGasOracle, DAGasOracleSync, ProviderResult,
 };
 
 // From https://github.com/ethereum-optimism/optimism/blob/f93f9f40adcd448168c6ea27820aeee5da65fcbd/packages/contracts-bedrock/src/L2/GasPriceOracle.sol#L26
@@ -42,15 +42,15 @@ const MIN_TRANSACTION_SIZE: i128 = 100_000_000;
 /// Details: https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/fjord/exec-engine.md#fjord-l1-cost-fee-changes-fastlz-estimator
 #[derive(Debug)]
 pub(crate) struct LocalBedrockDAGasOracle<AP, T> {
-    oracle: GasPriceOracleInstance<T, AP>,
-    multicaller: MulticallInstance<T, AP>,
+    oracle: GasPriceOracleInstance<T, AP, AnyNetwork>,
+    multicaller: MulticallInstance<T, AP, AnyNetwork>,
     block_data_cache: TokioMutex<LruMap<BlockHashOrNumber, BedrockDAGasBlockData>>,
     blocking_task_pool: BlockingTaskPool,
 }
 
 impl<AP, T> LocalBedrockDAGasOracle<AP, T>
 where
-    AP: AlloyProvider<T> + Clone,
+    AP: AlloyProvider<T>,
     T: Transport + Clone,
 {
     pub(crate) fn new(oracle_address: Address, provider: AP) -> Self {

--- a/crates/provider/src/alloy/da/local/nitro.rs
+++ b/crates/provider/src/alloy/da/local/nitro.rs
@@ -12,7 +12,7 @@
 // If not, see https://www.gnu.org/licenses/.
 
 use alloy_primitives::{Address, Bytes};
-use alloy_provider::Provider as AlloyProvider;
+use alloy_provider::network::AnyNetwork;
 use alloy_transport::Transport;
 use anyhow::Context;
 use rundler_types::da::{DAGasBlockData, DAGasUOData, NitroDAGasBlockData, NitroDAGasUOData};
@@ -21,8 +21,8 @@ use tokio::sync::Mutex as TokioMutex;
 use tracing::instrument;
 
 use crate::{
-    alloy::da::arbitrum::NodeInterface::NodeInterfaceInstance, BlockHashOrNumber, DAGasOracle,
-    DAGasOracleSync, ProviderResult,
+    alloy::da::arbitrum::NodeInterface::NodeInterfaceInstance, AlloyProvider, BlockHashOrNumber,
+    DAGasOracle, DAGasOracleSync, ProviderResult,
 };
 
 /// Cached Arbitrum Nitro DA gas oracle
@@ -30,7 +30,7 @@ use crate::{
 /// The goal of this oracle is to only need to make maximum
 /// 1 network call per block + 1 network call per distinct UO
 pub(crate) struct CachedNitroDAGasOracle<AP, T> {
-    node_interface: NodeInterfaceInstance<T, AP>,
+    node_interface: NodeInterfaceInstance<T, AP, AnyNetwork>,
     // Use a tokio::Mutex here to ensure only one network call per block, other threads can async wait for the result
     block_data_cache: TokioMutex<LruMap<BlockHashOrNumber, NitroDAGasBlockData>>,
 }

--- a/crates/provider/src/alloy/da/optimism.rs
+++ b/crates/provider/src/alloy/da/optimism.rs
@@ -12,7 +12,7 @@
 // If not, see https://www.gnu.org/licenses/.
 
 use alloy_primitives::{Address, Bytes};
-use alloy_provider::Provider as AlloyProvider;
+use alloy_provider::network::AnyNetwork;
 use alloy_sol_types::sol;
 use alloy_transport::Transport;
 use anyhow::Context;
@@ -21,7 +21,7 @@ use tracing::instrument;
 use GasPriceOracle::GasPriceOracleInstance;
 
 use super::DAGasOracle;
-use crate::{BlockHashOrNumber, ProviderResult};
+use crate::{AlloyProvider, BlockHashOrNumber, ProviderResult};
 
 // From https://github.com/ethereum-optimism/optimism/blob/f93f9f40adcd448168c6ea27820aeee5da65fcbd/packages/contracts-bedrock/src/L2/GasPriceOracle.sol#L54
 sol! {
@@ -39,7 +39,7 @@ sol! {
 }
 
 pub(super) struct OptimismBedrockDAGasOracle<AP, T> {
-    oracle: GasPriceOracleInstance<T, AP>,
+    oracle: GasPriceOracleInstance<T, AP, AnyNetwork>,
 }
 
 impl<AP, T> OptimismBedrockDAGasOracle<AP, T>

--- a/crates/provider/src/alloy/evm.rs
+++ b/crates/provider/src/alloy/evm.rs
@@ -15,25 +15,29 @@ use std::marker::PhantomData;
 
 use alloy_json_rpc::{RpcParam, RpcReturn};
 use alloy_primitives::{Address, Bytes, TxHash, B256, U256};
-use alloy_provider::{ext::DebugApi, network::TransactionBuilder, Provider as AlloyProvider};
+use alloy_provider::{ext::DebugApi, network::TransactionBuilder};
 use alloy_rpc_types_eth::{
     state::{AccountOverride, StateOverride},
-    Block, BlockId, BlockNumberOrTag, BlockTransactionsKind, FeeHistory, Filter, Log, Transaction,
-    TransactionReceipt, TransactionRequest,
+    BlockId, BlockNumberOrTag, BlockTransactionsKind, FeeHistory, Filter, Log,
 };
 use alloy_rpc_types_trace::geth::{
     GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
 };
+use alloy_serde::WithOtherFields;
 use alloy_transport::Transport;
 use anyhow::Context;
 use rundler_contracts::utils::{
+    GetBalances::{self, GetBalancesInstance},
     GetCodeHashes::{self, GetCodeHashesInstance},
     GetGasUsed::{self, GasUsedResult},
     StorageLoader,
 };
 use tracing::instrument;
 
-use crate::{EvmCall, EvmProvider, ProviderResult};
+use crate::{
+    AlloyProvider, Block, EvmCall, EvmProvider, ProviderResult, Transaction, TransactionReceipt,
+    TransactionRequest,
+};
 
 /// Evm Provider implementation using [alloy-provider](https://github.com/alloy-rs/alloy-rs)
 pub struct AlloyEvmProvider<AP, T> {
@@ -63,11 +67,7 @@ where
     }
 }
 
-impl<AP, T> From<AP> for AlloyEvmProvider<AP, T>
-where
-    T: Transport + Clone,
-    AP: AlloyProvider<T>,
-{
+impl<AP, T> From<AP> for AlloyEvmProvider<AP, T> {
     fn from(inner: AP) -> Self {
         Self::new(inner)
     }
@@ -107,7 +107,8 @@ where
         block: Option<BlockId>,
         state_overrides: &StateOverride,
     ) -> ProviderResult<Bytes> {
-        let mut call = self.inner.call(tx);
+        let tx = WithOtherFields::new(tx.clone());
+        let mut call = self.inner.call(&tx);
         if let Some(block) = block {
             call = call.block(block);
         }
@@ -126,7 +127,17 @@ where
         Ok(self
             .inner
             .get_block(block_id, BlockTransactionsKind::Hashes)
-            .await?)
+            .await?
+            .map(|b| b.inner))
+    }
+
+    #[instrument(skip(self))]
+    async fn get_full_block(&self, block_id: BlockId) -> ProviderResult<Option<Block>> {
+        Ok(self
+            .inner
+            .get_block(block_id, BlockTransactionsKind::Full)
+            .await?
+            .map(|b| b.inner))
     }
 
     #[instrument(skip(self))]
@@ -141,7 +152,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_transaction_by_hash(&self, tx: TxHash) -> ProviderResult<Option<Transaction>> {
-        Ok(self.inner.get_transaction_by_hash(tx).await?)
+        Ok(self
+            .inner
+            .get_transaction_by_hash(tx)
+            .await?
+            .map(|t| t.inner))
     }
 
     #[instrument(skip(self))]
@@ -149,7 +164,11 @@ where
         &self,
         tx: TxHash,
     ) -> ProviderResult<Option<TransactionReceipt>> {
-        Ok(self.inner.get_transaction_receipt(tx).await?)
+        Ok(self
+            .inner
+            .get_transaction_receipt(tx)
+            .await?
+            .map(|t| t.inner))
     }
 
     #[instrument(skip(self))]
@@ -269,11 +288,15 @@ where
             .flat_map(|slot| slot.0)
             .collect::<Vec<_>>();
 
-        let tx = TransactionRequest::default()
+        let tx = alloy_rpc_types_eth::TransactionRequest::default()
             .to(address)
             .with_input(slot_data);
 
-        let result_bytes = self.inner.call(&tx).overrides(&overrides).await?;
+        let result_bytes = self
+            .inner
+            .call(&WithOtherFields::new(tx))
+            .overrides(&overrides)
+            .await?;
 
         if result_bytes.len() != expected_ret_size {
             return Err(anyhow::anyhow!(
@@ -316,114 +339,136 @@ where
         let ret = call.call().await?;
         Ok(ret.hash)
     }
+
+    #[instrument(skip(self))]
+    async fn get_balances(&self, addresses: Vec<Address>) -> ProviderResult<Vec<U256>> {
+        let helper_addr = Address::random();
+        let helper = GetBalancesInstance::new(helper_addr, &self.inner);
+
+        let mut overrides = StateOverride::default();
+        let account = AccountOverride {
+            code: Some(GetBalances::DEPLOYED_BYTECODE.clone()),
+            ..Default::default()
+        };
+        overrides.insert(helper_addr, account);
+
+        Ok(helper
+            .getBalances(addresses)
+            .state(overrides)
+            .call()
+            .await?
+            .balances)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy_provider::ProviderBuilder;
-    use alloy_sol_macro::sol;
+    // TODO: on_anvil() only works if the network is Ethereum, but we need AnyNetwork
 
-    use crate::{AlloyEvmProvider, EvmProvider};
+    // use alloy_provider::{network::AnyNetwork, ProviderBuilder};
+    // use alloy_sol_macro::sol;
 
-    sol!(
-        #[allow(missing_docs)]
-        #[sol(rpc, bytecode="0x6080604052348015600f57600080fd5b506064431060635760405162461bcd60e51b815260206004820152601660248201527f73686f756c64206e6f74206265206465706c6f79656400000000000000000000604482015260640160405180910390fd5b6102b8806100726000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c80637b34b62114610030575b600080fd5b61004361003e366004610159565b610055565b60405190815260200160405180910390f35b600080825167ffffffffffffffff81111561007257610072610127565b60405190808252806020026020018201604052801561009b578160200160208202803683370190505b50905060005b83518110156100f3578381815181106100bc576100bc610229565b60200260200101516001600160a01b03163f8282815181106100e0576100e0610229565b60209081029190910101526001016100a1565b50600081604051602001610107919061023f565b60408051601f198184030181529190528051602090910120949350505050565b634e487b7160e01b600052604160045260246000fd5b80356001600160a01b038116811461015457600080fd5b919050565b60006020828403121561016b57600080fd5b813567ffffffffffffffff81111561018257600080fd5b8201601f8101841361019357600080fd5b803567ffffffffffffffff8111156101ad576101ad610127565b8060051b604051601f19603f830116810181811067ffffffffffffffff821117156101da576101da610127565b6040529182526020818401810192908101878411156101f857600080fd5b6020850194505b8385101561021e576102108561013d565b8152602094850194016101ff565b509695505050505050565b634e487b7160e01b600052603260045260246000fd5b602080825282518282018190526000918401906040840190835b81811015610277578351835260209384019390920191600101610259565b50909594505050505056fea2646970667358221220b2b7c1db7d478df6ecb5a14ec979bf9abb43dd1f7b85388b1c502bf5099282d264736f6c634300081a0033")]
-        contract GetCodeHashes {
+    // use crate::{AlloyEvmProvider, EvmProvider};
 
-            constructor() {
-                require(block.number < 100, "should not be deployed");
-            }
+    // sol!(
+    //     #[allow(missing_docs)]
+    //     #[sol(rpc, bytecode="0x6080604052348015600f57600080fd5b506064431060635760405162461bcd60e51b815260206004820152601660248201527f73686f756c64206e6f74206265206465706c6f79656400000000000000000000604482015260640160405180910390fd5b6102b8806100726000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c80637b34b62114610030575b600080fd5b61004361003e366004610159565b610055565b60405190815260200160405180910390f35b600080825167ffffffffffffffff81111561007257610072610127565b60405190808252806020026020018201604052801561009b578160200160208202803683370190505b50905060005b83518110156100f3578381815181106100bc576100bc610229565b60200260200101516001600160a01b03163f8282815181106100e0576100e0610229565b60209081029190910101526001016100a1565b50600081604051602001610107919061023f565b60408051601f198184030181529190528051602090910120949350505050565b634e487b7160e01b600052604160045260246000fd5b80356001600160a01b038116811461015457600080fd5b919050565b60006020828403121561016b57600080fd5b813567ffffffffffffffff81111561018257600080fd5b8201601f8101841361019357600080fd5b803567ffffffffffffffff8111156101ad576101ad610127565b8060051b604051601f19603f830116810181811067ffffffffffffffff821117156101da576101da610127565b6040529182526020818401810192908101878411156101f857600080fd5b6020850194505b8385101561021e576102108561013d565b8152602094850194016101ff565b509695505050505050565b634e487b7160e01b600052603260045260246000fd5b602080825282518282018190526000918401906040840190835b81811015610277578351835260209384019390920191600101610259565b50909594505050505056fea2646970667358221220b2b7c1db7d478df6ecb5a14ec979bf9abb43dd1f7b85388b1c502bf5099282d264736f6c634300081a0033")]
+    //     contract GetCodeHashes {
 
-            function getCodeHashes(
-                address[] memory addresses
-            ) public view returns (bytes32 hash) {
-                bytes32[] memory hashes = new bytes32[](addresses.length);
-                for (uint i = 0; i < addresses.length; i++) {
-                    hashes[i] = addresses[i].codehash;
-                }
-                bytes memory data = abi.encode(hashes);
-                return keccak256(data);
-            }
-        }
-    );
+    //         constructor() {
+    //             require(block.number < 100, "should not be deployed");
+    //         }
 
-    sol!(
-        #[allow(missing_docs)]
-        #[sol(rpc, bytecode="0x6080604052348015600f57600080fd5b506064431060635760405162461bcd60e51b815260206004820152601660248201527f73686f756c64206e6f74206265206465706c6f79656400000000000000000000604482015260640160405180910390fd5b6102f0806100726000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c8063694f712d14610030575b600080fd5b61004361003e366004610120565b610059565b6040516100509190610225565b60405180910390f35b604080516060808201835260008083526020830181905292820152905a9050600080866001600160a01b031686866040516100949190610277565b60006040518083038185875af1925050503d80600081146100d1576040519150601f19603f3d011682016040523d82523d6000602084013e6100d6565b606091505b509150915060405180606001604052805a6100f19086610293565b8152921515602084015260409092015295945050505050565b634e487b7160e01b600052604160045260246000fd5b60008060006060848603121561013557600080fd5b83356001600160a01b038116811461014c57600080fd5b925060208401359150604084013567ffffffffffffffff81111561016f57600080fd5b8401601f8101861361018057600080fd5b803567ffffffffffffffff81111561019a5761019a61010a565b604051601f8201601f19908116603f0116810167ffffffffffffffff811182821017156101c9576101c961010a565b6040528181528282016020018810156101e157600080fd5b816020840160208301376000602083830101528093505050509250925092565b60005b8381101561021c578181015183820152602001610204565b50506000910152565b60208152815160208201526020820151151560408201526000604083015160608084015280518060808501526102628160a0860160208501610201565b601f01601f19169290920160a0019392505050565b60008251610289818460208701610201565b9190910192915050565b818103818111156102b457634e487b7160e01b600052601160045260246000fd5b9291505056fea2646970667358221220fd5c4f5bf9f90b6eab39aa46ddeda959ed5909b6e92973ab51c047771409755e64736f6c634300081a0033")]
+    //         function getCodeHashes(
+    //             address[] memory addresses
+    //         ) public view returns (bytes32 hash) {
+    //             bytes32[] memory hashes = new bytes32[](addresses.length);
+    //             for (uint i = 0; i < addresses.length; i++) {
+    //                 hashes[i] = addresses[i].codehash;
+    //             }
+    //             bytes memory data = abi.encode(hashes);
+    //             return keccak256(data);
+    //         }
+    //     }
+    // );
 
-        contract GetGasUsed {
-            struct GasUsedResult {
-                uint256 gasUsed;
-                bool success;
-                bytes result;
-            }
+    // sol!(
+    //     #[allow(missing_docs)]
+    //     #[sol(rpc, bytecode="0x6080604052348015600f57600080fd5b506064431060635760405162461bcd60e51b815260206004820152601660248201527f73686f756c64206e6f74206265206465706c6f79656400000000000000000000604482015260640160405180910390fd5b6102f0806100726000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c8063694f712d14610030575b600080fd5b61004361003e366004610120565b610059565b6040516100509190610225565b60405180910390f35b604080516060808201835260008083526020830181905292820152905a9050600080866001600160a01b031686866040516100949190610277565b60006040518083038185875af1925050503d80600081146100d1576040519150601f19603f3d011682016040523d82523d6000602084013e6100d6565b606091505b509150915060405180606001604052805a6100f19086610293565b8152921515602084015260409092015295945050505050565b634e487b7160e01b600052604160045260246000fd5b60008060006060848603121561013557600080fd5b83356001600160a01b038116811461014c57600080fd5b925060208401359150604084013567ffffffffffffffff81111561016f57600080fd5b8401601f8101861361018057600080fd5b803567ffffffffffffffff81111561019a5761019a61010a565b604051601f8201601f19908116603f0116810167ffffffffffffffff811182821017156101c9576101c961010a565b6040528181528282016020018810156101e157600080fd5b816020840160208301376000602083830101528093505050509250925092565b60005b8381101561021c578181015183820152602001610204565b50506000910152565b60208152815160208201526020820151151560408201526000604083015160608084015280518060808501526102628160a0860160208501610201565b601f01601f19169290920160a0019392505050565b60008251610289818460208701610201565b9190910192915050565b818103818111156102b457634e487b7160e01b600052601160045260246000fd5b9291505056fea2646970667358221220fd5c4f5bf9f90b6eab39aa46ddeda959ed5909b6e92973ab51c047771409755e64736f6c634300081a0033")]
 
-            constructor() {
-                require(block.number < 100, "should not be deployed");
-            }
+    //     contract GetGasUsed {
+    //         struct GasUsedResult {
+    //             uint256 gasUsed;
+    //             bool success;
+    //             bytes result;
+    //         }
 
-            function getGas(
-                address target,
-                uint256 value,
-                bytes memory data
-            ) public returns (GasUsedResult memory) {
-                uint256 preGas = gasleft();
-                (bool success, bytes memory result) = target.call{value : value}(data);
-                return GasUsedResult({
-                    gasUsed: preGas - gasleft(),
-                    success: success,
-                    result: result
-                });
-            }
-        }
+    //         constructor() {
+    //             require(block.number < 100, "should not be deployed");
+    //         }
 
-    );
+    //         function getGas(
+    //             address target,
+    //             uint256 value,
+    //             bytes memory data
+    //         ) public returns (GasUsedResult memory) {
+    //             uint256 preGas = gasleft();
+    //             (bool success, bytes memory result) = target.call{value : value}(data);
+    //             return GasUsedResult({
+    //                 gasUsed: preGas - gasleft(),
+    //                 success: success,
+    //                 result: result
+    //             });
+    //         }
+    //     }
 
-    #[tokio::test]
-    async fn test_get_code_hash_unorder_equal() {
-        let alloy_provider = ProviderBuilder::new().on_anvil();
+    // );
 
-        let get_code_hashes_contract = GetCodeHashes::deploy(alloy_provider.clone()).await.unwrap();
-        let get_gas_used_contract = GetGasUsed::deploy(alloy_provider.clone()).await.unwrap();
+    // #[tokio::test]
+    // async fn test_get_code_hash_unorder_equal() {
+    //     let alloy_provider = ProviderBuilder::new().on_anvil();
 
-        let emv_provider = AlloyEvmProvider::new(alloy_provider);
-        let address_1 = get_code_hashes_contract.address();
-        let address_2 = get_gas_used_contract.address();
+    //     let get_code_hashes_contract = GetCodeHashes::deploy(alloy_provider.clone()).await.unwrap();
+    //     let get_gas_used_contract = GetGasUsed::deploy(alloy_provider.clone()).await.unwrap();
 
-        let hash_1 = emv_provider
-            .get_code_hash(vec![*address_1, *address_2], None)
-            .await
-            .unwrap();
+    //     let evm_provider = AlloyEvmProvider::new(alloy_provider);
+    //     let address_1 = get_code_hashes_contract.address();
+    //     let address_2 = get_gas_used_contract.address();
 
-        let hash_2 = emv_provider
-            .get_code_hash(vec![*address_2, *address_1], None)
-            .await
-            .unwrap();
+    //     let hash_1 = evm_provider
+    //         .get_code_hash(vec![*address_1, *address_2], None)
+    //         .await
+    //         .unwrap();
 
-        assert_eq!(hash_1, hash_2);
-    }
+    //     let hash_2 = evm_provider
+    //         .get_code_hash(vec![*address_2, *address_1], None)
+    //         .await
+    //         .unwrap();
 
-    #[tokio::test]
-    async fn test_get_code_hash_unequal() {
-        let alloy_provider = ProviderBuilder::new().on_anvil();
+    //     assert_eq!(hash_1, hash_2);
+    // }
 
-        let get_code_hashes_contract = GetCodeHashes::deploy(alloy_provider.clone()).await.unwrap();
-        let get_gas_used_contract = GetGasUsed::deploy(alloy_provider.clone()).await.unwrap();
+    // #[tokio::test]
+    // async fn test_get_code_hash_unequal() {
+    //     let alloy_provider = ProviderBuilder::new().on_anvil();
 
-        let emv_provider = AlloyEvmProvider::new(alloy_provider);
-        let address_1 = get_code_hashes_contract.address();
-        let address_2 = get_gas_used_contract.address();
+    //     let get_code_hashes_contract = GetCodeHashes::deploy(alloy_provider.clone()).await.unwrap();
+    //     let get_gas_used_contract = GetGasUsed::deploy(alloy_provider.clone()).await.unwrap();
 
-        let hash_1 = emv_provider
-            .get_code_hash(vec![*address_1, *address_2], None)
-            .await
-            .unwrap();
+    //     let evm_provider = AlloyEvmProvider::new(alloy_provider);
+    //     let address_1 = get_code_hashes_contract.address();
+    //     let address_2 = get_gas_used_contract.address();
 
-        let hash_2 = emv_provider
-            .get_code_hash(vec![*address_1], None)
-            .await
-            .unwrap();
+    //     let hash_1 = evm_provider
+    //         .get_code_hash(vec![*address_1, *address_2], None)
+    //         .await
+    //         .unwrap();
 
-        assert_ne!(hash_1, hash_2);
-    }
+    //     let hash_2 = evm_provider
+    //         .get_code_hash(vec![*address_1], None)
+    //         .await
+    //         .unwrap();
+
+    //     assert_ne!(hash_1, hash_2);
+    // }
 }

--- a/crates/provider/src/alloy/mod.rs
+++ b/crates/provider/src/alloy/mod.rs
@@ -13,7 +13,7 @@
 
 use std::time::Duration;
 
-use alloy_provider::{Provider as AlloyProvider, ProviderBuilder};
+use alloy_provider::{network::AnyNetwork, Provider as AlloyProvider, ProviderBuilder};
 use alloy_rpc_client::ClientBuilder;
 use alloy_transport::layers::RetryBackoffService;
 use alloy_transport_http::Http;
@@ -47,8 +47,10 @@ pub fn new_alloy_provider(
     rpc_url: &str,
     provider_client_timeout_seconds: u64,
 ) -> anyhow::Result<
-    impl AlloyProvider<RetryBackoffService<AlloyMetricMiddleware<ProviderTimeout<Http<Client>>>>>
-        + Clone,
+    impl AlloyProvider<
+            RetryBackoffService<AlloyMetricMiddleware<ProviderTimeout<Http<Client>>>>,
+            AnyNetwork,
+        > + Clone,
 > {
     let url = Url::parse(rpc_url).context("invalid rpc url")?;
     let metric_layer = AlloyMetricLayer::default();
@@ -62,7 +64,9 @@ pub fn new_alloy_provider(
         .layer(metric_layer)
         .layer(timeout_layer)
         .http(url);
-    let provider = ProviderBuilder::new().on_client(client);
+    let provider = ProviderBuilder::new()
+        .network::<AnyNetwork>()
+        .on_client(client);
     Ok(provider)
 }
 

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -37,18 +37,19 @@ pub use alloy::{
     evm::AlloyEvmProvider,
     new_alloy_da_gas_oracle, new_alloy_evm_provider, new_alloy_provider,
 };
-
+pub use alloy_provider::network::{AnyHeader, AnyNetwork, AnyReceiptEnvelope, AnyTxEnvelope};
+use alloy_serde::WithOtherFields;
+use alloy_transport::{BoxTransport, Transport};
 mod traits;
 // re-export alloy RPC types
 use std::marker::PhantomData;
 
+pub use alloy_consensus::{ReceiptWithBloom, Transaction as TransactionTrait};
 pub use alloy_json_rpc::{RpcParam, RpcReturn};
 pub use alloy_rpc_types_eth::{
     state::{AccountOverride, StateOverride},
-    Block, BlockHashOrNumber, BlockId, BlockNumberOrTag, FeeHistory, Filter, FilterBlockOption,
-    Header as BlockHeader, Log, ReceiptEnvelope as TransactionReceiptEnvelope,
-    ReceiptWithBloom as TransactionReceiptWithBloom, RpcBlockHash, Transaction, TransactionReceipt,
-    TransactionRequest,
+    BlockHashOrNumber, BlockId, BlockNumberOrTag, FeeHistory, Filter, FilterBlockOption,
+    Header as BlockHeader, Log, RpcBlockHash,
 };
 pub use alloy_rpc_types_trace::geth::{
     CallConfig as GethDebugTracerCallConfig, CallFrame as GethDebugTracerCallFrame,
@@ -64,6 +65,27 @@ use rundler_types::{
 #[cfg(any(test, feature = "test-utils"))]
 pub use traits::test_utils::*;
 pub use traits::*;
+
+/// Transaction request type for all networks.
+pub type TransactionRequest = alloy_rpc_types_eth::TransactionRequest;
+/// Transaction receipt type for all networks.
+pub type TransactionReceipt = alloy_rpc_types_eth::TransactionReceipt<AnyReceiptEnvelope<Log>>;
+/// Transaction type for all networks.
+pub type Transaction = alloy_rpc_types_eth::Transaction<AnyTxEnvelope>;
+/// Block type for all networks.
+pub type Block = alloy_rpc_types_eth::Block<
+    WithOtherFields<Transaction>,
+    alloy_rpc_types_eth::Header<AnyHeader>,
+>;
+/// Alloy provider type for all networks.
+pub trait AlloyProvider<T: Transport + Clone = BoxTransport>:
+    alloy_provider::Provider<T, AnyNetwork> + Clone
+{
+}
+impl<T: Transport + Clone, AP: alloy_provider::Provider<T, AnyNetwork> + Clone> AlloyProvider<T>
+    for AP
+{
+}
 
 /// A trait that provides access to various providers.
 pub trait Providers: Send + Sync + Clone {

--- a/crates/provider/src/traits/evm.rs
+++ b/crates/provider/src/traits/evm.rs
@@ -76,8 +76,11 @@ pub trait EvmProvider: Send + Sync {
     /// Get the current block number
     async fn get_block_number(&self) -> ProviderResult<u64>;
 
-    /// Get a block by its hash or number
+    /// Get a block by its hash or number. Only includes transaction hashes.
     async fn get_block(&self, block_id: BlockId) -> ProviderResult<Option<Block>>;
+
+    /// Get a full block by its hash or number. Includes full transactions.
+    async fn get_full_block(&self, block_id: BlockId) -> ProviderResult<Option<Block>>;
 
     /// Get the balance of an address
     async fn get_balance(&self, address: Address, block: Option<BlockId>) -> ProviderResult<U256>;
@@ -141,4 +144,7 @@ pub trait EvmProvider: Send + Sync {
         addresses: Vec<Address>,
         block: Option<BlockId>,
     ) -> ProviderResult<B256>;
+
+    /// Get the balances of multiple addresses
+    async fn get_balances(&self, addresses: Vec<Address>) -> ProviderResult<Vec<U256>>;
 }

--- a/crates/provider/src/traits/test_utils.rs
+++ b/crates/provider/src/traits/test_utils.rs
@@ -14,8 +14,7 @@
 use alloy_json_rpc::{RpcParam, RpcReturn};
 use alloy_primitives::{Address, Bytes, TxHash, B256, U256};
 use alloy_rpc_types_eth::{
-    state::StateOverride, Block, BlockId, BlockNumberOrTag, FeeHistory, Filter, Log, Transaction,
-    TransactionReceipt, TransactionRequest,
+    state::StateOverride, BlockId, BlockNumberOrTag, FeeHistory, Filter, Log,
 };
 use alloy_rpc_types_trace::geth::{
     GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
@@ -29,9 +28,10 @@ use rundler_types::{
 
 use super::error::ProviderResult;
 use crate::{
-    AggregatorOut, BlockHashOrNumber, BundleHandler, DAGasOracle, DAGasOracleSync, DAGasProvider,
-    DepositInfo, EntryPoint, EntryPointProvider, EvmCall, EvmProvider as EvmProviderTrait,
-    ExecutionResult, HandleOpsOut, SignatureAggregator, SimulationProvider,
+    AggregatorOut, Block, BlockHashOrNumber, BundleHandler, DAGasOracle, DAGasOracleSync,
+    DAGasProvider, DepositInfo, EntryPoint, EntryPointProvider, EvmCall,
+    EvmProvider as EvmProviderTrait, ExecutionResult, HandleOpsOut, SignatureAggregator,
+    SimulationProvider, Transaction, TransactionReceipt, TransactionRequest,
 };
 
 mockall::mock! {
@@ -61,6 +61,8 @@ mockall::mock! {
         async fn get_block_number(&self) -> ProviderResult<u64>;
 
         async fn get_block(&self, block_id: BlockId) -> ProviderResult<Option<Block>>;
+
+        async fn get_full_block(&self, block_id: BlockId) -> ProviderResult<Option<Block>>;
 
         async fn get_balance(&self, address: Address, block: Option<BlockId>) -> ProviderResult<U256>;
 
@@ -109,6 +111,11 @@ mockall::mock! {
             addresses: Vec<Address>,
             block: Option<BlockId>,
         ) -> ProviderResult<B256>;
+
+        async fn get_balances(
+            &self,
+            addresses: Vec<Address>,
+        ) -> ProviderResult<Vec<U256>>;
     }
 }
 

--- a/crates/rpc/src/eth/api.rs
+++ b/crates/rpc/src/eth/api.rs
@@ -188,7 +188,7 @@ mod tests {
     use alloy_sol_types::SolInterface;
     use mockall::predicate::eq;
     use rundler_contracts::v0_6::IEntryPoint::{handleOpsCall, IEntryPointCalls};
-    use rundler_provider::{Log, MockEntryPointV0_6, MockEvmProvider, Transaction};
+    use rundler_provider::{AnyTxEnvelope, Log, MockEntryPointV0_6, MockEvmProvider, Transaction};
     use rundler_sim::MockGasEstimator;
     use rundler_types::{
         pool::{MockPool, PoolOperation},
@@ -294,6 +294,9 @@ mod tests {
             PrimitiveSignature::test_signature(),
             hash,
         ));
+        let tx_hash = *inner.tx_hash();
+        let inner = AnyTxEnvelope::Ethereum(inner);
+
         let tx = Transaction {
             inner,
             block_hash: Some(block_hash),
@@ -303,7 +306,6 @@ mod tests {
             from: Address::default(),
         };
 
-        let tx_hash = *tx.inner.tx_hash();
         let log = Log {
             inner: PrimitiveLog {
                 address: ep,

--- a/crates/rpc/src/eth/events/mod.rs
+++ b/crates/rpc/src/eth/events/mod.rs
@@ -88,7 +88,7 @@ fn filter_receipt_logs_matching_user_op(
 mod tests {
 
     use alloy_primitives::{address, utils::keccak256, Address, Log as PrimitiveLog, LogData};
-    use rundler_provider::{TransactionReceiptEnvelope, TransactionReceiptWithBloom};
+    use rundler_provider::{AnyReceiptEnvelope, ReceiptWithBloom, TransactionReceipt};
 
     use super::*;
 
@@ -232,11 +232,15 @@ mod tests {
             logs,
             ..Default::default()
         };
+
         TransactionReceipt {
-            inner: TransactionReceiptEnvelope::Legacy(TransactionReceiptWithBloom {
-                receipt,
-                ..Default::default()
-            }),
+            inner: AnyReceiptEnvelope {
+                inner: ReceiptWithBloom {
+                    receipt,
+                    ..Default::default()
+                },
+                r#type: 0,
+            },
             transaction_hash: B256::ZERO,
             transaction_index: None,
             block_hash: None,


### PR DESCRIPTION
## Proposed Changes

  - Add `get_full_block` and `get_balances` to `EvmProvider`
  - For `get_full_block`: alloy requires the use of `AnyNetwork` to deserialize blocks for any network, else we'd get errors deserializing arbitrum, optimism, etc blocks.
  - Modify the provider crate and types to use `AnyNetwork`
