### PR TITLE
feat(builder): for v0.7+ only run the validation portion during bundle sim

### DIFF
--- a/crates/provider/src/alloy/entry_point/v0_6.rs
+++ b/crates/provider/src/alloy/entry_point/v0_6.rs
@@ -34,7 +34,8 @@ use rundler_types::{
     chain::ChainSpec,
     da::{DAGasBlockData, DAGasData},
     v0_6::{UserOperation, UserOperationBuilder},
-    GasFees, UserOperation as _, UserOpsPerAggregator, ValidationOutput, ValidationRevert,
+    EntryPointVersion, GasFees, UserOperation as _, UserOpsPerAggregator, ValidationOutput,
+    ValidationRevert,
 };
 use rundler_utils::authorization_utils;
 use tracing::instrument;
@@ -93,6 +94,10 @@ where
     AP: AlloyProvider<T>,
     D: Send + Sync,
 {
+    fn version(&self) -> EntryPointVersion {
+        EntryPointVersion::V0_6
+    }
+
     fn address(&self) -> &Address {
         self.i_entry_point.address()
     }
@@ -246,6 +251,7 @@ where
         gas_limit: u64,
         gas_fees: GasFees,
         proxy: Option<Address>,
+        _validation_only: bool,
     ) -> ProviderResult<HandleOpsOut> {
         let tx = get_handle_ops_call(
             &self.i_entry_point,

--- a/crates/provider/src/traits/entry_point.rs
+++ b/crates/provider/src/traits/entry_point.rs
@@ -15,7 +15,8 @@ use alloy_primitives::{Address, Bytes, U256};
 use rundler_types::{
     chain::ChainSpec,
     da::{DAGasBlockData, DAGasData},
-    GasFees, Timestamp, UserOperation, UserOpsPerAggregator, ValidationOutput, ValidationRevert,
+    EntryPointVersion, GasFees, Timestamp, UserOperation, UserOpsPerAggregator, ValidationOutput,
+    ValidationRevert,
 };
 
 use crate::{
@@ -92,6 +93,9 @@ pub struct ExecutionResult {
 #[async_trait::async_trait]
 #[auto_impl::auto_impl(&, &mut, Rc, Arc, Box)]
 pub trait EntryPoint: Send + Sync {
+    /// Get the version of the entry point contract
+    fn version(&self) -> EntryPointVersion;
+
     /// Get the address of the entry point contract
     fn address(&self) -> &Address;
 
@@ -145,6 +149,7 @@ pub trait BundleHandler: Send + Sync {
         gas_limit: u64,
         gas_fees: GasFees,
         proxy: Option<Address>,
+        validation_only: bool,
     ) -> ProviderResult<HandleOpsOut>;
 
     /// Construct the transaction to send a bundle of operations to the entry point contract

--- a/crates/provider/src/traits/test_utils.rs
+++ b/crates/provider/src/traits/test_utils.rs
@@ -23,7 +23,8 @@ use rundler_contracts::utils::GetGasUsed::GasUsedResult;
 use rundler_types::{
     chain::ChainSpec,
     da::{DAGasBlockData, DAGasData},
-    v0_6, v0_7, ExpectedStorage, GasFees, UserOpsPerAggregator, ValidationOutput, ValidationRevert,
+    v0_6, v0_7, EntryPointVersion, ExpectedStorage, GasFees, UserOpsPerAggregator,
+    ValidationOutput, ValidationRevert,
 };
 
 use super::error::ProviderResult;
@@ -132,6 +133,7 @@ mockall::mock! {
 
     #[async_trait::async_trait]
     impl EntryPoint for EntryPointV0_6 {
+        fn version(&self) -> EntryPointVersion;
         fn address(&self) -> &Address;
         async fn balance_of(&self, address: Address, block_id: Option<BlockId>)
             -> ProviderResult<U256>;
@@ -207,6 +209,7 @@ mockall::mock! {
             gas_limit: u64,
             gas_fees: GasFees,
             proxy: Option<Address>,
+            validation_only: bool,
         ) -> ProviderResult<HandleOpsOut>;
         fn get_send_bundle_transaction(
             &self,
@@ -231,6 +234,7 @@ mockall::mock! {
 
     #[async_trait::async_trait]
     impl EntryPoint for EntryPointV0_7 {
+        fn version(&self) -> EntryPointVersion;
         fn address(&self) -> &Address;
         async fn balance_of(&self, address: Address, block_id: Option<BlockId>)
             -> ProviderResult<U256>;
@@ -306,6 +310,7 @@ mockall::mock! {
             gas_limit: u64,
             gas_fees: GasFees,
             proxy: Option<Address>,
+            validation_only: bool,
         ) -> ProviderResult<HandleOpsOut>;
         fn get_send_bundle_transaction(
             &self,


### PR DESCRIPTION
Closes #903

## Proposed Changes

  - Skip bundle simulation if v0.7+ and there is only one UO in the bundle. This simulation was just performed.
  - If v0.7+ add a reverting UO as the last index in the bundle to skip the execution portion during simulation as it doesn't impact bundle validity.
