### PR TITLE
feat(cli): Add CLI options to set absolute bundle gas target and maximum

### DIFF
--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -259,13 +259,14 @@ impl BuilderArgs {
 
         let provider_client_timeout_seconds = common.provider_client_timeout_seconds;
 
+        let target_bundle_gas = super::resolve_target_bundle_gas(common, &chain_spec);
+        let max_bundle_gas = super::resolve_max_bundle_execution_gas(common, &chain_spec);
+
         tracing::info!(
             "Builder bundle limits: Chain block gas limit: {}. Target bundle gas: {}. Max bundle gas: {}",
             chain_spec.block_gas_limit,
-            chain_spec
-                .block_gas_limit_mult(common.target_bundle_block_gas_limit_ratio),
-            chain_spec
-                .block_gas_limit_mult(common.max_bundle_block_gas_limit_ratio)
+            target_bundle_gas,
+            max_bundle_gas
         );
 
         Ok(BuilderTaskArgs {
@@ -275,10 +276,8 @@ impl BuilderArgs {
             unsafe_mode: common.unsafe_mode,
             rpc_url,
             max_bundle_size: self.max_bundle_size,
-            target_bundle_gas: chain_spec
-                .block_gas_limit_mult(common.target_bundle_block_gas_limit_ratio),
-            max_bundle_gas: chain_spec
-                .block_gas_limit_mult(common.max_bundle_block_gas_limit_ratio),
+            target_bundle_gas,
+            max_bundle_gas,
             sender_args,
             sim_settings: common.try_into()?,
             max_blocks_to_wait_for_mine: self.max_blocks_to_wait_for_mine,


### PR DESCRIPTION
On September 10, [Base will begin enforcing a per‑transaction gas cap of 16,777,216 gas](https://docs.base.org/base-chain/network-information/block-building#per-transaction-gas-maximum) at the mempool. Ethereum L1 will follow soon with [an in-protocol per-transaction gas limit](https://eips.ethereum.org/EIPS/eip-7825). We're currently recommending that rundler users set `max_bundle_block_gas_limit_ratio` to `0.105` and `target_bundle_block_gas_limit_ratio` to `0.06` for Base. This will produce bundles below the limit for today's gas limit of 140M.

This PR introduces absolute flags for the bundle gas target and maximum to allow a fixed value (e.g. 90% x 16,777,216) to be set instead of a ratio based on the chain's gas limit, which will change frequently and result in the per-transaction limit being exceeded.