### PR TITLE
feat(pool): add address tracking to pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4840,8 +4840,11 @@ dependencies = [
 name = "rundler-pool"
 version = "0.6.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
+ "alloy-network-primitives",
  "alloy-primitives",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ alloy-consensus = "0.7.3"
 alloy-contract = "0.7.3"
 alloy-eips = { version = "0.7.3", features = ["k256","serde", "std"] }
 alloy-json-rpc = "0.7.3"
+alloy-network-primitives = "0.7.3"
 alloy-provider = { version = "0.7.3", default-features = false, features = ["reqwest", "reqwest-rustls-tls"] }
 alloy-rpc-client = "0.7.3"
 alloy-rpc-types-eth = "0.7.3"

--- a/crates/pool/Cargo.toml
+++ b/crates/pool/Cargo.toml
@@ -36,7 +36,10 @@ tonic-reflection.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+alloy-consensus.workspace = true
 alloy-eips.workspace = true
+alloy-network-primitives.workspace = true
+alloy-serde.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true
 mockall.workspace = true

--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -484,7 +484,10 @@ message PaymasterBalance {
   bytes confirmed_balance = 3;
 }
 
-message SubscribeNewHeadsRequest {}
+message SubscribeNewHeadsRequest {
+  // The addresses to track
+  repeated bytes to_track = 1;
+}
 message SubscribeNewHeadsResponse {
   // The new chain head
   NewHead new_head = 1;
@@ -494,8 +497,17 @@ message NewHead {
   bytes block_hash = 1;
   // The block number
   uint64 block_number = 2;
+  // Address Updates
+  repeated AddressUpdate address_updates = 3;
 }
-
+message AddressUpdate {
+  // The address
+  bytes address = 1;
+  // The new nonce  
+  uint64 nonce = 2;
+  // The new balance
+  bytes balance = 3;
+}
 message AdminSetTrackingRequest {
   // The serialized entry point address via which the UserOperation is being submitted
   bytes entry_point = 1;

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -51,12 +51,9 @@ pub(crate) type MempoolResult<T> = std::result::Result<T, MempoolError>;
 #[cfg_attr(test, automock)]
 #[async_trait]
 /// In-memory operation pool
-pub trait Mempool: Send + Sync {
+pub(crate) trait Mempool: Send + Sync {
     /// Call to update the mempool with a new chain update
     async fn on_chain_update(&self, update: &ChainUpdate);
-
-    /// Returns the entry point address this pool targets.
-    fn entry_point(&self) -> Address;
 
     /// Returns the entry point version this pool targets.
     fn entry_point_version(&self) -> EntryPointVersion;

--- a/crates/pool/src/mempool/uo_pool.rs
+++ b/crates/pool/src/mempool/uo_pool.rs
@@ -466,10 +466,6 @@ where
             .record(maintenance_time.as_micros() as f64);
     }
 
-    fn entry_point(&self) -> Address {
-        self.config.entry_point
-    }
-
     fn entry_point_version(&self) -> EntryPointVersion {
         self.config.entry_point_version
     }
@@ -1150,6 +1146,7 @@ mod tests {
                 entrypoint: pool.config.entry_point,
                 is_addition: false,
             }],
+            address_updates: vec![],
             reorg_larger_than_history: false,
         })
         .await;
@@ -1248,6 +1245,7 @@ mod tests {
                 entrypoint: pool.config.entry_point,
                 is_addition: false,
             }],
+            address_updates: vec![],
             reorg_larger_than_history: false,
         })
         .await;
@@ -1282,6 +1280,7 @@ mod tests {
                 entrypoint: pool.config.entry_point,
                 is_addition: true,
             }],
+            address_updates: vec![],
             reorg_larger_than_history: false,
         })
         .await;
@@ -1319,6 +1318,7 @@ mod tests {
             unmined_ops: vec![],
             entity_balance_updates: vec![],
             unmined_entity_balance_updates: vec![],
+            address_updates: vec![],
             reorg_larger_than_history: false,
         })
         .await;
@@ -1364,6 +1364,7 @@ mod tests {
             unmined_ops: vec![],
             entity_balance_updates: vec![],
             unmined_entity_balance_updates: vec![],
+            address_updates: vec![],
             reorg_larger_than_history: false,
         })
         .await;
@@ -1440,6 +1441,7 @@ mod tests {
             entity_balance_updates: vec![],
             unmined_entity_balance_updates: vec![],
             unmined_ops: vec![],
+            address_updates: vec![],
             reorg_larger_than_history: false,
         })
         .await;

--- a/crates/pool/src/server/remote/protos.rs
+++ b/crates/pool/src/server/remote/protos.rs
@@ -22,9 +22,9 @@ use rundler_types::{
         NitroDAGasUOData as RundlerNitroDAGasUOData,
     },
     pool::{
-        NewHead as PoolNewHead, PaymasterMetadata as PoolPaymasterMetadata, PoolOperation,
-        Reputation as PoolReputation, ReputationStatus as PoolReputationStatus,
-        StakeStatus as RundlerStakeStatus,
+        AddressUpdate as PoolAddressUpdate, NewHead as PoolNewHead,
+        PaymasterMetadata as PoolPaymasterMetadata, PoolOperation, Reputation as PoolReputation,
+        ReputationStatus as PoolReputationStatus, StakeStatus as RundlerStakeStatus,
     },
     v0_6, v0_7, Entity as RundlerEntity, EntityInfos, EntityType as RundlerEntityType,
     EntityUpdate as RundlerEntityUpdate, EntityUpdateType as RundlerEntityUpdateType,
@@ -537,6 +537,11 @@ impl TryFrom<NewHead> for PoolNewHead {
         Ok(Self {
             block_hash: from_bytes(&new_head.block_hash)?,
             block_number: new_head.block_number,
+            address_updates: new_head
+                .address_updates
+                .into_iter()
+                .map(PoolAddressUpdate::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
         })
     }
 }
@@ -546,6 +551,33 @@ impl From<PoolNewHead> for NewHead {
         Self {
             block_hash: head.block_hash.to_proto_bytes(),
             block_number: head.block_number,
+            address_updates: head
+                .address_updates
+                .into_iter()
+                .map(AddressUpdate::from)
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<AddressUpdate> for PoolAddressUpdate {
+    type Error = ConversionError;
+
+    fn try_from(update: AddressUpdate) -> Result<Self, Self::Error> {
+        Ok(Self {
+            address: from_bytes(&update.address)?,
+            nonce: update.nonce,
+            balance: from_bytes(&update.balance)?,
+        })
+    }
+}
+
+impl From<PoolAddressUpdate> for AddressUpdate {
+    fn from(update: PoolAddressUpdate) -> Self {
+        Self {
+            address: update.address.to_proto_bytes(),
+            nonce: update.nonce,
+            balance: update.balance.to_proto_bytes(),
         }
     }
 }

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -240,7 +240,7 @@ where
 
         let mut new_heads = self
             .pool
-            .subscribe_new_heads()
+            .subscribe_new_heads(vec![])
             .await
             .context("should subscribe new heads")?;
 

--- a/crates/task/src/block_watcher.rs
+++ b/crates/task/src/block_watcher.rs
@@ -33,7 +33,7 @@ pub async fn wait_for_new_block(
     loop {
         let block = retry::with_unlimited_retries(
             "watch latest block",
-            || provider.get_block(BlockId::latest()),
+            || provider.get_full_block(BlockId::latest()),
             UnlimitedRetryOpts::default(),
         )
         .await;

--- a/crates/types/src/pool/traits.rs
+++ b/crates/types/src/pool/traits.rs
@@ -76,7 +76,10 @@ pub trait Pool: Send + Sync {
     ///
     /// The pool will notify the subscriber when a new chain head is received, and the pool
     /// has processed all operations up to that head.
-    async fn subscribe_new_heads(&self) -> PoolResult<Pin<Box<dyn Stream<Item = NewHead> + Send>>>;
+    async fn subscribe_new_heads(
+        &self,
+        to_track: Vec<Address>,
+    ) -> PoolResult<Pin<Box<dyn Stream<Item = NewHead> + Send>>>;
 
     /// Get reputation status given entrypoint and address
     async fn get_reputation_status(

--- a/crates/types/src/pool/types.rs
+++ b/crates/types/src/pool/types.rs
@@ -26,6 +26,19 @@ pub struct NewHead {
     pub block_hash: B256,
     /// The number of the new head
     pub block_number: u64,
+    /// The updates to the state of the addresses
+    pub address_updates: Vec<AddressUpdate>,
+}
+
+/// An update to the state of an address
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AddressUpdate {
+    /// The address that was updated
+    pub address: Address,
+    /// The new nonce for the address
+    pub nonce: u64,
+    /// The new balance for the address
+    pub balance: U256,
 }
 
 /// The reputation of an entity


### PR DESCRIPTION
## Proposed Changes

  - Modify new heads subscription to pass addresses to track
  - Track addresses during chain tracking, adding address updates from any of the tracked addresses
  - Address updates contains latest nonce, balance, and any mined transaction hashes
