### PR TITLE
fix(sim): remove paymaster clear and skip postop in v0.7 estimation

### DIFF
--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -81,6 +81,7 @@ fn generate_v0_7_bindings() -> Result<(), Box<dyn error::Error>> {
     write_deployed_bytecode!("v0_7", CallGasEstimationProxy);
     write_deployed_bytecode!("v0_7", EntryPointSimulations);
     write_deployed_bytecode!("v0_7", VerificationGasEstimationHelper);
+    write_deployed_bytecode!("v0_7", EntryPointSimulations);
 
     Ok(())
 }

--- a/crates/contracts/contracts/v0_7/src/EntryPointSimulations.sol
+++ b/crates/contracts/contracts/v0_7/src/EntryPointSimulations.sol
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.23;
+
+/* solhint-disable avoid-low-level-calls */
+/* solhint-disable no-inline-assembly */
+
+import "@account-abstraction/core/EntryPoint.sol";
+import "@account-abstraction/interfaces/IEntryPointSimulations.sol";
+
+// Adapted from https://github.com/eth-infinitism/account-abstraction/blob/v0.7.0/contracts/core/EntryPointSimulations.sol
+
+/*
+ * This contract inherits the EntryPoint and extends it with the view-only methods that are executed by
+ * the bundler in order to check UserOperation validity and estimate its gas consumption.
+ * This contract should never be deployed on-chain and is only used as a parameter for the "eth_call" request.
+ */
+contract EntryPointSimulations is EntryPoint, IEntryPointSimulations {
+    // solhint-disable-next-line var-name-mixedcase
+    AggregatorStakeInfo private NOT_AGGREGATED =
+        AggregatorStakeInfo(address(0), StakeInfo(0, 0));
+
+    SenderCreator private _senderCreator;
+
+    function initSenderCreator() internal virtual {
+        //this is the address of the first contract created with CREATE by this address.
+        address createdObj = address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(hex"d694", address(this), hex"01")
+                    )
+                )
+            )
+        );
+        _senderCreator = SenderCreator(createdObj);
+    }
+
+    function senderCreator()
+        internal
+        view
+        virtual
+        override
+        returns (SenderCreator)
+    {
+        // return the same senderCreator as real EntryPoint.
+        // this call is slightly (100) more expensive than EntryPoint's access to immutable member
+        return _senderCreator;
+    }
+
+    /**
+     * simulation contract should not be deployed, and specifically, accounts should not trust
+     * it as entrypoint, since the simulation functions don't check the signatures
+     */
+    constructor() {
+        require(block.number < 100, "should not be deployed");
+    }
+
+    /// @inheritdoc IEntryPointSimulations
+    function simulateValidation(
+        PackedUserOperation calldata userOp
+    ) external returns (ValidationResult memory) {
+        UserOpInfo memory outOpInfo;
+
+        _simulationOnlyValidations(userOp);
+        (
+            uint256 validationData,
+            uint256 paymasterValidationData
+        ) = _validatePrepayment(0, userOp, outOpInfo);
+        StakeInfo memory paymasterInfo = _getStakeInfo(
+            outOpInfo.mUserOp.paymaster
+        );
+        StakeInfo memory senderInfo = _getStakeInfo(outOpInfo.mUserOp.sender);
+        StakeInfo memory factoryInfo;
+        {
+            bytes calldata initCode = userOp.initCode;
+            address factory = initCode.length >= 20
+                ? address(bytes20(initCode[0:20]))
+                : address(0);
+            factoryInfo = _getStakeInfo(factory);
+        }
+
+        address aggregator = address(uint160(validationData));
+        ReturnInfo memory returnInfo = ReturnInfo(
+            outOpInfo.preOpGas,
+            outOpInfo.prefund,
+            validationData,
+            paymasterValidationData,
+            getMemoryBytesFromOffset(outOpInfo.contextOffset)
+        );
+
+        AggregatorStakeInfo memory aggregatorInfo = NOT_AGGREGATED;
+        if (
+            uint160(aggregator) != SIG_VALIDATION_SUCCESS &&
+            uint160(aggregator) != SIG_VALIDATION_FAILED
+        ) {
+            aggregatorInfo = AggregatorStakeInfo(
+                aggregator,
+                _getStakeInfo(aggregator)
+            );
+        }
+        return
+            ValidationResult(
+                returnInfo,
+                senderInfo,
+                factoryInfo,
+                paymasterInfo,
+                aggregatorInfo
+            );
+    }
+
+    /// @inheritdoc IEntryPointSimulations
+    function simulateHandleOp(
+        PackedUserOperation calldata op,
+        address target,
+        bytes calldata targetCallData
+    ) external nonReentrant returns (ExecutionResult memory) {
+        UserOpInfo memory opInfo;
+        _simulationOnlyValidations(op);
+        (
+            uint256 validationData,
+            uint256 paymasterValidationData
+        ) = _validatePrepayment(0, op, opInfo);
+
+        uint256 paid = _executeUserOp(0, op, opInfo);
+        bool targetSuccess;
+        bytes memory targetResult;
+        if (target != address(0)) {
+            (targetSuccess, targetResult) = target.call(targetCallData);
+        }
+        return
+            ExecutionResult(
+                opInfo.preOpGas,
+                paid,
+                validationData,
+                paymasterValidationData,
+                targetSuccess,
+                targetResult
+            );
+    }
+
+    /// MODIFICATION: add this for gas estimation
+    function simulateHandleOpNoPostOp(
+        PackedUserOperation calldata op,
+        address target,
+        bytes calldata targetCallData
+    ) external nonReentrant returns (ExecutionResult memory) {
+        UserOpInfo memory opInfo;
+        _simulationOnlyValidations(op);
+        (
+            uint256 validationData,
+            uint256 paymasterValidationData
+        ) = _validatePrepayment(0, op, opInfo);
+
+        // MODIFICATION: clear the `opInfo.context` so that postOp does not run before the target call
+        bytes memory context;
+        uint256 contextOffset;
+        assembly {
+            contextOffset := context
+        }
+        opInfo.contextOffset = contextOffset;
+
+        uint256 paid = _executeUserOp(0, op, opInfo);
+        bool targetSuccess;
+        bytes memory targetResult;
+        if (target != address(0)) {
+            (targetSuccess, targetResult) = target.call(targetCallData);
+        }
+        return
+            ExecutionResult(
+                opInfo.preOpGas,
+                paid,
+                validationData,
+                paymasterValidationData,
+                targetSuccess,
+                targetResult
+            );
+    }
+
+    function _simulationOnlyValidations(
+        PackedUserOperation calldata userOp
+    ) internal {
+        //initialize senderCreator(). we can't rely on constructor
+        initSenderCreator();
+
+        try
+            this._validateSenderAndPaymaster(
+                userOp.initCode,
+                userOp.sender,
+                userOp.paymasterAndData
+            )
+        // solhint-disable-next-line no-empty-blocks
+        {
+
+        } catch Error(string memory revertReason) {
+            if (bytes(revertReason).length != 0) {
+                revert FailedOp(0, revertReason);
+            }
+        }
+    }
+
+    /**
+     * Called only during simulation.
+     * This function always reverts to prevent warm/cold storage differentiation in simulation vs execution.
+     * @param initCode         - The smart account constructor code.
+     * @param sender           - The sender address.
+     * @param paymasterAndData - The paymaster address (followed by other params, ignored by this method)
+     */
+    function _validateSenderAndPaymaster(
+        bytes calldata initCode,
+        address sender,
+        bytes calldata paymasterAndData
+    ) external view {
+        if (initCode.length == 0 && sender.code.length == 0) {
+            // it would revert anyway. but give a meaningful message
+            revert("AA20 account not deployed");
+        }
+        if (paymasterAndData.length >= 20) {
+            address paymaster = address(bytes20(paymasterAndData[0:20]));
+            if (paymaster.code.length == 0) {
+                // It would revert anyway. but give a meaningful message.
+                revert("AA30 paymaster not deployed");
+            }
+        }
+        // always revert
+        revert("");
+    }
+
+    //make sure depositTo cost is more than normal EntryPoint's cost,
+    // to mitigate DoS vector on the bundler
+    // empiric test showed that without this wrapper, simulation depositTo costs less..
+    function depositTo(
+        address account
+    ) public payable override(IStakeManager, StakeManager) {
+        unchecked {
+            // silly code, to waste some gas to make sure depositTo is always little more
+            // expensive than on-chain call
+            uint256 x = 1;
+            while (x < 5) {
+                x++;
+            }
+            StakeManager.depositTo(account);
+        }
+    }
+}

--- a/crates/contracts/contracts/v0_7/src/imports.sol
+++ b/crates/contracts/contracts/v0_7/src/imports.sol
@@ -9,5 +9,4 @@ import "@account-abstraction/interfaces/IPaymaster.sol";
 import "@account-abstraction/interfaces/IAggregator.sol";
 import "@account-abstraction/interfaces/IStakeManager.sol";
 import "@account-abstraction/interfaces/PackedUserOperation.sol";
-import "@account-abstraction/core/EntryPointSimulations.sol";
 import "@account-abstraction/core/SenderCreator.sol";

--- a/crates/contracts/src/v0_7.rs
+++ b/crates/contracts/src/v0_7.rs
@@ -208,6 +208,16 @@ sol!(
         returns (
             ExecutionResult memory
         );
+
+        function simulateHandleOpNoPostOp(
+            PackedUserOperation calldata op,
+            address target,
+            bytes calldata targetCallData
+        )
+        external
+        returns (
+            ExecutionResult memory
+        );
     }
 
     #[allow(missing_docs)]
@@ -259,7 +269,7 @@ static __ENTRY_POINT_SIMULATIONS_V0_7_DEPLOYED_BYTECODE_HEX: &[u8] = include_byt
     "../contracts/out/v0_7/EntryPointSimulations.sol/EntryPointSimulations_deployedBytecode.txt"
 );
 
-static __ENTRY_POINT_SIMULATIONS_V0_7_DEPLOYED_BYTECODE: [u8; 16893] = {
+static __ENTRY_POINT_SIMULATIONS_V0_7_DEPLOYED_BYTECODE: [u8; 17253] = {
     match const_hex::const_decode_to_array(__ENTRY_POINT_SIMULATIONS_V0_7_DEPLOYED_BYTECODE_HEX) {
         Ok(a) => a,
         Err(_) => panic!("Failed to decode entry point simulations hex"),

--- a/crates/provider/src/traits/entry_point.rs
+++ b/crates/provider/src/traits/entry_point.rs
@@ -19,9 +19,7 @@ use rundler_types::{
     ValidationRevert,
 };
 
-use crate::{
-    BlockHashOrNumber, BlockId, EvmCall, ProviderResult, StateOverride, TransactionRequest,
-};
+use crate::{BlockHashOrNumber, BlockId, ProviderResult, StateOverride, TransactionRequest};
 
 /// Output of a successful signature aggregator simulation call
 #[derive(Clone, Debug, Default)]
@@ -218,12 +216,18 @@ pub trait SimulationProvider: Send + Sync {
         block_id: Option<BlockId>,
     ) -> ProviderResult<Result<ValidationOutput, ValidationRevert>>;
 
-    /// Get call data and state overrides needed to call `simulateHandleOp`
-    fn get_simulate_handle_op_call(&self, op: Self::UO, state_override: StateOverride) -> EvmCall;
-
-    /// Call the entry point contract's `simulateHandleOp` function
-    /// with a spoofed state
+    /// Call the entry point contract's `simulateHandleOp` function.
     async fn simulate_handle_op(
+        &self,
+        op: Self::UO,
+        target: Address,
+        target_call_data: Bytes,
+        block_id: BlockId,
+        state_override: StateOverride,
+    ) -> ProviderResult<Result<ExecutionResult, ValidationRevert>>;
+
+    /// Simulate handle op function for gas estimation
+    async fn simulate_handle_op_estimate_gas(
         &self,
         op: Self::UO,
         target: Address,

--- a/crates/provider/src/traits/test_utils.rs
+++ b/crates/provider/src/traits/test_utils.rs
@@ -167,12 +167,15 @@ mockall::mock! {
             user_op: v0_6::UserOperation,
             block_id: Option<BlockId>
         ) -> ProviderResult<Result<ValidationOutput, ValidationRevert>>;
-        fn get_simulate_handle_op_call(
+        async fn simulate_handle_op(
             &self,
             op: v0_6::UserOperation,
+            target: Address,
+            target_call_data: Bytes,
+            block_id: BlockId,
             state_override: StateOverride,
-        ) -> crate::EvmCall;
-        async fn simulate_handle_op(
+        ) -> ProviderResult<Result<ExecutionResult, ValidationRevert>>;
+        async fn simulate_handle_op_estimate_gas(
             &self,
             op: v0_6::UserOperation,
             target: Address,
@@ -268,12 +271,15 @@ mockall::mock! {
             user_op: v0_7::UserOperation,
             block_id: Option<BlockId>
         ) -> ProviderResult<Result<ValidationOutput, ValidationRevert>>;
-        fn get_simulate_handle_op_call(
+        async fn simulate_handle_op(
             &self,
             op: v0_7::UserOperation,
+            target: Address,
+            target_call_data: Bytes,
+            block_id: BlockId,
             state_override: StateOverride,
-        ) -> crate::EvmCall;
-        async fn simulate_handle_op(
+        ) -> ProviderResult<Result<ExecutionResult, ValidationRevert>>;
+        async fn simulate_handle_op_estimate_gas(
             &self,
             op: v0_7::UserOperation,
             target: Address,

--- a/crates/sim/src/estimation/estimate_call_gas.rs
+++ b/crates/sim/src/estimation/estimate_call_gas.rs
@@ -142,7 +142,7 @@ where
             self.settings.max_gas_estimation_rounds,
         )
         .await?;
-        tracing::info!(
+        tracing::debug!(
             "call gas estimation took {} ms with {} rounds",
             timer.elapsed().as_millis(),
             num_rounds
@@ -169,7 +169,7 @@ where
 
         let target_revert_data = self
             .entry_point
-            .simulate_handle_op(
+            .simulate_handle_op_estimate_gas(
                 callless_op,
                 *self.entry_point.address(),
                 target_call_data,
@@ -227,7 +227,7 @@ where
         );
         Ok(self
             .entry_point
-            .simulate_handle_op(
+            .simulate_handle_op_estimate_gas(
                 op,
                 *self.entry_point.address(),
                 target_call_data,

--- a/crates/sim/src/estimation/estimate_verification_gas.rs
+++ b/crates/sim/src/estimation/estimate_verification_gas.rs
@@ -116,7 +116,7 @@ where
             self.settings.max_gas_estimation_rounds,
         )
         .await?;
-        tracing::info!(
+        tracing::debug!(
             "verification gas estimation took {} ms with {} rounds",
             timer.elapsed().as_millis(),
             num_rounds

--- a/crates/sim/src/estimation/v0_6.rs
+++ b/crates/sim/src/estimation/v0_6.rs
@@ -526,17 +526,17 @@ mod tests {
     use std::sync::Arc;
 
     use alloy_primitives::{hex, uint};
-    use alloy_sol_types::{Revert, SolCall, SolError, SolValue};
+    use alloy_sol_types::{Revert, SolError, SolValue};
     use rundler_contracts::{
         common::EstimationTypes::*,
         v0_6::{
             GetBalances::{GetBalancesErrors, GetBalancesResult},
-            IEntryPoint, UserOperation as ContractUserOperation,
+            UserOperation as ContractUserOperation,
         },
     };
     use rundler_provider::{
-        EvmCall, ExecutionResult, GasUsedResult, MockEntryPointV0_6, MockEvmProvider,
-        MockFeeEstimator, ProviderError,
+        ExecutionResult, GasUsedResult, MockEntryPointV0_6, MockEvmProvider, MockFeeEstimator,
+        ProviderError,
     };
     use rundler_types::{
         da::DAGasOracleType,
@@ -582,24 +582,6 @@ mod tests {
 
         // Fill in concrete implementations of call data and
         // `simulation_should_revert`
-        entry
-            .expect_get_simulate_handle_op_call()
-            .returning(|op, state_override| {
-                let data = IEntryPoint::simulateHandleOpCall {
-                    op: op.into(),
-                    target: Address::ZERO,
-                    targetCallData: Bytes::new(),
-                }
-                .abi_encode()
-                .into();
-
-                EvmCall {
-                    to: Address::ZERO,
-                    data,
-                    value: U256::ZERO,
-                    state_override,
-                }
-            });
         entry.expect_simulation_should_revert().return_const(true);
 
         entry.expect_address().return_const(Address::ZERO);
@@ -1005,7 +987,7 @@ mod tests {
 
         let gas_estimate = 100_000;
         entry
-            .expect_simulate_handle_op()
+            .expect_simulate_handle_op_estimate_gas()
             .returning(move |_a, _b, _c, _d, _e| {
                 Ok(Ok(ExecutionResult {
                     target_result: EstimateGasResult {
@@ -1043,7 +1025,7 @@ mod tests {
         // return an invalid response for the ExecutionResult
         // for a successful gas estimation
         entry
-            .expect_simulate_handle_op()
+            .expect_simulate_handle_op_estimate_gas()
             .returning(|_a, _b, _c, _d, _e| {
                 Ok(Ok(ExecutionResult {
                     target_result: EstimateGasRevertAtMax {
@@ -1080,7 +1062,7 @@ mod tests {
         let (mut entry, mut provider) = create_base_config();
 
         entry
-            .expect_simulate_handle_op()
+            .expect_simulate_handle_op_estimate_gas()
             .returning(|_a, _b, _c, _d, _e| {
                 Ok(Ok(ExecutionResult {
                     target_result: EstimateGasContinuation {
@@ -1096,7 +1078,7 @@ mod tests {
             })
             .times(1);
         entry
-            .expect_simulate_handle_op()
+            .expect_simulate_handle_op_estimate_gas()
             .returning(|_a, _b, _c, _d, _e| {
                 Ok(Ok(ExecutionResult {
                     target_result: EstimateGasResult {
@@ -1135,7 +1117,7 @@ mod tests {
         let gas_usage = 10_000;
 
         entry
-            .expect_simulate_handle_op()
+            .expect_simulate_handle_op_estimate_gas()
             .returning(move |_op, _b, _c, _d, _e| {
                 Ok(Ok(ExecutionResult {
                     target_result: EstimateGasResult {
@@ -1281,7 +1263,7 @@ mod tests {
             .returning(|| Ok((B256::ZERO, 0)));
 
         entry
-            .expect_simulate_handle_op()
+            .expect_simulate_handle_op_estimate_gas()
             .returning(move |_a, _b, _c, _d, _e| {
                 Ok(Ok(ExecutionResult {
                     target_result: TestCallGasResult {
@@ -1335,7 +1317,7 @@ mod tests {
         };
 
         entry
-            .expect_simulate_handle_op()
+            .expect_simulate_handle_op_estimate_gas()
             .returning(move |_a, _b, _c, _d, _e| {
                 Ok(Ok(ExecutionResult {
                     target_result: TestCallGasResult {
@@ -1377,7 +1359,7 @@ mod tests {
             .returning(|| Ok((B256::ZERO, 0)));
 
         entry
-            .expect_simulate_handle_op()
+            .expect_simulate_handle_op_estimate_gas()
             .returning(move |_a, _b, _c, _d, _e| {
                 Ok(Ok(ExecutionResult {
                     target_result: TestCallGasResult {


### PR DESCRIPTION
## Proposed Changes

  - Rundler v0.8 had a change where we clear paymasters during call gas estimation. See https://github.com/alchemyplatform/rundler/pull/1130
  - We since learned that some account implementations may look at the paymaster and paymaster data during their validation functions. Clearing this paymaster could cause validation to fail.
  - This clearing was done in order to skip running the paymaster's `postOp` function as it may have side effects that impact the gas estimation done as part of the target call in `simulateHandleOp`. Onchain, `postOp` always runs after the execution, so me must not run it before its estimation.
  - The fix is to modify `simulateHandleOp` to skip the `postOp` call (by clearing the `context` on `opInfo`).
