### PR TITLE
feat: enable fallbacks for common RPC provider differences

### DIFF
--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -246,6 +246,14 @@ pub struct CommonArgs {
     )]
     tracer_timeout: String,
 
+    /// If set, allows the simulator to fallback to unsafe mode if the simulation tracer fails
+    #[arg(
+        long = "enable_unsafe_fallback",
+        name = "enable_unsafe_fallback",
+        env = "ENABLE_UNSAFE_FALLBACK"
+    )]
+    enable_unsafe_fallback: bool,
+
     /// Amount of blocks to search when calling eth_getUserOperationByHash.
     /// Defaults from 0 to latest block
     #[arg(
@@ -255,6 +263,17 @@ pub struct CommonArgs {
         global = true
     )]
     user_operation_event_block_distance: Option<u64>,
+
+    /// Amount of blocks to search when calling eth_getUserOperationByHash during a fallback.
+    ///
+    /// Defaults to unset. If set, will be used in the case that a first query for events fails.
+    #[arg(
+        long = "user_operation_event_block_distance_fallback",
+        name = "user_operation_event_block_distance_fallback",
+        env = "USER_OPERATION_EVENT_BLOCK_DISTANCE_FALLBACK",
+        global = true
+    )]
+    user_operation_event_block_distance_fallback: Option<u64>,
 
     #[arg(
         long = "max_simulate_handle_ops_gas",
@@ -525,11 +544,12 @@ impl TryFrom<&CommonArgs> for SimulationSettings {
             bail!("Invalid value for tracer_timeout, must be parsable by the ParseDuration function. See docs https://pkg.go.dev/time#ParseDuration")
         }
 
-        Ok(Self::new(
-            value.min_unstake_delay,
-            U256::from(value.min_stake_value),
-            value.tracer_timeout.clone(),
-        ))
+        Ok(Self {
+            min_unstake_delay: value.min_unstake_delay,
+            min_stake_value: U256::from(value.min_stake_value),
+            tracer_timeout: value.tracer_timeout.clone(),
+            enable_unsafe_fallback: value.enable_unsafe_fallback,
+        })
     }
 }
 

--- a/bin/rundler/src/cli/rpc.rs
+++ b/bin/rundler/src/cli/rpc.rs
@@ -118,6 +118,8 @@ impl RpcArgs {
         let eth_api_settings = EthApiSettings {
             permissions_enabled: self.permissions_enabled,
             user_operation_event_block_distance: common.user_operation_event_block_distance,
+            user_operation_event_block_distance_fallback: common
+                .user_operation_event_block_distance_fallback,
         };
 
         Ok(RpcTaskArgs {

--- a/crates/rpc/src/eth/api.rs
+++ b/crates/rpc/src/eth/api.rs
@@ -407,7 +407,12 @@ mod tests {
             .v0_6(EntryPointRouteImpl::new(
                 ep.clone(),
                 gas_estimator,
-                UserOperationEventProviderV0_6::new(chain_spec.clone(), provider.clone(), None),
+                UserOperationEventProviderV0_6::new(
+                    chain_spec.clone(),
+                    provider.clone(),
+                    None,
+                    None,
+                ),
             ))
             .build();
 

--- a/crates/rpc/src/eth/mod.rs
+++ b/crates/rpc/src/eth/mod.rs
@@ -82,6 +82,8 @@ pub trait EthApi {
 pub struct EthApiSettings {
     /// The number of blocks to look back for user operation events
     pub user_operation_event_block_distance: Option<u64>,
+    /// The number of blocks to look back for user operation events during a fallback
+    pub user_operation_event_block_distance_fallback: Option<u64>,
     /// If external permissions are allowed
     pub permissions_enabled: bool,
 }

--- a/crates/rpc/src/task.rs
+++ b/crates/rpc/src/task.rs
@@ -149,6 +149,9 @@ where
                     self.args
                         .eth_api_settings
                         .user_operation_event_block_distance,
+                    self.args
+                        .eth_api_settings
+                        .user_operation_event_block_distance_fallback,
                 ),
             ));
         }
@@ -175,6 +178,9 @@ where
                     self.args
                         .eth_api_settings
                         .user_operation_event_block_distance,
+                    self.args
+                        .eth_api_settings
+                        .user_operation_event_block_distance_fallback,
                 ),
             ));
         }

--- a/crates/sim/src/simulation/mod.rs
+++ b/crates/sim/src/simulation/mod.rs
@@ -158,17 +158,8 @@ pub struct Settings {
     /// The max duration of the custom javascript tracer. Must be in a format parseable by the
     /// ParseDuration function on an ethereum node. See Docs: https://pkg.go.dev/time#ParseDuration
     pub tracer_timeout: String,
-}
-
-impl Settings {
-    /// Create new settings
-    pub fn new(min_unstake_delay: u32, min_stake_value: U256, tracer_timeout: String) -> Self {
-        Self {
-            min_unstake_delay,
-            min_stake_value,
-            tracer_timeout,
-        }
-    }
+    /// If set, allows the simulator to fallback to unsafe mode if the simulation tracer fails
+    pub enable_unsafe_fallback: bool,
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -180,6 +171,7 @@ impl Default for Settings {
             // 10^18 wei = 1 eth
             min_stake_value: uint!(1_000_000_000_000_000_000_U256),
             tracer_timeout: "10s".to_string(),
+            enable_unsafe_fallback: false,
         }
     }
 }

--- a/crates/sim/src/simulation/simulator.rs
+++ b/crates/sim/src/simulation/simulator.rs
@@ -454,7 +454,19 @@ where
             .await
         {
             Ok(context) => context,
-            error @ Err(_) => error?,
+            error @ Err(_) => {
+                if self.sim_settings.enable_unsafe_fallback {
+                    tracing::warn!(
+                        "tracing error with enable_unsafe_fallback set, falling back to unsafe sim. Error: {error:?}"
+                    );
+                    return self
+                        .unsafe_sim
+                        .simulate_validation(op, trusted, block_hash, expected_code_hash)
+                        .await;
+                } else {
+                    error?
+                }
+            }
         };
 
         // Gather all violations from the tracer

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,8 +40,12 @@ See [chain spec](./architecture/chain_spec.md) for a detailed description of cha
   - env: *MIN_UNSTAKE_DELAY*
 - `--tracer_timeout`: The timeout used for custom javascript tracers, the string must be in a valid parseable format that can be used in the `ParseDuration` function on an ethereum node. See Docs [Here](https://pkg.go.dev/time#ParseDuration). (default: `15s`)
   - env: *TRACER_TIMEOUT*
-- `--user_operation_event_block_distance`: Number of blocks to search when calling `eth_getUserOperationByHash`. (default: all blocks)
+- `--enable_unsafe_fallback`: If set, allows the simulation code to fallback to an unsafe simulation if there is a tracer error. (default: `false`)
+  - env: *ENABLE_UNSAFE_FALLBACK*
+- `--user_operation_event_block_distance`: Number of blocks to search when calling `eth_getUserOperationByHash`/`eth_getUserOperationReceipt`. (default: all blocks)
   - env: *USER_OPERATION_EVENT_BLOCK_DISTANCE*
+- `--user_operation_event_block_distance_fallback`: Number of blocks to search when falling back during `eth_getUserOperationByHash`/`eth_getUserOperationReceipt` upon initial failure using `user_operation_event_block_distance`. (default: None)
+  - env: *USER_OPERATION_EVENT_BLOCK_DISTANCE_FALLBACK*
 - `--max_simulate_handle_ops_gas`: Maximum gas for simulating handle operations. (default: `20000000`).
   - env: *MAX_SIMULATE_HANDLE_OPS_GAS*
 - `--verification_estimation_gas_fee`: The gas fee to use during verification estimation. (default: `1000000000000` 10K gwei).


### PR DESCRIPTION
## Proposed Changes

  - Adds 2 new CLI variables
  - `enable_unsafe_fallback` - allows simulation to fallback to unsafe mode if the tracer is failing
  - `user_operation_event_block_distance_fallback` - allows RPC to fallback to a shorter distance if get_logs is failing
