### PR TITLE
feat: add revert check to mempool add

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,117 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Rundler is a high-performance, modular Rust implementation of an ERC-4337 bundler for Account Abstraction. It's built by Alchemy and designed for cloud-scale deployments with a focus on reliability and performance.
+
+## Development Commands
+
+### Building and Testing
+```bash
+# Build the project
+make build
+cargo build --all --all-features
+
+# Run unit tests
+make test-unit
+cargo nextest run --locked --workspace --all-features --no-fail-fast
+
+# Run all tests (unit + spec tests)
+make test
+
+# Run ERC-4337 spec tests (v0.6 and v0.7)
+make test-spec-integrated
+make test-spec-integrated-v0_6  # v0.6 only
+make test-spec-integrated-v0_7  # v0.7 only
+
+# Run spec tests in modular mode
+make test-spec-modular
+```
+
+### Code Quality
+```bash
+# Format code (requires nightly Rust)
+make fmt
+cargo +nightly fmt
+
+# Lint code
+make lint
+cargo clippy --all --all-features --tests -- -D warnings
+
+# Clean build artifacts
+make clean
+cargo clean
+```
+
+### Running Locally
+```bash
+# Run full node (RPC + Pool + Builder in single process)
+cargo run node
+
+# Run individual components in distributed mode
+cargo run rpc       # RPC server only
+cargo run pool      # Pool server only  
+cargo run builder   # Builder server only
+```
+
+## Architecture
+
+Rundler consists of 3 main modular components:
+
+1. **RPC Server** (`crates/rpc/`): Implements ERC-4337 RPC methods (`eth_*`, `debug_*`, `rundler_*` namespaces)
+2. **Pool** (`crates/pool/`): User Operation mempool with validation, simulation, and chain reorg handling
+3. **Builder** (`crates/builder/`): Bundle construction, transaction submission, and mining monitoring
+
+### Communication Patterns
+- **RPC → Pool**: Submits user operations via `eth_sendUserOperation`
+- **RPC → Builder**: Debug namespace for manual bundling control
+- **Builder ↔ Pool**: Bundle coordination and operation status updates
+
+### Key Supporting Crates
+- `crates/sim/`: Gas estimation and operation simulation
+- `crates/provider/`: Ethereum provider abstractions with Alloy
+- `crates/types/`: Core type definitions
+- `crates/contracts/`: Smart contract bindings and utilities
+- `crates/signer/`: Transaction signing (local keys, AWS KMS)
+
+## Configuration
+
+### Environment Variables
+Most CLI options can be set via environment variables. Key ones:
+- `NODE_HTTP`: Ethereum RPC endpoint (required)
+- `NETWORK`: Predefined network (dev, ethereum, optimism, etc.)
+- `CHAIN_SPEC`: Path to custom chain specification TOML
+- `RUST_LOG`: Log level control
+
+### Chain Specifications
+Chain configs are in `bin/rundler/chain_specs/` with network-specific settings for gas estimation, fee calculation, and protocol parameters.
+
+## Entry Point Support
+
+- **v0.6**: ERC-4337 v0.6 specification (can be disabled with `--disable_entry_point_v0_6`)
+- **v0.7**: ERC-4337 v0.7 specification (can be disabled with `--disable_entry_point_v0_7`)
+
+Both versions are supported simultaneously by default.
+
+## Prerequisites
+
+- Rust 1.87+ with nightly for formatting
+- Docker (for spec tests)
+- PDM (Python dependency manager for spec tests)  
+- Protobuf compiler (protoc)
+- Buf (protobuf linting)
+- Foundry ^0.3.0 (contract compilation)
+
+## Testing Setup
+
+For spec tests, first install frameworks:
+```bash
+cd test/spec-tests/v0_6/bundler-spec-tests && pdm install && pdm run update-deps
+cd test/spec-tests/v0_7/bundler-spec-tests && pdm install && pdm run update-deps
+```
+
+## Workspace Structure
+
+This is a Cargo workspace with the main binary in `bin/rundler/` and library crates in `crates/`. The architecture is designed for both monolithic and distributed deployment modes.

--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -300,6 +300,7 @@ impl BuilderArgs {
                 .verification_gas_limit_efficiency_reject_threshold,
             chain_spec,
             assigner_max_ops_per_request: self.assigner_max_ops_per_request,
+            revert_check_call_type: common.revert_check_call_type,
         })
     }
 

--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -44,7 +44,7 @@ use reth_tasks::TaskManager;
 use rpc::RpcCliArgs;
 use rundler_provider::{
     AlloyEntryPointV0_6, AlloyEntryPointV0_7, AlloyEvmProvider, AlloyNetworkConfig, DAGasOracle,
-    DAGasOracleSync, EntryPointProvider, EvmProvider, FeeEstimator, Providers,
+    DAGasOracleSync, EntryPointProvider, EvmProvider, FeeEstimator, Providers, RevertCheckCallType,
 };
 use rundler_sim::{
     EstimationSettings, MempoolConfigs, PrecheckSettings, SimulationSettings, MIN_CALL_GAS_LIMIT,
@@ -537,6 +537,23 @@ pub struct CommonArgs {
         value_parser = ValueParser::new(parse_key_val)
     )]
     pub aggregator_options: Vec<(String, String)>,
+
+    #[arg(
+        long = "revert_check_call_type",
+        name = "revert_check_call_type",
+        env = "REVERT_CHECK_CALL_TYPE",
+        value_parser = ValueParser::new(parse_revert_check_call_type)
+    )]
+    pub revert_check_call_type: Option<RevertCheckCallType>,
+}
+
+fn parse_revert_check_call_type(s: &str) -> Result<RevertCheckCallType, anyhow::Error> {
+    match s {
+        "eth_call" => Ok(RevertCheckCallType::EthCall),
+        "eth_simulateV1" => Ok(RevertCheckCallType::EthSimulateV1),
+        "debug_trace_call" => Ok(RevertCheckCallType::DebugTraceCall),
+        _ => Err(anyhow::anyhow!("invalid revert check mode: {}, must be one of eth_call, eth_simulate_v1, debug_trace_call", s)),
+    }
 }
 
 impl CommonArgs {

--- a/bin/rundler/src/cli/mod.rs
+++ b/bin/rundler/src/cli/mod.rs
@@ -377,14 +377,6 @@ pub struct CommonArgs {
     pre_verification_gas_accept_percent: u32,
 
     #[arg(
-        long = "execution_gas_limit_efficiency_reject_threshold",
-        name = "execution_gas_limit_efficiency_reject_threshold",
-        env = "EXECUTION_GAS_LIMIT_EFFICIENCY_REJECT_THRESHOLD",
-        default_value = "0.0"
-    )]
-    pub execution_gas_limit_efficiency_reject_threshold: f64,
-
-    #[arg(
         long = "verification_gas_limit_efficiency_reject_threshold",
         name = "verification_gas_limit_efficiency_reject_threshold",
         env = "VERIFICATION_GAS_LIMIT_EFFICIENCY_REJECT_THRESHOLD",

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -15,9 +15,9 @@ use std::{collections::HashMap, net::SocketAddr, time::Duration};
 
 use alloy_primitives::Address;
 use anyhow::Context;
-use clap::{builder::ValueParser, Args};
+use clap::Args;
 use rundler_pool::{LocalPoolBuilder, PoolConfig, PoolTask, PoolTaskArgs};
-use rundler_provider::{Providers, RevertCheckMode};
+use rundler_provider::Providers;
 use rundler_sim::MempoolConfigs;
 use rundler_task::TaskSpawnerExt;
 use rundler_types::{
@@ -174,23 +174,6 @@ pub struct PoolArgs {
         env = "POOL_MAX_TIME_IN_POOL_SECS"
     )]
     pub max_time_in_pool_secs: Option<u64>,
-
-    #[arg(
-        long = "pool.revert_check_mode",
-        name = "pool.revert_check_mode",
-        env = "POOL_REVERT_CHECK_MODE",
-        value_parser = ValueParser::new(parse_revert_check_mode)
-    )]
-    pub revert_check_mode: Option<RevertCheckMode>,
-}
-
-fn parse_revert_check_mode(s: &str) -> Result<RevertCheckMode, anyhow::Error> {
-    match s {
-        "eth_call" => Ok(RevertCheckMode::EthCall),
-        "eth_simulate_v1" => Ok(RevertCheckMode::EthSimulateV1),
-        "debug_trace_call" => Ok(RevertCheckMode::DebugTraceCall),
-        _ => Err(anyhow::anyhow!("invalid revert check mode: {}, must be one of eth_call, eth_simulate_v1, debug_trace_call", s)),
-    }
 }
 
 impl PoolArgs {
@@ -244,7 +227,7 @@ impl PoolArgs {
                 .verification_gas_limit_efficiency_reject_threshold,
             max_time_in_pool: self.max_time_in_pool_secs.map(Duration::from_secs),
             max_expected_storage_slots: common.max_expected_storage_slots.unwrap_or(usize::MAX),
-            revert_check_mode: self.revert_check_mode,
+            revert_check_call_type: common.revert_check_call_type,
         };
 
         let mut pool_configs = vec![];

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -174,6 +174,14 @@ pub struct PoolArgs {
         env = "POOL_MAX_TIME_IN_POOL_SECS"
     )]
     pub max_time_in_pool_secs: Option<u64>,
+
+    #[arg(
+        long = "pool.disable_revert_check",
+        name = "pool.disable_revert_check",
+        env = "POOL_DISABLE_REVERT_CHECK",
+        default_value = "false"
+    )]
+    pub disable_revert_check: bool,
 }
 
 impl PoolArgs {
@@ -223,12 +231,11 @@ impl PoolArgs {
             reputation_tracking_enabled: self.reputation_tracking_enabled,
             drop_min_num_blocks: self.drop_min_num_blocks,
             da_gas_tracking_enabled,
-            execution_gas_limit_efficiency_reject_threshold: common
-                .execution_gas_limit_efficiency_reject_threshold,
             verification_gas_limit_efficiency_reject_threshold: common
                 .verification_gas_limit_efficiency_reject_threshold,
             max_time_in_pool: self.max_time_in_pool_secs.map(Duration::from_secs),
             max_expected_storage_slots: common.max_expected_storage_slots.unwrap_or(usize::MAX),
+            revert_check_enabled: !self.disable_revert_check,
         };
 
         let mut pool_configs = vec![];

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -852,6 +852,10 @@ where
 
     async fn process_revert(&self, tx_hash: B256) -> anyhow::Result<()> {
         warn!("Bundle transaction {tx_hash:?} reverted onchain");
+        if !self.chain_spec.rpc_debug_trace_transaction_enabled {
+            warn!("Debug trace transaction is not enabled, skipping trace");
+            return Ok(());
+        }
 
         let trace_options = GethDebugTracingOptions::new_tracer(
             GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::CallTracer),

--- a/crates/builder/src/emit.rs
+++ b/crates/builder/src/emit.rs
@@ -14,7 +14,7 @@
 use std::{fmt::Display, sync::Arc};
 
 use alloy_primitives::{Address, B256, U256};
-use rundler_provider::TransactionRequest;
+use rundler_provider::{HandleOpRevert, TransactionRequest};
 use rundler_sim::SimulationError;
 use rundler_types::{GasFees, ValidTimeRange};
 use rundler_utils::strs;
@@ -194,6 +194,8 @@ pub enum SkipReason {
 pub enum OpRejectionReason {
     /// Operation failed its 2nd validation simulation attempt
     FailedRevalidation { error: SimulationError },
+    /// Operation failed its revert check
+    FailedRevertCheck { error: HandleOpRevert },
     /// Operation reverted during bundle formation simulation with message
     FailedInBundle { message: Arc<String> },
     /// Operation's storage slot condition was not met

--- a/crates/builder/src/task.rs
+++ b/crates/builder/src/task.rs
@@ -22,6 +22,7 @@ use alloy_primitives::{Address, B256};
 use anyhow::Context;
 use rundler_provider::{
     AlloyNetworkConfig, EntryPoint, Providers as ProvidersT, ProvidersWithEntryPointT,
+    RevertCheckCallType,
 };
 use rundler_signer::{SignerManager, SigningScheme};
 use rundler_sim::{
@@ -91,6 +92,8 @@ pub struct Args {
     pub verification_gas_limit_efficiency_reject_threshold: f64,
     /// Maximum ops requested from mempool
     pub assigner_max_ops_per_request: u64,
+    /// Revert check call type
+    pub revert_check_call_type: Option<RevertCheckCallType>,
 }
 
 /// Builder settings
@@ -417,6 +420,7 @@ where
                 .args
                 .verification_gas_limit_efficiency_reject_threshold,
             submission_proxy: submission_proxy.cloned(),
+            revert_check_call_type: self.args.revert_check_call_type,
         };
 
         let transaction_sender = self

--- a/crates/contracts/src/v0_7.rs
+++ b/crates/contracts/src/v0_7.rs
@@ -132,6 +132,8 @@ sol!(
 
         error FailedOpWithRevert(uint256 opIndex, string reason, bytes inner);
 
+        error PostOpReverted(bytes returnData);
+
         error SignatureValidationFailed(address aggregator);
 
         function handleOps(

--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -646,6 +646,8 @@ message MempoolError {
     UseUnsupportedEIP use_unsupported_eip = 20;
     AggregatorError aggregator = 21;
     Invalid7702AuthSignature invalid_7702_auth_signature = 22;
+    ExecutionRevert execution_revert = 23;
+    PostOpRevert post_op_revert = 24;
   }
 }
 
@@ -719,6 +721,16 @@ message TooManyExpectedStorageSlots {
 
 message UseUnsupportedEIP {
   string eip_name = 1;
+}
+
+message ExecutionRevert {
+  bytes data = 1;
+  string reason = 2;
+}
+
+message PostOpRevert {
+  bytes data = 1;
+  string reason = 2;
 }
 
 // PRECHECK VIOLATIONS

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -21,6 +21,7 @@ mod size;
 
 mod paymaster;
 pub(crate) use paymaster::{PaymasterConfig, PaymasterTracker};
+use rundler_provider::RevertCheckMode;
 
 mod uo_pool;
 use std::{
@@ -179,8 +180,8 @@ pub struct PoolConfig {
     pub max_time_in_pool: Option<Duration>,
     /// The maximum number of storage slots that can be expected to be used by a user operation during validation
     pub max_expected_storage_slots: usize,
-    /// Whether to enable the revert check
-    pub revert_check_enabled: bool,
+    /// Whether to enable the revert check and the mode to use
+    pub revert_check_mode: Option<RevertCheckMode>,
 }
 
 /// Origin of an operation.

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -173,16 +173,14 @@ pub struct PoolConfig {
     pub drop_min_num_blocks: u64,
     /// Reject user operations with gas limit efficiency below this threshold.
     /// Gas limit efficiency is defined as the ratio of the gas limit to the gas used.
-    /// This applies to the execution gas limit.
-    pub execution_gas_limit_efficiency_reject_threshold: f64,
-    /// Reject user operations with gas limit efficiency below this threshold.
-    /// Gas limit efficiency is defined as the ratio of the gas limit to the gas used.
     /// This applies to the verification gas limit.
     pub verification_gas_limit_efficiency_reject_threshold: f64,
     /// Maximum time a UO is allowed in the pool before being dropped
     pub max_time_in_pool: Option<Duration>,
     /// The maximum number of storage slots that can be expected to be used by a user operation during validation
     pub max_expected_storage_slots: usize,
+    /// Whether to enable the revert check
+    pub revert_check_enabled: bool,
 }
 
 /// Origin of an operation.

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -21,7 +21,7 @@ mod size;
 
 mod paymaster;
 pub(crate) use paymaster::{PaymasterConfig, PaymasterTracker};
-use rundler_provider::RevertCheckMode;
+use rundler_provider::RevertCheckCallType;
 
 mod uo_pool;
 use std::{
@@ -181,7 +181,7 @@ pub struct PoolConfig {
     /// The maximum number of storage slots that can be expected to be used by a user operation during validation
     pub max_expected_storage_slots: usize,
     /// Whether to enable the revert check and the mode to use
-    pub revert_check_mode: Option<RevertCheckMode>,
+    pub revert_check_call_type: Option<RevertCheckCallType>,
 }
 
 /// Origin of an operation.

--- a/crates/provider/src/alloy/entry_point/mod.rs
+++ b/crates/provider/src/alloy/entry_point/mod.rs
@@ -12,11 +12,19 @@
 // If not, see https://www.gnu.org/licenses/.
 
 use alloy_consensus::{transaction::SignableTransaction, TxEnvelope, TypedTransaction};
-use alloy_primitives::{address, Address, Bytes, Signature, U256};
-use alloy_provider::network::TransactionBuilder7702;
+use alloy_primitives::{address, Address, Bytes, Log, LogData, Signature, U256};
+use alloy_provider::{ext::DebugApi, network::TransactionBuilder7702};
 use alloy_rlp::Encodable;
-use alloy_rpc_types_eth::TransactionRequest;
-use rundler_types::authorization::Eip7702Auth;
+use alloy_rpc_types_eth::{
+    simulate::{SimBlock, SimulatePayload},
+    BlockId, TransactionRequest,
+};
+use alloy_rpc_types_trace::geth::{
+    CallConfig, GethDebugBuiltInTracerType, GethDebugTracerType, GethDebugTracingOptions, GethTrace,
+};
+use rundler_types::{authorization::Eip7702Auth, chain::ChainSpec};
+
+use crate::{AlloyProvider, ProviderResult};
 
 pub(crate) mod v0_6;
 pub(crate) mod v0_7;
@@ -74,4 +82,103 @@ fn max_bundle_transaction_data(
             panic!("transaction is neither EIP-1559 nor EIP-7702");
         }
     }
+}
+
+struct SimulateResult {
+    gas_used: u128,
+    success: bool,
+    data: Bytes,
+    logs: Vec<Log>,
+}
+
+async fn simulate_transaction<P: AlloyProvider>(
+    provider: &P,
+    chain_spec: &ChainSpec,
+    tx: TransactionRequest,
+    block_id: BlockId,
+) -> ProviderResult<SimulateResult> {
+    if chain_spec.rpc_eth_simulate_v1_enabled {
+        simulate_with_simulate_v1(provider, tx, block_id).await
+    } else if chain_spec.rpc_debug_trace_call_enabled {
+        simulate_with_debug_trace_call(provider, tx, block_id).await
+    } else {
+        Err(
+            anyhow::anyhow!("either eth_simulateV1 or debug_traceCall must be enabled to simulate")
+                .into(),
+        )
+    }
+}
+
+async fn simulate_with_simulate_v1<P: AlloyProvider>(
+    provider: &P,
+    tx: TransactionRequest,
+    block_id: BlockId,
+) -> ProviderResult<SimulateResult> {
+    let payload = SimulatePayload {
+        block_state_calls: vec![SimBlock {
+            block_overrides: None,
+            state_overrides: None,
+            calls: vec![tx],
+        }],
+        trace_transfers: false,
+        validation: false,
+        return_full_transactions: false,
+    };
+
+    let result = provider.simulate(&payload).block_id(block_id).await?;
+    if result.len() != 1 {
+        return Err(anyhow::anyhow!("expected 1 simulated block, got {}", result.len()).into());
+    }
+    if result[0].calls.len() != 1 {
+        return Err(anyhow::anyhow!("expected 1 call, got {}", result[0].calls.len()).into());
+    }
+    let result_call = &result[0].calls[0];
+
+    Ok(SimulateResult {
+        gas_used: result_call.gas_used.into(),
+        success: result_call.status,
+        data: result_call.return_data.clone(),
+        logs: result_call
+            .logs
+            .clone()
+            .into_iter()
+            .map(|log| log.inner)
+            .collect(),
+    })
+}
+
+async fn simulate_with_debug_trace_call<P: AlloyProvider>(
+    provider: &P,
+    tx: TransactionRequest,
+    block_id: BlockId,
+) -> ProviderResult<SimulateResult> {
+    let trace_options = GethDebugTracingOptions::new_tracer(GethDebugTracerType::BuiltInTracer(
+        GethDebugBuiltInTracerType::CallTracer,
+    ))
+    .with_call_config(CallConfig::default().with_log());
+
+    let trace = provider
+        .debug_trace_call(tx.into(), block_id, trace_options.into())
+        .await?;
+
+    let GethTrace::CallTracer(call_frame) = trace else {
+        return Err(anyhow::anyhow!("expected call tracer, got {:?}", trace).into());
+    };
+
+    Ok(SimulateResult {
+        gas_used: call_frame.gas_used.try_into().unwrap_or(u128::MAX),
+        success: call_frame.revert_reason.is_none(),
+        data: call_frame.output.unwrap_or_default(),
+        logs: call_frame
+            .logs
+            .iter()
+            .filter_map(|log| {
+                let address = log.address?;
+                let topics = log.clone().topics?;
+                let data = log.clone().data?;
+                let data = LogData::new(topics, data)?;
+                Some(Log { address, data })
+            })
+            .collect(),
+    })
 }

--- a/crates/provider/src/alloy/entry_point/mod.rs
+++ b/crates/provider/src/alloy/entry_point/mod.rs
@@ -26,7 +26,7 @@ use alloy_rpc_types_trace::geth::{
 use rundler_types::authorization::Eip7702Auth;
 use rundler_utils::json_rpc;
 
-use crate::{AlloyProvider, ProviderResult, RevertCheckMode};
+use crate::{AlloyProvider, ProviderResult, RevertCheckCallType};
 
 pub(crate) mod v0_6;
 pub(crate) mod v0_7;
@@ -97,12 +97,14 @@ async fn simulate_transaction<P: AlloyProvider>(
     provider: &P,
     tx: TransactionRequest,
     block_id: BlockId,
-    revert_check_mode: RevertCheckMode,
+    revert_check_call_type: RevertCheckCallType,
 ) -> ProviderResult<SimulateResult> {
-    match revert_check_mode {
-        RevertCheckMode::EthCall => simulate_with_eth_call(provider, tx, block_id).await,
-        RevertCheckMode::EthSimulateV1 => simulate_with_simulate_v1(provider, tx, block_id).await,
-        RevertCheckMode::DebugTraceCall => {
+    match revert_check_call_type {
+        RevertCheckCallType::EthCall => simulate_with_eth_call(provider, tx, block_id).await,
+        RevertCheckCallType::EthSimulateV1 => {
+            simulate_with_simulate_v1(provider, tx, block_id).await
+        }
+        RevertCheckCallType::DebugTraceCall => {
             simulate_with_debug_trace_call(provider, tx, block_id).await
         }
     }

--- a/crates/provider/src/alloy/entry_point/v0_6.rs
+++ b/crates/provider/src/alloy/entry_point/v0_6.rs
@@ -45,7 +45,7 @@ use tracing::instrument;
 use crate::{
     AggregatorOut, AggregatorSimOut, AlloyProvider, BlockHashOrNumber, BundleHandler, DAGasOracle,
     DAGasProvider, DepositInfo, EntryPoint, EntryPointProvider as EntryPointProviderTrait,
-    ExecutionResult, HandleOpRevert, HandleOpsOut, ProviderResult, RevertCheckMode,
+    ExecutionResult, HandleOpRevert, HandleOpsOut, ProviderResult, RevertCheckCallType,
     SignatureAggregator, SimulationProvider, TransactionRequest,
 };
 
@@ -510,7 +510,7 @@ where
         &self,
         op: Self::UO,
         block_id: BlockId,
-        revert_check_mode: RevertCheckMode,
+        revert_check_call_type: RevertCheckCallType,
     ) -> ProviderResult<Result<u128, HandleOpRevert>> {
         let mut state_override = StateOverride::default();
         let da_gas = op
@@ -539,7 +539,7 @@ where
             self.i_entry_point.provider(),
             tx,
             block_id,
-            revert_check_mode,
+            revert_check_call_type,
         )
         .await?;
 
@@ -561,6 +561,9 @@ where
                             ValidationRevert::EntryPoint(e),
                         )));
                     }
+                }
+                ValidationRevert::Unknown(data) => {
+                    return Ok(Err(HandleOpRevert::TransactionRevert(data)));
                 }
                 _ => return Ok(Err(HandleOpRevert::ValidationRevert(revert))),
             }

--- a/crates/provider/src/alloy/entry_point/v0_6.rs
+++ b/crates/provider/src/alloy/entry_point/v0_6.rs
@@ -510,8 +510,9 @@ where
         &self,
         op: Self::UO,
         block_id: BlockId,
+        sender_eoa: Address,
     ) -> ProviderResult<Result<u128, HandleOpRevert>> {
-        // TODO: handle aggregators. Signatures & proxies are going to be a bit tricky.
+        // TODO(revert): handle aggregators. Signatures & proxies are going to be a bit tricky.
 
         let tx = get_handle_ops_call(
             &self.i_entry_point,
@@ -520,7 +521,7 @@ where
                 aggregator: Address::ZERO,
                 signature: Bytes::new(),
             }],
-            Address::random(),
+            sender_eoa,
             None,
             GasFees::default(),
             None,

--- a/crates/provider/src/alloy/entry_point/v0_7.rs
+++ b/crates/provider/src/alloy/entry_point/v0_7.rs
@@ -573,8 +573,9 @@ where
         &self,
         op: Self::UO,
         block_id: BlockId,
+        sender_eoa: Address,
     ) -> ProviderResult<Result<u128, HandleOpRevert>> {
-        // TODO: handle aggregators. Signatures & proxies are going to be a bit tricky.
+        // TODO(revert): handle aggregators. Signatures & proxies are going to be a bit tricky.
 
         let tx = get_handle_ops_call(
             &self.i_entry_point,
@@ -583,7 +584,7 @@ where
                 aggregator: Address::ZERO,
                 signature: Bytes::new(),
             }],
-            Address::random(),
+            sender_eoa,
             None,
             GasFees::default(),
             None,

--- a/crates/provider/src/traits/entry_point.rs
+++ b/crates/provider/src/traits/entry_point.rs
@@ -217,6 +217,17 @@ pub trait DAGasProvider: Send + Sync {
     ) -> ProviderResult<(u128, DAGasData, DAGasBlockData)>;
 }
 
+/// Mode for checking for reverts during simulation
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum RevertCheckMode {
+    /// Use eth_call to check for reverts
+    EthCall,
+    /// Use eth_simulateV1 to check for reverts
+    EthSimulateV1,
+    /// Use debug_traceCall to check for reverts
+    DebugTraceCall,
+}
+
 /// Trait for simulating user operations on an entry point contract
 #[async_trait::async_trait]
 #[auto_impl::auto_impl(&, &mut, Rc, Arc, Box)]
@@ -263,7 +274,7 @@ pub trait SimulationProvider: Send + Sync {
         &self,
         op: Self::UO,
         block_id: BlockId,
-        sender_eoa: Address,
+        revert_check_mode: RevertCheckMode,
     ) -> ProviderResult<Result<u128, HandleOpRevert>>;
 
     /// Decode the revert data from a call to `simulateHandleOps`

--- a/crates/provider/src/traits/entry_point.rs
+++ b/crates/provider/src/traits/entry_point.rs
@@ -263,6 +263,7 @@ pub trait SimulationProvider: Send + Sync {
         &self,
         op: Self::UO,
         block_id: BlockId,
+        sender_eoa: Address,
     ) -> ProviderResult<Result<u128, HandleOpRevert>>;
 
     /// Decode the revert data from a call to `simulateHandleOps`

--- a/crates/provider/src/traits/entry_point.rs
+++ b/crates/provider/src/traits/entry_point.rs
@@ -106,6 +106,8 @@ pub enum HandleOpRevert {
         /// String reason for the revert, if available
         reason: Option<String>,
     },
+    /// The transaction revert for unknown reason
+    TransactionRevert(Bytes),
 }
 
 /// Trait for interacting with an entry point contract.
@@ -219,7 +221,7 @@ pub trait DAGasProvider: Send + Sync {
 
 /// Mode for checking for reverts during simulation
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub enum RevertCheckMode {
+pub enum RevertCheckCallType {
     /// Use eth_call to check for reverts
     EthCall,
     /// Use eth_simulateV1 to check for reverts
@@ -274,7 +276,7 @@ pub trait SimulationProvider: Send + Sync {
         &self,
         op: Self::UO,
         block_id: BlockId,
-        revert_check_mode: RevertCheckMode,
+        revert_check_call_type: RevertCheckCallType,
     ) -> ProviderResult<Result<u128, HandleOpRevert>>;
 
     /// Decode the revert data from a call to `simulateHandleOps`

--- a/crates/provider/src/traits/test_utils.rs
+++ b/crates/provider/src/traits/test_utils.rs
@@ -30,8 +30,9 @@ use super::error::ProviderResult;
 use crate::{
     AggregatorOut, Block, BlockHashOrNumber, BundleHandler, DAGasOracle, DAGasOracleSync,
     DAGasProvider, DepositInfo, EntryPoint, EntryPointProvider, EvmCall,
-    EvmProvider as EvmProviderTrait, ExecutionResult, FeeEstimator, HandleOpsOut, RpcRecv, RpcSend,
-    SignatureAggregator, SimulationProvider, Transaction, TransactionReceipt, TransactionRequest,
+    EvmProvider as EvmProviderTrait, ExecutionResult, FeeEstimator, HandleOpRevert, HandleOpsOut,
+    RpcRecv, RpcSend, SignatureAggregator, SimulationProvider, Transaction, TransactionReceipt,
+    TransactionRequest,
 };
 
 mockall::mock! {
@@ -185,6 +186,11 @@ mockall::mock! {
             block_id: BlockId,
             state_override: StateOverride,
         ) -> ProviderResult<Result<ExecutionResult, ValidationRevert>>;
+        async fn simulate_handle_op_revert_check(
+            &self,
+            op: v0_6::UserOperation,
+            block_id: BlockId,
+        ) -> ProviderResult<Result<u128, HandleOpRevert>>;
         fn decode_simulate_handle_ops_revert(
             revert_data: &Bytes,
         ) -> ProviderResult<Result<ExecutionResult, ValidationRevert>>;
@@ -289,6 +295,11 @@ mockall::mock! {
             block_id: BlockId,
             state_override: StateOverride,
         ) -> ProviderResult<Result<ExecutionResult, ValidationRevert>>;
+        async fn simulate_handle_op_revert_check(
+            &self,
+            op: v0_7::UserOperation,
+            block_id: BlockId,
+        ) -> ProviderResult<Result<u128, HandleOpRevert>>;
         fn decode_simulate_handle_ops_revert(
             revert_data: &Bytes,
         ) -> ProviderResult<Result<ExecutionResult, ValidationRevert>>;

--- a/crates/provider/src/traits/test_utils.rs
+++ b/crates/provider/src/traits/test_utils.rs
@@ -190,6 +190,7 @@ mockall::mock! {
             &self,
             op: v0_6::UserOperation,
             block_id: BlockId,
+            sender_eoa: Address,
         ) -> ProviderResult<Result<u128, HandleOpRevert>>;
         fn decode_simulate_handle_ops_revert(
             revert_data: &Bytes,
@@ -299,6 +300,7 @@ mockall::mock! {
             &self,
             op: v0_7::UserOperation,
             block_id: BlockId,
+            sender_eoa: Address,
         ) -> ProviderResult<Result<u128, HandleOpRevert>>;
         fn decode_simulate_handle_ops_revert(
             revert_data: &Bytes,

--- a/crates/provider/src/traits/test_utils.rs
+++ b/crates/provider/src/traits/test_utils.rs
@@ -31,7 +31,7 @@ use crate::{
     AggregatorOut, Block, BlockHashOrNumber, BundleHandler, DAGasOracle, DAGasOracleSync,
     DAGasProvider, DepositInfo, EntryPoint, EntryPointProvider, EvmCall,
     EvmProvider as EvmProviderTrait, ExecutionResult, FeeEstimator, HandleOpRevert, HandleOpsOut,
-    RevertCheckMode, RpcRecv, RpcSend, SignatureAggregator, SimulationProvider, Transaction,
+    RevertCheckCallType, RpcRecv, RpcSend, SignatureAggregator, SimulationProvider, Transaction,
     TransactionReceipt, TransactionRequest,
 };
 
@@ -190,7 +190,7 @@ mockall::mock! {
             &self,
             op: v0_6::UserOperation,
             block_id: BlockId,
-            revert_check_mode: RevertCheckMode,
+            revert_check_call_type: RevertCheckCallType,
         ) -> ProviderResult<Result<u128, HandleOpRevert>>;
         fn decode_simulate_handle_ops_revert(
             revert_data: &Bytes,
@@ -300,7 +300,7 @@ mockall::mock! {
             &self,
             op: v0_7::UserOperation,
             block_id: BlockId,
-            revert_check_mode: RevertCheckMode,
+            revert_check_call_type: RevertCheckCallType,
         ) -> ProviderResult<Result<u128, HandleOpRevert>>;
         fn decode_simulate_handle_ops_revert(
             revert_data: &Bytes,

--- a/crates/provider/src/traits/test_utils.rs
+++ b/crates/provider/src/traits/test_utils.rs
@@ -31,8 +31,8 @@ use crate::{
     AggregatorOut, Block, BlockHashOrNumber, BundleHandler, DAGasOracle, DAGasOracleSync,
     DAGasProvider, DepositInfo, EntryPoint, EntryPointProvider, EvmCall,
     EvmProvider as EvmProviderTrait, ExecutionResult, FeeEstimator, HandleOpRevert, HandleOpsOut,
-    RpcRecv, RpcSend, SignatureAggregator, SimulationProvider, Transaction, TransactionReceipt,
-    TransactionRequest,
+    RevertCheckMode, RpcRecv, RpcSend, SignatureAggregator, SimulationProvider, Transaction,
+    TransactionReceipt, TransactionRequest,
 };
 
 mockall::mock! {
@@ -190,7 +190,7 @@ mockall::mock! {
             &self,
             op: v0_6::UserOperation,
             block_id: BlockId,
-            sender_eoa: Address,
+            revert_check_mode: RevertCheckMode,
         ) -> ProviderResult<Result<u128, HandleOpRevert>>;
         fn decode_simulate_handle_ops_revert(
             revert_data: &Bytes,
@@ -300,7 +300,7 @@ mockall::mock! {
             &self,
             op: v0_7::UserOperation,
             block_id: BlockId,
-            sender_eoa: Address,
+            revert_check_mode: RevertCheckMode,
         ) -> ProviderResult<Result<u128, HandleOpRevert>>;
         fn decode_simulate_handle_ops_revert(
             revert_data: &Bytes,

--- a/crates/rpc/src/eth/events/common.rs
+++ b/crates/rpc/src/eth/events/common.rs
@@ -335,6 +335,11 @@ where
         tx_hash: B256,
         user_op_hash: B256,
     ) -> anyhow::Result<Option<E::UO>> {
+        if !self.chain_spec.rpc_debug_trace_transaction_enabled {
+            tracing::warn!("Debug trace transaction is not enabled, skipping trace");
+            return Ok(None);
+        }
+
         // initial call wasn't to an entrypoint, so we need to trace the transaction to find the user operation
         let trace_options = GethDebugTracingOptions {
             tracer: Some(GethDebugTracerType::BuiltInTracer(

--- a/crates/types/src/chain.rs
+++ b/crates/types/src/chain.rs
@@ -142,6 +142,16 @@ pub struct ChainSpec {
     pub chain_history_size: u64,
 
     /*
+     * Node RPC
+     */
+    /// True if the node RPC supports eth_simulateV1
+    pub rpc_eth_simulate_v1_enabled: bool,
+    /// True if the node RPC supports debug_traceCall
+    pub rpc_debug_trace_call_enabled: bool,
+    /// True if the node RPC supports debug_traceTransaction
+    pub rpc_debug_trace_transaction_enabled: bool,
+
+    /*
      * Contracts
      */
     /// Registry of signature aggregators
@@ -206,6 +216,9 @@ impl Default for ChainSpec {
             flashbots_relay_url: None,
             bloxroute_enabled: false,
             chain_history_size: 64,
+            rpc_eth_simulate_v1_enabled: true,
+            rpc_debug_trace_call_enabled: true,
+            rpc_debug_trace_transaction_enabled: true,
             signature_aggregators: Arc::new(ContractRegistry::default()),
             submission_proxies: Arc::new(ContractRegistry::default()),
         }
@@ -334,6 +347,11 @@ impl ChainSpec {
     /// Check if the chain supports EIP-7702
     pub fn supports_eip7702(&self, entry_point: Address) -> bool {
         self.eip7702_enabled && entry_point == self.entry_point_address_v0_7
+    }
+
+    /// Check if the chain supports revert checking
+    pub fn supports_revert_check(&self) -> bool {
+        self.rpc_eth_simulate_v1_enabled || self.rpc_debug_trace_call_enabled
     }
 }
 

--- a/crates/types/src/chain.rs
+++ b/crates/types/src/chain.rs
@@ -216,7 +216,7 @@ impl Default for ChainSpec {
             flashbots_relay_url: None,
             bloxroute_enabled: false,
             chain_history_size: 64,
-            rpc_eth_simulate_v1_enabled: true,
+            rpc_eth_simulate_v1_enabled: false,
             rpc_debug_trace_call_enabled: true,
             rpc_debug_trace_transaction_enabled: true,
             signature_aggregators: Arc::new(ContractRegistry::default()),
@@ -347,11 +347,6 @@ impl ChainSpec {
     /// Check if the chain supports EIP-7702
     pub fn supports_eip7702(&self, entry_point: Address) -> bool {
         self.eip7702_enabled && entry_point == self.entry_point_address_v0_7
-    }
-
-    /// Check if the chain supports revert checking
-    pub fn supports_revert_check(&self) -> bool {
-        self.rpc_eth_simulate_v1_enabled || self.rpc_debug_trace_call_enabled
     }
 }
 

--- a/crates/types/src/chain.rs
+++ b/crates/types/src/chain.rs
@@ -144,12 +144,14 @@ pub struct ChainSpec {
     /*
      * Node RPC
      */
-    /// True if the node RPC supports eth_simulateV1
-    pub rpc_eth_simulate_v1_enabled: bool,
-    /// True if the node RPC supports debug_traceCall
-    pub rpc_debug_trace_call_enabled: bool,
     /// True if the node RPC supports debug_traceTransaction
     pub rpc_debug_trace_transaction_enabled: bool,
+
+    /*
+     * Network specific behavior
+     */
+    /// Monad minimum reserve balance for EIP-7702 delegated accounts in MON
+    pub monad_min_reserve_balance: Option<u64>,
 
     /*
      * Contracts
@@ -216,9 +218,8 @@ impl Default for ChainSpec {
             flashbots_relay_url: None,
             bloxroute_enabled: false,
             chain_history_size: 64,
-            rpc_eth_simulate_v1_enabled: false,
-            rpc_debug_trace_call_enabled: true,
             rpc_debug_trace_transaction_enabled: true,
+            monad_min_reserve_balance: None,
             signature_aggregators: Arc::new(ContractRegistry::default()),
             submission_proxies: Arc::new(ContractRegistry::default()),
         }

--- a/crates/types/src/pool/error.rs
+++ b/crates/types/src/pool/error.rs
@@ -11,7 +11,9 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use alloy_primitives::{Address, U256};
+use std::fmt::Display;
+
+use alloy_primitives::{Address, Bytes, U256};
 
 use crate::{
     validation_results::ValidationRevert, Entity, EntityType, StorageSlot, Timestamp,
@@ -38,6 +40,25 @@ impl From<MempoolError> for PoolError {
             MempoolError::Other(e) => Self::Other(e),
             _ => Self::MempoolError(error),
         }
+    }
+}
+
+/// Inner revert data
+#[derive(Debug, Clone)]
+pub struct InnerRevert {
+    /// Revert data
+    pub data: Bytes,
+    /// Revert reason
+    pub reason: Option<String>,
+}
+
+impl Display for InnerRevert {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.reason.as_ref().unwrap_or(&self.data.to_string())
+        )
     }
 }
 
@@ -109,6 +130,12 @@ pub enum MempoolError {
     /// Use unsupported EIP
     #[error("{0} is not supported")]
     EIPNotSupported(String),
+    /// Execution reverted
+    #[error("Execution reverted: {0}")]
+    ExecutionRevert(InnerRevert),
+    /// Post op reverted
+    #[error("Post op reverted: {0}")]
+    PostOpRevert(InnerRevert),
 }
 
 /// Precheck violation enumeration

--- a/crates/utils/src/json_rpc.rs
+++ b/crates/utils/src/json_rpc.rs
@@ -11,23 +11,12 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-#![warn(missing_docs, unreachable_pub, unused_crate_dependencies)]
-#![deny(unused_must_use, rust_2018_idioms)]
-#![doc(test(
-    no_crate_inject,
-    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
-))]
+//! JSON-RPC utilities
 
-//! Rundler utilities
+/// The error code for internal errors in JSON-RPC responses
+pub const INTERNAL_ERROR_CODE: i64 = -32603;
 
-pub mod authorization_utils;
-pub mod cache;
-pub mod emit;
-pub mod eth;
-pub mod guard_timer;
-pub mod json_rpc;
-pub mod log;
-pub mod math;
-pub mod random;
-pub mod retry;
-pub mod strs;
+/// Check if a JSON-RPC response indicates an execution revert
+pub fn check_execution_reverted(message: &str) -> bool {
+    message == "execution reverted"
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,8 +62,6 @@ See [chain spec](./architecture/chain_spec.md) for a detailed description of cha
   - env: *BASE_FEE_ACCEPT_PERCENT*
 - `--pre_verification_gas_accept_percent`: Percentage of the required PVG that a user operation must have in order to be accepted into the mempool. Only applies if there is dynamic PVG, else the full amount is required. (default: `50`)
   - env: *PRE_VERIFICATION_GAS_ACCEPT_PERCENT*
-- `--execution_gas_limit_efficiency_reject_threshold`: The ratio of execution gas used to gas limit under which to reject UOs upon entry to the mempool (default: `0.0` disabled)
-  - env: *EXECUTION_GAS_LIMIT_EFFICIENCY_REJECT_THRESHOLD*
 - `--verification_gas_limit_efficiency_reject_threshold`: The ratio of verification gas used to gas limit under which to reject UOs upon entry to the mempool (default: `0.0` disabled)
   - env: *VERIFICATION_GAS_LIMIT_EFFICIENCY_REJECT_THRESHOLD*
 - `--verification_gas_allowed_error_pct`: The allowed error percentage during verification gas estimation. (default: 15)
@@ -206,6 +204,8 @@ List of command line options for configuring the Pool.
   - env: *POOL_DROP_MIN_NUM_BLOCKS*
 - `--pool.max_time_in_pool_secs`: The maximum amount of time a UO is allowed to be in the mempool, in seconds. (default: `None`)
   - env: *POOL_MAX_TIME_IN_POOL_SECS*
+- `--pool.disable_revert_check`: Disable the pool's revert check. (default: `false`)
+  - env: *POOL_DISABLE_REVERT_CHECK*
 
 ## Builder Options
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,150 +20,152 @@ These options are common to all subcommands and can be used globally:
 See [chain spec](./architecture/chain_spec.md) for a detailed description of chain spec derivation from these options.
 
 - `--network`: Network to look up a hardcoded chain spec. (default: None)
-  - env: *NETWORK*
+  - env: _NETWORK_
 - `--chain_spec`: Path to a chain spec TOML file.
-  - env: *CHAIN_SPEC*
+  - env: _CHAIN_SPEC_
 - (env only): Chain specification overrides.
-  - env: *CHAIN_**
+  - env: \*CHAIN\_\*\*
 
 ### Rundler Common
 
 - `--node_http`: EVM Node HTTP URL to use. (**REQUIRED**)
-  - env: *NODE_HTTP*
+  - env: _NODE_HTTP_
 - `--max_verification_gas`: Maximum verification gas. (default: `5000000`).
-  - env: *MAX_VERIFICATION_GAS*
+  - env: _MAX_VERIFICATION_GAS_
 - `--max_uo_cost`: Maximum cost of a UO that the mempool will accept. Optional, defaults to MAX (default: `None`).
-  - env: *MAX_UO_COST*
+  - env: _MAX_UO_COST_
 - `--min_stake_value`: Minimum stake value. (default: `1000000000000000000`).
-  - env: *MIN_STAKE_VALUE*
+  - env: _MIN_STAKE_VALUE_
 - `--min_unstake_delay`: Minimum unstake delay. (default: `86400`).
-  - env: *MIN_UNSTAKE_DELAY*
+  - env: _MIN_UNSTAKE_DELAY_
 - `--tracer_timeout`: The timeout used for custom javascript tracers, the string must be in a valid parseable format that can be used in the `ParseDuration` function on an ethereum node. See Docs [Here](https://pkg.go.dev/time#ParseDuration). (default: `15s`)
-  - env: *TRACER_TIMEOUT*
+  - env: _TRACER_TIMEOUT_
 - `--enable_unsafe_fallback`: If set, allows the simulation code to fallback to an unsafe simulation if there is a tracer error. (default: `false`)
-  - env: *ENABLE_UNSAFE_FALLBACK*
+  - env: _ENABLE_UNSAFE_FALLBACK_
 - `--user_operation_event_block_distance`: Number of blocks to search when calling `eth_getUserOperationByHash`/`eth_getUserOperationReceipt`. (default: all blocks)
-  - env: *USER_OPERATION_EVENT_BLOCK_DISTANCE*
+  - env: _USER_OPERATION_EVENT_BLOCK_DISTANCE_
 - `--user_operation_event_block_distance_fallback`: Number of blocks to search when falling back during `eth_getUserOperationByHash`/`eth_getUserOperationReceipt` upon initial failure using `user_operation_event_block_distance`. (default: None)
-  - env: *USER_OPERATION_EVENT_BLOCK_DISTANCE_FALLBACK*
+  - env: _USER_OPERATION_EVENT_BLOCK_DISTANCE_FALLBACK_
 - `--verification_estimation_gas_fee`: The gas fee to use during verification estimation. (default: `1000000000000` 10K gwei).
-  - env: *VERIFICATION_ESTIMATION_GAS_FEE*
+  - env: _VERIFICATION_ESTIMATION_GAS_FEE_
   - See [RPC documentation](./architecture/rpc.md#verificationGasLimit-estimation) for details.
 - `--bundle_base_fee_overhead_percent`: bundle transaction base fee overhead over network pending value. (default: `27`).
-  - env: *BUNDLE_BASE_FEE_OVERHEAD_PERCENT*
+  - env: _BUNDLE_BASE_FEE_OVERHEAD_PERCENT_
 - `--bundle_priority_fee_overhead_percent`: bundle transaction priority fee overhead over network value. (default: `0`).
-  - env: *BUNDLE_PRIORITY_FEE_OVERHEAD_PERCENT*
+  - env: _BUNDLE_PRIORITY_FEE_OVERHEAD_PERCENT_
 - `--priority_fee_mode_kind`: Priority fee mode kind. Possible values are `base_fee_percent` and `priority_fee_increase_percent`. (default: `priority_fee_increase_percent`).
   - options: ["base_fee_percent", "priority_fee_increase_percent"]
-  - env: *PRIORITY_FEE_MODE_KIND*
+  - env: _PRIORITY_FEE_MODE_KIND_
 - `--priority_fee_mode_value`: Priority fee mode value. (default: `0`).
-  - env: *PRIORITY_FEE_MODE_VALUE*
+  - env: _PRIORITY_FEE_MODE_VALUE_
 - `--base_fee_accept_percent`: Percentage of the current network fees a user operation must have in order to be accepted into the mempool. (default: `100`).
-  - env: *BASE_FEE_ACCEPT_PERCENT*
+  - env: _BASE_FEE_ACCEPT_PERCENT_
 - `--pre_verification_gas_accept_percent`: Percentage of the required PVG that a user operation must have in order to be accepted into the mempool. Only applies if there is dynamic PVG, else the full amount is required. (default: `50`)
-  - env: *PRE_VERIFICATION_GAS_ACCEPT_PERCENT*
+  - env: _PRE_VERIFICATION_GAS_ACCEPT_PERCENT_
 - `--verification_gas_limit_efficiency_reject_threshold`: The ratio of verification gas used to gas limit under which to reject UOs upon entry to the mempool (default: `0.0` disabled)
-  - env: *VERIFICATION_GAS_LIMIT_EFFICIENCY_REJECT_THRESHOLD*
+  - env: _VERIFICATION_GAS_LIMIT_EFFICIENCY_REJECT_THRESHOLD_
 - `--verification_gas_allowed_error_pct`: The allowed error percentage during verification gas estimation. (default: 15)
-  - env: *VERIFICATION_GAS_ALLOWED_ERROR_PCT*
+  - env: _VERIFICATION_GAS_ALLOWED_ERROR_PCT_
 - `--call_gas_allowed_error_pct`: The allowed error percentage during call gas estimation. (default: 15)
-  - env: *CALL_GAS_ALLOWED_ERROR_PCT*
+  - env: _CALL_GAS_ALLOWED_ERROR_PCT_
 - `--max_gas_estimation_gas`: The gas limit to use during the call to the gas estimation binary search helper functions. (default: 550M)
-  - env: *MAX_GAS_ESTIMATION_GAS*
+  - env: _MAX_GAS_ESTIMATION_GAS_
 - `--max_gas_estimation_rounds`: The maximum amount of remote RPC calls to make during gas estimation while attempting to converge to the error percentage. (default: 3)
-  - env: *MAX_GAS_ESTIMATION_ROUNDS*
+  - env: _MAX_GAS_ESTIMATION_ROUNDS_
 - `--aws_region`: AWS region. (default: `us-east-1`).
-  - env: *AWS_REGION*
-  - (*Only required if using other AWS features*)
+  - env: _AWS_REGION_
+  - (_Only required if using other AWS features_)
 - `--unsafe`: Flag for unsafe bundling mode. When set Rundler will skip checking simulation rules (and any `debug_traceCall`). (default: `false`).
-  - env: *UNSAFE*
+  - env: _UNSAFE_
 - `--mempool_config_path`: Path to the mempool configuration file. (example: `mempool-config.json`, `s3://my-bucket/mempool-config.json`). (default: `None`)
-  - This path can either be a local file path or an S3 url. If using an S3 url, Make sure your machine has access to this file. 
-  - env: *MEMPOOL_CONFIG_PATH*
+  - This path can either be a local file path or an S3 url. If using an S3 url, Make sure your machine has access to this file.
+  - env: _MEMPOOL_CONFIG_PATH_
   - See [here](./architecture/pool.md#alternative-mempools-in-preview) for details.
 - `--entry_point_builders_path`: Path to the entry point builders configuration file (example: `builders.json`, `s3://my-bucket/builders.json`). (default: `None`)
   - This path can either be a local file path or an S3 url. If using an S3 url, Make sure your machine has access to this file.
-  - env: *ENTRY_POINT_BUILDERS_PATH*
+  - env: _ENTRY_POINT_BUILDERS_PATH_
   - NOTE: most deployments can ignore this and use the settings below.
   - See [here](./architecture/builder.md#custom) for details.
 - `--disable_entry_point_v0_6`: Disable entry point v0.6 support. (default: `false`).
-  - env: *DISABLE_ENTRY_POINT_V0_6*
+  - env: _DISABLE_ENTRY_POINT_V0_6_
 - `--num_builders_v0_6`: The number of bundle builders to run on entry point v0.6 (default: `1`)
-  - env: *NUM_BUILDERS_V0_6*
+  - env: _NUM_BUILDERS_V0_6_
   - NOTE: ignored if `entry_point_builders_path` is set
 - `--disable_entry_point_v0_7`: Disable entry point v0.7 support. (default: `false`).
-  - env: *DISABLE_ENTRY_POINT_V0_7*
+  - env: _DISABLE_ENTRY_POINT_V0_7_
 - `--num_builders_v0_7`: The number of bundle builders to run on entry point v0.7 (default: `1`)
-  - env: *NUM_BUILDERS_V0_7*
+  - env: _NUM_BUILDERS_V0_7_
   - NOTE: ignored if `entry_point_builders_path` is set
 - `--da_gas_tracking_enabled`: Enable the DA gas tracking feature of the mempool (default: `false`)
-  - env: *DA_GAS_TRACKING_ENABLED*
+  - env: _DA_GAS_TRACKING_ENABLED_
 - `--max_expected_storage_slots`: Optionally set the maximum number of expected storage slots to submit with a conditional transaction. (default: `None`)
-  - env: *MAX_EXPECTED_STORAGE_SLOTS*
+  - env: _MAX_EXPECTED_STORAGE_SLOTS_
 - `--enabled_aggregators`: List of enabled aggregators.
-  - env: *ENABLED_AGGREGATORS*
+  - env: _ENABLED_AGGREGATORS_
   - Types: see [aggregator.rs](../bin/rundler/src/cli/aggregator.rs)
 - `--aggregator_options`: List of aggregator specific options
-  - env: *ENABLED_AGGREGATORS*
+  - env: _ENABLED_AGGREGATORS_
   - List of KEY=VALUE delimited by ',': i.e. `ENABLED_AGGREGATORS="KEY1=VALUE1,KEY2=VALUE2"`
   - Options: see [aggregator.rs](../bin/rundler/src/cli/aggregator.rs)
 - `--provider_client_timeout_seconds`: Timeout in seconds of external provider RPC requests (default: `10`)
-  - env: *PROVIDER_CLIENT_TIMEOUT_SECONDS*
+  - env: _PROVIDER_CLIENT_TIMEOUT_SECONDS_
 - `--provider_rate_limit_retry_enabled`: Enable retries on rate limit errors - with default backoff settings (default: `false`)
-  - env: *PROVIDER_RATE_LIMIT_RETRY_ENABLED*
+  - env: _PROVIDER_RATE_LIMIT_RETRY_ENABLED_
 - `--provider_consistency_retry_enabled`: Enable retries on block consistency errors - with default backoff settings (default: `false`)
-  - env: *PROVIDER_CONSISTENCY_RETRY_ENABLED*
+  - env: _PROVIDER_CONSISTENCY_RETRY_ENABLED_
+- `--revert_check_call_type`: Enable revert checking with the specified call type. Options: [eth_simulateV1, debug_traceCall, eth_call] (default: `None`)
+  - eng: _REVERT_CHECK_CALL_TYPE_
 
 ## Metrics Options
 
 Options for the metrics server:
 
 - `--metrics.port`: Port to listen on for metrics requests. default: `8080`.
-  - env: *METRICS_PORT*
+  - env: _METRICS_PORT_
 - `--metrics.host`: Host to listen on for metrics requests. default: `0.0.0.0`.
-  - env: *METRICS_HOST*
+  - env: _METRICS_HOST_
 - `--metrics.tags`: Tags for metrics in the format `key1=value1,key2=value2,...`.
-  - env: *METRICS_TAGS*
+  - env: _METRICS_TAGS_
 - `--metrics.sample_interval_millis`: Sample interval to use for sampling metrics. default: `1000`.
-  - env: *METRICS_SAMPLE_INTERVAL_MILLIS*
+  - env: _METRICS_SAMPLE_INTERVAL_MILLIS_
 
 ## Logging Options
 
 Options for logging:
 
 - `RUST_LOG` environment variable is used for controlling log level see: [env_logger](https://docs.rs/env_logger/0.10.1/env_logger/#enabling-logging).
-Only `level` is supported.
+  Only `level` is supported.
 - `--log.file`: Log file. If not provided, logs will be written to stdout.
-  - env: *LOG_FILE*
+  - env: _LOG_FILE_
 - `--log.json`: If set, logs will be written in JSON format.
-  - env: *LOG_JSON*
- - `--log.otlp_grpc_endpoint`: If set, tracing spans will be forwarded to the provided gRPC OTLP endpoint.
-  - env: *LOG_OTLP_GRPC_ENDPOINT*
+  - env: _LOG_JSON_
+- `--log.otlp_grpc_endpoint`: If set, tracing spans will be forwarded to the provided gRPC OTLP endpoint.
+- env: _LOG_OTLP_GRPC_ENDPOINT_
 
 ## RPC Options
 
 List of command line options for configuring the RPC API.
 
-- `--rpc.port`:	Port to listen on for JSON-RPC requests (default: `3000`)
-  - env: *RPC_PORT*
-- `--rpc.host`:	Host to listen on for JSON-RPC requests (default: `0.0.0.0`)
-  - env: *RPC_HOST*
-- `--rpc.api`:	Which APIs to expose over the RPC interface (default: `eth,rundler`)
-  - env: *RPC_API*
-- `--rpc.timeout_seconds`:	Timeout for RPC requests (default: `20`)
-  - env: *RPC_TIMEOUT_SECONDS*
-- `--rpc.max_connections`:	Maximum number of concurrent connections (default: `100`)
-  - env: *RPC_MAX_CONNECTIONS*
+- `--rpc.port`: Port to listen on for JSON-RPC requests (default: `3000`)
+  - env: _RPC_PORT_
+- `--rpc.host`: Host to listen on for JSON-RPC requests (default: `0.0.0.0`)
+  - env: _RPC_HOST_
+- `--rpc.api`: Which APIs to expose over the RPC interface (default: `eth,rundler`)
+  - env: _RPC_API_
+- `--rpc.timeout_seconds`: Timeout for RPC requests (default: `20`)
+  - env: _RPC_TIMEOUT_SECONDS_
+- `--rpc.max_connections`: Maximum number of concurrent connections (default: `100`)
+  - env: _RPC_MAX_CONNECTIONS_
 - `--rpc.corsdomain`: Enable the cors functionality on the server (default: None and therefore corsdomain is disabled).
-  - env: *RPC_CORSDOMAIN*
-- `--rpc.pool_url`:	Pool URL for RPC (default: `http://localhost:50051`)
-  - env: *RPC_POOL_URL*
-  - *Only required when running in distributed mode* 
-- `--rpc.builder_url`:	Builder URL for RPC (default: `http://localhost:50052`)
-  - env: *RPC_BUILDER_URL*
-  - *Only required when running in distributed mode* 
+  - env: _RPC_CORSDOMAIN_
+- `--rpc.pool_url`: Pool URL for RPC (default: `http://localhost:50051`)
+  - env: _RPC_POOL_URL_
+  - _Only required when running in distributed mode_
+- `--rpc.builder_url`: Builder URL for RPC (default: `http://localhost:50052`)
+  - env: _RPC_BUILDER_URL_
+  - _Only required when running in distributed mode_
 - `--rpc.permissions_enabled`: True if user operation permissions are enabled on the RPC API (default: `false`)
-  - env: *RPC_PERMISSIONS_ENABLED
+  - env: \*RPC_PERMISSIONS_ENABLED
   - **NOTE: Do not enable this on a public API - for internal, trusted connections only.**
 
 ## Pool Options
@@ -171,115 +173,114 @@ List of command line options for configuring the RPC API.
 List of command line options for configuring the Pool.
 
 - `--pool.port`: Port to listen on for gRPC requests (default: `50051`)
-  - env: *POOL_PORT*
-  - *Only required when running in distributed mode* 
+  - env: _POOL_PORT_
+  - _Only required when running in distributed mode_
 - `--pool.host`: Host to listen on for gRPC requests (default: `127.0.0.1`)
-  - env: *POOL_HOST*
-  - *Only required when running in distributed mode* 
+  - env: _POOL_HOST_
+  - _Only required when running in distributed mode_
 - `--pool.max_size_in_bytes`: Maximum size in bytes for the pool (default: `500000000`, `0.5 GB`)
-  - env: *POOL_MAX_SIZE_IN_BYTES*
+  - env: _POOL_MAX_SIZE_IN_BYTES_
 - `--pool.same_sender_mempool_count`: Maximum number of user operations for an unstaked sender (default: `4`)
-  - env: *POOL_SAME_SENDER_MEMPOOL_COUNT*
+  - env: _POOL_SAME_SENDER_MEMPOOL_COUNT_
 - `--pool.min_replacement_fee_increase_percentage`: Minimum replacement fee increase percentage (default: `10`)
-  - env: *POOL_MIN_REPLACEMENT_FEE_INCREASE_PERCENTAGE*
+  - env: _POOL_MIN_REPLACEMENT_FEE_INCREASE_PERCENTAGE_
 - `--pool.blocklist_path`: Path to a blocklist file (e.g `blocklist.json`, `s3://my-bucket/blocklist.json`)
-  - env: *POOL_BLOCKLIST_PATH*
-  - This path can either be a local file path or an S3 url. If using an S3 url, Make sure your machine has access to this file. 
+  - env: _POOL_BLOCKLIST_PATH_
+  - This path can either be a local file path or an S3 url. If using an S3 url, Make sure your machine has access to this file.
   - See [here](./architecture/pool.md#allowlistblocklist) for details.
 - `--pool.allowlist_path`: Path to an allowlist file (e.g `allowlist.json`, `s3://my-bucket/allowlist.json`)
-  - env: *POOL_ALLOWLIST_PATH*
-  - This path can either be a local file path or an S3 url. If using an S3 url, Make sure your machine has access to this file. 
+  - env: _POOL_ALLOWLIST_PATH_
+  - This path can either be a local file path or an S3 url. If using an S3 url, Make sure your machine has access to this file.
   - See [here](./architecture/pool.md#allowlistblocklist) for details.
 - `--pool.chain_poll_interval_millis`: Interval at which the pool polls an Eth node for new blocks (default: `100`)
-  - env: *POOL_CHAIN_POLL_INTERVAL_MILLIS*
+  - env: _POOL_CHAIN_POLL_INTERVAL_MILLIS_
 - `--pool.chain_sync_max_retries`: The amount of times to retry syncing the chain before giving up and waiting for the next block (default: `5`)
-  - env: *POOL_CHAIN_SYNC_MAX_RETRIES*
+  - env: _POOL_CHAIN_SYNC_MAX_RETRIES_
 - `--pool.paymaster_tracking_enabled`: Boolean field that sets whether the pool server starts with paymaster tracking enabled (default: `true`)
-  - env: *POOL_PAYMASTER_TRACKING_ENABLED*
+  - env: _POOL_PAYMASTER_TRACKING_ENABLED_
 - `--pool.paymaster_cache_length`: Length of the paymaster cache (default: `10_000`)
-  - env: *POOL_PAYMASTER_CACHE_LENGTH*
+  - env: _POOL_PAYMASTER_CACHE_LENGTH_
 - `--pool.reputation_tracking_enabled`: Boolean field that sets whether the pool server starts with reputation tracking enabled (default: `true`)
-  - env: *POOL_REPUTATION_TRACKING_ENABLED*
+  - env: _POOL_REPUTATION_TRACKING_ENABLED_
 - `--pool.drop_min_num_blocks`: The minimum number of blocks that a UO must stay in the mempool before it can be requested to be dropped by the user (default: `10`)
-  - env: *POOL_DROP_MIN_NUM_BLOCKS*
+  - env: _POOL_DROP_MIN_NUM_BLOCKS_
 - `--pool.max_time_in_pool_secs`: The maximum amount of time a UO is allowed to be in the mempool, in seconds. (default: `None`)
-  - env: *POOL_MAX_TIME_IN_POOL_SECS*
+  - env: _POOL_MAX_TIME_IN_POOL_SECS_
 - `--pool.disable_revert_check`: Disable the pool's revert check. (default: `false`)
-  - env: *POOL_DISABLE_REVERT_CHECK*
+  - env: _POOL_DISABLE_REVERT_CHECK_
 
 ## Builder Options
 
 List of command line options for configuring the Builder.
 
 - `--builder.port`: Port to listen on for gRPC requests (default: `50052`)
-  - env: *BUILDER_PORT*
-  - *Only required when running in distributed mode* 
+  - env: _BUILDER_PORT_
+  - _Only required when running in distributed mode_
 - `--builder.host`: Host to listen on for gRPC requests (default: `127.0.0.1`)
-  - env: *BUILDER_HOST*
-  - *Only required when running in distributed mode* 
+  - env: _BUILDER_HOST_
+  - _Only required when running in distributed mode_
 - `--builder.max_bundle_size`: Maximum number of ops to include in one bundle (default: `128`)
-  - env: *BUILDER_MAX_BUNDLE_SIZE*
+  - env: _BUILDER_MAX_BUNDLE_SIZE_
 - `--builder.max_blocks_to_wait_for_mine`: After submitting a bundle transaction, the maximum number of blocks to wait for that transaction to mine before trying to resend with higher gas fees (default: `2`)
-  - env: *BUILDER_MAX_BLOCKS_TO_WAIT_FOR_MINE*
+  - env: _BUILDER_MAX_BLOCKS_TO_WAIT_FOR_MINE_
 - `--builder.replacement_fee_percent_increase`: Percentage amount to increase gas fees when retrying a transaction after it failed to mine (default: `10`)
-  - env: *BUILDER_REPLACEMENT_FEE_PERCENT_INCREASE*
+  - env: _BUILDER_REPLACEMENT_FEE_PERCENT_INCREASE_
 - `--builder.max_cancellation_fee_increases`: Maximum number of cancellation fee increases to attempt (default: `15`)
-  - env: *BUILDER_MAX_CANCELLATION_FEE_INCREASES*
+  - env: _BUILDER_MAX_CANCELLATION_FEE_INCREASES_
 - `--builder.max_replacement_underpriced_blocks`: The maximum number of blocks to wait in a replacement underpriced state before issuing a cancellation transaction (default: `20`)
-  - env: *BUILDER_MAX_REPLACEMENT_UNDERPRICED_BLOCKS*
+  - env: _BUILDER_MAX_REPLACEMENT_UNDERPRICED_BLOCKS_
 - `--builder.sender`: Choice of what sender type to use for transaction submission. (default: `raw`, options: `raw`, `flashbots`, `polygon_bloxroute`)
-  - env: *BUILDER_SENDER*
+  - env: _BUILDER_SENDER_
 - `--builder.submit_url`: Only used if builder.sender == "raw." If present, the URL of the ETH provider that will be used to send transactions. Defaults to the value of `node_http`.
-  - env: *BUILDER_SUBMIT_URL*
+  - env: _BUILDER_SUBMIT_URL_
 - `--builder.use_conditional_rpc`: Only used if builder.sender == "raw." Use `eth_sendRawTransactionConditional` when submitting. (default: `false`)
-  - env: *BUILDER_USE_CONDITIONAL_RPC*
+  - env: _BUILDER_USE_CONDITIONAL_RPC_
 - `--builder.flashbots_relay_builders`: Only used if builder.sender == "flashbots." Additional builders to send bundles to through the Flashbots relay RPC (comma-separated). List of builders that the Flashbots RPC supports can be found [here](https://docs.flashbots.net/flashbots-auction/advanced/rpc-endpoint#eth_sendprivatetransaction). (default: `flashbots`)
-  - env: *BUILDER_FLASHBOTS_RELAY_BUILDERS*
+  - env: _BUILDER_FLASHBOTS_RELAY_BUILDERS_
 - `--builder.flashbots_relay_auth_key`: Only used/required if builder.sender == "flashbots." Authorization key to use with the flashbots relay. See [here](https://docs.flashbots.net/flashbots-auction/advanced/rpc-endpoint#authentication) for more info. (default: None)
-  - env: *BUILDER_FLASHBOTS_RELAY_AUTH_KEY*
+  - env: _BUILDER_FLASHBOTS_RELAY_AUTH_KEY_
 - `--builder.bloxroute_auth_header`: Only used/required if builder.sender == "polygon_bloxroute." If using the bloxroute transaction sender on Polygon, this is the auth header to supply with the requests. (default: None)
-  - env: *BUILDER_BLOXROUTE_AUTH_HEADER*
+  - env: _BUILDER_BLOXROUTE_AUTH_HEADER_
 - `--builder.pool_url`: If running in distributed mode, the URL of the pool server to use.
-  - env: *BUILDER_POOL_URL*
-  - *Only required when running in distributed mode*
+  - env: _BUILDER_POOL_URL_
+  - _Only required when running in distributed mode_
 
 ## Signer Options
 
 - `--signer.private_keys`: Private keys to use for signing transactions, separated by `,`
-  - env: *SIGNER_PRIVATE_KEYS*
+  - env: _SIGNER_PRIVATE_KEYS_
 - `--signer.mnemonic`: Mnemonic to use for signing transactions
-  - env: *SIGNER_MNEMONIC*
-- `--signer.aws_kms_key_ids`: AWS KMS key IDs to use for signing transactions, separated by `,`. 
-  - env: *SIGNER_AWS_KMS_KEY_IDS*
+  - env: _SIGNER_MNEMONIC_
+- `--signer.aws_kms_key_ids`: AWS KMS key IDs to use for signing transactions, separated by `,`.
+  - env: _SIGNER_AWS_KMS_KEY_IDS_
   - To enable signer locking see `SIGNER_ENABLE_KMS_LOCKING`.
 - `--signer.aws_kms_grouped_keys`: AWS KMS key ids grouped to keys in `aws_kms_key_ids` Separated by `,`. Groups are made based on the number of signers required. There must be enough signers to make a full group for every entry in `aws_kms_key_ids`.
-  - env: *SIGNER_AWS_KMS_GROUPED_KEYS*
+  - env: _SIGNER_AWS_KMS_GROUPED_KEYS_
 - `--signer.enable_kms_locking`: True if keys should be locked before use. Only applies to keys in `aws_kms_key_ids`.
-  - env: *SIGNER_ENABLE_KMS_LOCKING*
+  - env: _SIGNER_ENABLE_KMS_LOCKING_
 - `--signer.redis_uri`: Redis URI to use for KMS leasing (default: `""`)
-  - env: *SIGNER_REDIS_URI*
-  -*Only required when SIGNER_ENABLE_KMS_LOCKING is set* 
+  - env: _SIGNER_REDIS_URI_ -_Only required when SIGNER_ENABLE_KMS_LOCKING is set_
 - `--signer.redis_lock_ttl_millis`: Redis lock TTL in milliseconds (default: `60000`)
-  - env: *SIGNER_REDIS_LOCK_TTL_MILLIS*
-  - *Only required when SIGNER_ENABLE_KMS_LOCKING is set* 
+  - env: _SIGNER_REDIS_LOCK_TTL_MILLIS_
+  - _Only required when SIGNER_ENABLE_KMS_LOCKING is set_
 - `--signer.enable_kms_funding`: Whether to enable kms funding from `aws_kms_key_ids` to the key ids in `aws_kms_key_groups`. (default: `false`)
-  - env: *SIGNER_ENABLE_KMS_FUNDING*
+  - env: _SIGNER_ENABLE_KMS_FUNDING_
 - `--signer.fund_below`: If KMS funding is enabled, this is the signer balance value below which to trigger a funding event
-  - env: *SIGNER_FUND_BELOW*
+  - env: _SIGNER_FUND_BELOW_
 - `--signer.fund_to`: If KMS funding is enabled, this is the signer balance to fund to during a funding event
-  - env: *SIGNER_FUND_TO*
+  - env: _SIGNER_FUND_TO_
 - `--signer.funding_txn_poll_interval_ms`: During funding, this is the poll interval for transaction status (default: `1000`)
-  - env: *SIGNER_FUNDING_TXN_POLL_INTERVAL_MS*
+  - env: _SIGNER_FUNDING_TXN_POLL_INTERVAL_MS_
 - `--signer.funding_txn_poll_max_retries`: During funding, this is the maximum amount of time to poll for transaction status before abandoning (default: `20`)
-  - env: *SIGNER_FUNDING_TXN_POLL_MAX_RETRIES*
+  - env: _SIGNER_FUNDING_TXN_POLL_MAX_RETRIES_
 - `--signer.funding_txn_priority_fee_multiplier`: During funding, this is the multiplier to apply to the network priority fee (default: `2.0`)
-  - env: *SIGNER_FUNDING_TXN_PRIORITY_FEE_MULTIPLIER*
+  - env: _SIGNER_FUNDING_TXN_PRIORITY_FEE_MULTIPLIER_
 - `--signer.funding_txn_base_fee_multiplier`: During funding, this is the multiplier to apply to the network base fee (default: `2.0`)
-  - env: *SIGNER_FUNDING_TXN_BASE_FEE_MULTIPLIER*
+  - env: _SIGNER_FUNDING_TXN_BASE_FEE_MULTIPLIER_
 
 ### Signing schemes
 
-Rundler supports multiple ways to sign bundle transactions. In configuration precedence order: 
+Rundler supports multiple ways to sign bundle transactions. In configuration precedence order:
 
 1. KMS locked master key with funded sub-keys: `--signer.enable_kms_funding`
 2. Private keys: `--signer.private_keys`
@@ -297,8 +298,8 @@ Locking uses Redis and thus a Redis URL must be provided to Rundler for key leas
 If `--signer.enable_kms_funding` is set this scheme will be enabled. It will look for subkeys in the following precedence order:
 
 1. `aws_kms_grouped_keys`: Must have enough signers to make a full group for each `aws_kms_key_ids`. Group size is based on number of signers requested.
-    - If locking is enabled, once a funding KMS key is locked, the corresponding group is used for all subkeys.
-    - Else, the first group is always used
+   - If locking is enabled, once a funding KMS key is locked, the corresponding group is used for all subkeys.
+   - Else, the first group is always used
 2. `private_keys`: Private keys for the subkeys. The same list applies regardless of which KMS key is locked.
 3. `mnemonic`: Supports a `mnemonic` from which multiple subkeys can be derived. The same `mnemonic` applies regardless of which KMS key is locked
 

--- a/test/spec-tests/local/docker-compose.yml
+++ b/test/spec-tests/local/docker-compose.yml
@@ -1,14 +1,13 @@
 services:
   geth:
-    image: ethereum/client-go:release-1.14
-    ports: [ '8545:8545' ]
+    image: ethereum/client-go:release-1.16
+    ports: ["8545:8545"]
     command: --verbosity 1
       --http.vhosts '*,localhost,host.docker.internal'
       --http
       --http.api eth,net,web3,debug
       --http.corsdomain '*'
       --http.addr "0.0.0.0"
-      --networkid 1337
       --dev
       --dev.period 0
       --allow-insecure-unlock


### PR DESCRIPTION
## Proposed Changes

  - Removes execution gas limit efficiency check from the mempool, this hasn't been useful
  - Adds a revert check to the mempool. If either execution or postop reverts the UO will be rejected
  - Implement the revert check in the entry point in three ways:
    - using `eth_simulateV1` - this should be used on most networks as its much more efficient
    - using `debug_traceCall`
    - using `eth_call` - this does not catch postop reverts, but does catch full execution reverts, only useful on monad at the moment.
   
TODO
- [x] Switch to using `simulateHandleOp` and add support for aggregated user ops
- [ ] Lots of testing in difference scenarios
- [x] Determine correct settings for various networks