### PR TITLE
fix(sim): fix paymaster data parsing during constant fee logic in gas estimation

### DIFF
--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -584,6 +584,7 @@ impl TryFromWithSpec<&CommonArgs> for EstimationSettings {
             max_paymaster_verification_gas: value.max_verification_gas as u128,
             max_paymaster_post_op_gas: max_bundle_execution_gas,
             max_bundle_execution_gas,
+            max_gas_estimation_gas: value.max_gas_estimation_gas,
             verification_estimation_gas_fee: value.verification_estimation_gas_fee,
             verification_gas_limit_efficiency_reject_threshold: value
                 .verification_gas_limit_efficiency_reject_threshold,

--- a/crates/contracts/contracts/v0_7/src/VerificationGasEstimationHelper.sol
+++ b/crates/contracts/contracts/v0_7/src/VerificationGasEstimationHelper.sol
@@ -197,9 +197,18 @@ contract VerificationGasEstimationHelper {
     {
         assembly {
             let ptr := add(paymasterAndData, 0x20)
-            paymaster := mload(ptr)
-            validationGasLimit := mload(add(ptr, 20)) // 20 bytes for address
-            postOpGasLimit := mload(add(ptr, 36)) // 20 + 16 bytes
+
+            // Load first 32 bytes and extract address (first 20 bytes)
+            let firstWord := mload(ptr)
+            paymaster := shr(96, firstWord) // Shift right 96 bits (12 bytes) to get address
+
+            // Load from offset 20 and extract first uint128 (bytes 20-35)
+            let secondWord := mload(add(ptr, 20))
+            validationGasLimit := shr(128, secondWord) // Shift right 128 bits to get upper 16 bytes
+
+            // Load from offset 36 and extract second uint128 (bytes 36-51)
+            let thirdWord := mload(add(ptr, 36))
+            postOpGasLimit := shr(128, thirdWord) // Shift right 128 bits to get upper 16 bytes
         }
         return (
             address(paymaster),

--- a/crates/contracts/src/v0_7.rs
+++ b/crates/contracts/src/v0_7.rs
@@ -299,7 +299,7 @@ static __VERIFICATION_GAS_ESTIMATION_HELPER_V0_7_DEPLOYED_BYTECODE_HEX: &[u8] = 
     "../contracts/out/v0_7/VerificationGasEstimationHelper.sol/VerificationGasEstimationHelper_deployedBytecode.txt"
 );
 
-static __VERIFICATION_GAS_ESTIMATION_HELPER_V0_7_DEPLOYED_BYTECODE: [u8; 5285] = {
+static __VERIFICATION_GAS_ESTIMATION_HELPER_V0_7_DEPLOYED_BYTECODE: [u8; 5261] = {
     match const_hex::const_decode_to_array(
         __VERIFICATION_GAS_ESTIMATION_HELPER_V0_7_DEPLOYED_BYTECODE_HEX,
     ) {

--- a/crates/sim/src/estimation/estimate_verification_gas.rs
+++ b/crates/sim/src/estimation/estimate_verification_gas.rs
@@ -179,7 +179,7 @@ where
 
         let call = TransactionRequest::default()
             .with_input(call)
-            .with_gas_limit(self.settings.max_bundle_execution_gas.try_into().unwrap())
+            .with_gas_limit(self.settings.max_gas_estimation_gas)
             .with_to(helper_addr);
 
         let ret = self

--- a/crates/sim/src/estimation/mod.rs
+++ b/crates/sim/src/estimation/mod.rs
@@ -103,6 +103,8 @@ pub struct Settings {
     pub max_paymaster_post_op_gas: u128,
     /// The maximum amount of execution gas in a bundle
     pub max_bundle_execution_gas: u128,
+    /// The maximum amount of gas that can be used during a round of binary search for gas estimation
+    pub max_gas_estimation_gas: u64,
     /// The gas fee to use during verification gas estimation, required to be held by the fee-payer
     /// during estimation. If using a paymaster, the fee-payer must have 3x this value.
     /// As the gas limit is varied during estimation, the fee is held constant by varying the

--- a/crates/sim/src/estimation/v0_6.rs
+++ b/crates/sim/src/estimation/v0_6.rs
@@ -654,6 +654,7 @@ mod tests {
         let settings = Settings {
             max_verification_gas: TEST_MAX_GAS_LIMITS,
             max_bundle_execution_gas: TEST_MAX_GAS_LIMITS,
+            max_gas_estimation_gas: TEST_MAX_GAS_LIMITS.try_into().unwrap(),
             max_paymaster_verification_gas: TEST_MAX_GAS_LIMITS,
             max_paymaster_post_op_gas: TEST_MAX_GAS_LIMITS,
             verification_estimation_gas_fee: 1_000_000_000_000,
@@ -758,6 +759,7 @@ mod tests {
         let settings = Settings {
             max_verification_gas: 10000000000,
             max_bundle_execution_gas: 10000000000,
+            max_gas_estimation_gas: 10000000000,
             max_paymaster_verification_gas: 10000000000,
             max_paymaster_post_op_gas: 10000000000,
             verification_estimation_gas_fee: 1_000_000_000_000,
@@ -838,6 +840,7 @@ mod tests {
         let settings = Settings {
             max_verification_gas: 10000000000,
             max_bundle_execution_gas: 10000000000,
+            max_gas_estimation_gas: 10000000000,
             max_paymaster_verification_gas: 10000000000,
             max_paymaster_post_op_gas: 10000000000,
             verification_estimation_gas_fee: 1_000_000_000_000,
@@ -1210,6 +1213,7 @@ mod tests {
         let settings = Settings {
             max_verification_gas: 10,
             max_bundle_execution_gas: 10,
+            max_gas_estimation_gas: 10,
             max_paymaster_post_op_gas: 10,
             max_paymaster_verification_gas: 10,
             verification_estimation_gas_fee: 1_000_000_000_000,

--- a/crates/sim/src/estimation/v0_7.rs
+++ b/crates/sim/src/estimation/v0_7.rs
@@ -756,6 +756,7 @@ mod tests {
         let settings = Settings {
             max_verification_gas: TEST_MAX_GAS_LIMITS,
             max_bundle_execution_gas: TEST_MAX_GAS_LIMITS,
+            max_gas_estimation_gas: TEST_MAX_GAS_LIMITS.try_into().unwrap(),
             max_paymaster_verification_gas: TEST_MAX_GAS_LIMITS,
             max_paymaster_post_op_gas: TEST_MAX_GAS_LIMITS,
             verification_estimation_gas_fee: 1_000_000_000_000,

--- a/docs/architecture/builder.md
+++ b/docs/architecture/builder.md
@@ -65,7 +65,7 @@ The builder supports multiple sender implementations to support bundle transacti
 
 - **Flashbots**: Submit bundles via the [Flashbots Protect](https://docs.flashbots.net/) RPC endpoint, only supported on Ethereum Mainnet.
 
-- **Bloxroute**: Submit bundles via Bloxroute's [Polygon Private Transaction](https://docs.bloxroute.com/apis/frontrunning-protection/polygon_private_tx) endpoint. Only supported on polygon.
+- **Bloxroute**: Submit bundles via Bloxroute's Polygon Private Transaction endpoint. Only supported on polygon.
 
 ## N-Senders
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -70,6 +70,8 @@ See [chain spec](./architecture/chain_spec.md) for a detailed description of cha
   - env: *VERIFICATION_GAS_ALLOWED_ERROR_PCT*
 - `--call_gas_allowed_error_pct`: The allowed error percentage during call gas estimation. (default: 15)
   - env: *CALL_GAS_ALLOWED_ERROR_PCT*
+- `--max_gas_estimation_gas`: The gas limit to use during the call to the gas estimation binary search helper functions. (default: 550M)
+  - env: *MAX_GAS_ESTIMATION_GAS*
 - `--max_gas_estimation_rounds`: The maximum amount of remote RPC calls to make during gas estimation while attempting to converge to the error percentage. (default: 3)
   - env: *MAX_GAS_ESTIMATION_ROUNDS*
 - `--aws_region`: AWS region. (default: `us-east-1`).


### PR DESCRIPTION
- Also use `MAX_GAS_ESTIMATION_GAS` during VGL/PVGL estimation