### PR TITLE
ci: upgrade to Node.js 24 

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -14,7 +14,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libxml2-utils
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Checkout Rundler
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use Node.js 24 instead of 18.

Node.js 24 includes updated V8, npm 11, and other performance and compatibility improvements.
No other changes were required. CI and lint checks run successfully under the new version.

Reference: [Node.js 24.4.1 release notes](https://github.com/nodejs/node/releases/tag/v24.4.1)