### PR TITLE
Josh/connection metrics

### DIFF
--- a/crates/rpc/src/rpc_metrics.rs
+++ b/crates/rpc/src/rpc_metrics.rs
@@ -152,15 +152,11 @@ where
         );
         let mut svc = self.service.clone();
         async move {
-            let available_connections = req
-                .extensions()
-                .get::<ConnectionGuard>()
-                .unwrap()
-                .available_connections() as f64;
-
+            if let Some(connection_guard) = req.extensions().get::<ConnectionGuard>() {
+                method_logger
+                    .record_available_connections(connection_guard.available_connections() as f64);
+            }
             let rp = svc.call(req).await;
-
-            method_logger.record_available_connections(available_connections);
             let http_status = rp.as_ref().ok().map(|rp| rp.status());
             if let Some(status_code) = http_status {
                 method_logger.record_http(get_http_status_from_code(status_code.as_u16()));

--- a/crates/types/src/task/metric_recorder.rs
+++ b/crates/types/src/task/metric_recorder.rs
@@ -24,6 +24,7 @@ pub struct MethodSessionLogger {
     method_name: String,
     protocol: String,
     method_metric: MethodMetrics,
+    json_rpsee_metric: JsonRpseeMetrics,
 }
 
 #[derive(Metrics)]
@@ -49,6 +50,13 @@ pub(crate) struct MethodStatusMetrics {
     rpc_response_status: Counter,
 }
 
+#[derive(Metrics)]
+#[metrics(scope = "jsonrpsee_stats")]
+pub(crate) struct JsonRpseeMetrics {
+    #[metric(describe = "The count of the current available connections for jsonrpsee server.")]
+    available_connections: Gauge,
+}
+
 impl MethodSessionLogger {
     /// create a session logger.
     pub fn new(service_name: String, method_name: String, protocol: String) -> Self {
@@ -57,6 +65,10 @@ impl MethodSessionLogger {
             method_name: method_name.clone(),
             service_name: service_name.clone(),
             protocol: protocol.clone(),
+            json_rpsee_metric: JsonRpseeMetrics::new_with_labels(&[(
+                "service_name",
+                service_name.clone(),
+            )]),
             method_metric: MethodMetrics::new_with_labels(&[
                 ("method_name", method_name),
                 ("service_name", service_name),
@@ -103,5 +115,13 @@ impl MethodSessionLogger {
         self.method_metric
             .request_latency
             .record(self.start_time.elapsed().as_millis() as f64);
+    }
+
+    /// Record current available connections in the pool that can be used
+    /// within the jsonrpsee server by reading the ConnectionGuard extension.
+    pub fn record_available_connections(&self, available_connections: f64) {
+        self.json_rpsee_metric
+            .available_connections
+            .set(available_connections);
     }
 }

--- a/crates/types/src/task/metric_recorder.rs
+++ b/crates/types/src/task/metric_recorder.rs
@@ -53,8 +53,10 @@ pub(crate) struct MethodStatusMetrics {
 #[derive(Metrics)]
 #[metrics(scope = "jsonrpsee_stats")]
 pub(crate) struct JsonRpseeMetrics {
-    #[metric(describe = "The count of the current available connections for jsonrpsee server.")]
-    available_connections: Gauge,
+    #[metric(
+        describe = "The count of the active connections for jsonrpsee server connection guard."
+    )]
+    active_connections: Gauge,
 }
 
 impl MethodSessionLogger {
@@ -117,11 +119,11 @@ impl MethodSessionLogger {
             .record(self.start_time.elapsed().as_millis() as f64);
     }
 
-    /// Record current available connections in the pool that can be used
-    /// within the jsonrpsee server by reading the ConnectionGuard extension.
-    pub fn record_available_connections(&self, available_connections: f64) {
+    /// Record current active connections being used within
+    /// the jsonrpsee server by reading the ConnectionGuard extension.
+    pub fn record_active_connections(&self, available_connections: f64) {
         self.json_rpsee_metric
-            .available_connections
+            .active_connections
             .set(available_connections);
     }
 }


### PR DESCRIPTION
## Proposed Changes

  - Use the internal jsonrpsee connection guard to record active connections being used for the RPC server
