### PR TITLE
Fix typos in code comments and documentation

### DIFF
--- a/crates/signer/src/funding.rs
+++ b/crates/signer/src/funding.rs
@@ -342,7 +342,7 @@ async fn estimate_da_gas<P: EvmProvider>(
 struct FunderMetrics {
     #[metric(describe = "the number of funding attempts")]
     funding_attempts: Counter,
-    #[metric(describe = "tne mumber of funding errors")]
+    #[metric(describe = "tne number of funding errors")]
     funding_errors: Counter,
     #[metric(describe = "the number of funding reattempts")]
     funding_reattempts: Counter,

--- a/docs/architecture/pool.md
+++ b/docs/architecture/pool.md
@@ -4,7 +4,7 @@ The `Pool` task is responsible for receiving, validating, sorting, and storing u
 
 ## Simulation
 
-Upon each `add_operation` call the `Pool` will preforms a series of checks.
+Upon each `add_operation` call the `Pool` will performs a series of checks.
 
 1. Run a series of [prechecks](https://eips.ethereum.org/EIPS/eip-4337#client-behavior-upon-receiving-a-useroperation) to catch any reasons why the UO may not be mined.
 

--- a/docs/architecture/rpc.md
+++ b/docs/architecture/rpc.md
@@ -560,7 +560,7 @@ More information on gas estimation can be found [here](https://www.alchemy.com/b
 
 The `eth_estimateUserOperationGas` accepts an optional state override set as the 3rd positional RPC parameter. It accepts the same format as Geth's `eth_call` [state overrides](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-eth#eth-call).
 
-This parameter can be used to modify the state of the chain before preforming gas estimation.
+This parameter can be used to modify the state of the chain before performing gas estimation.
 
 A typical use case for this could be to spoof some funds into a user's account while using an ERC-20 paymaster. Callers can override the balance (ETH, ERC20, or any arbitrary payment method) such that the fee-payer can pay the `verification_estimation_gas_fee`.
 


### PR DESCRIPTION


## Description

This PR fixes minor typos found in code comments and documentation files:

### Changes Made

- **`crates/signer/src/funding.rs`**: Fixed typo in metric description from "mumber" to "number"
- **`docs/architecture/pool.md`**: Corrected "preforms" to "performs" in Pool documentation
- **`docs/architecture/rpc.md`**: Fixed "preforming" to "performing" in gas estimation documentation


