### PR TITLE
feat(chain): add transaction gas limit and modify CLI to use it for bundle limits

### DIFF
--- a/bin/rundler/chain_specs/base.toml
+++ b/bin/rundler/chain_specs/base.toml
@@ -9,6 +9,7 @@ max_transaction_size_bytes = 130000
 
 priority_fee_oracle_type = "USAGE_BASED"
 min_max_priority_fee_per_gas = 1000000
-block_gas_limit = 120000000
+block_gas_limit = 140000000
+transaction_gas_limit = 16777216
 eip7702_enabled = true
 flashblocks_enabled = true

--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -259,13 +259,13 @@ impl BuilderArgs {
 
         let provider_client_timeout_seconds = common.provider_client_timeout_seconds;
 
+        let bundle_limits = common.bundle_limits(&chain_spec);
+
         tracing::info!(
-            "Builder bundle limits: Chain block gas limit: {}. Target bundle gas: {}. Max bundle gas: {}",
-            chain_spec.block_gas_limit,
-            chain_spec
-                .block_gas_limit_mult(common.target_bundle_block_gas_limit_ratio),
-            chain_spec
-                .block_gas_limit_mult(common.max_bundle_block_gas_limit_ratio)
+            "Builder bundle limits: Chain transaction gas limit: {}. Target bundle gas: {}. Max bundle gas: {}",
+            chain_spec.transaction_gas_limit(),
+            bundle_limits.target_bundle_execution_gas_limit,
+            bundle_limits.max_bundle_execution_gas_limit
         );
 
         Ok(BuilderTaskArgs {
@@ -275,10 +275,8 @@ impl BuilderArgs {
             unsafe_mode: common.unsafe_mode,
             rpc_url,
             max_bundle_size: self.max_bundle_size,
-            target_bundle_gas: chain_spec
-                .block_gas_limit_mult(common.target_bundle_block_gas_limit_ratio),
-            max_bundle_gas: chain_spec
-                .block_gas_limit_mult(common.max_bundle_block_gas_limit_ratio),
+            target_bundle_gas: bundle_limits.target_bundle_execution_gas_limit,
+            max_bundle_gas: bundle_limits.max_bundle_execution_gas_limit,
             sender_args,
             sim_settings: common.try_into()?,
             max_blocks_to_wait_for_mine: self.max_blocks_to_wait_for_mine,

--- a/crates/types/src/chain.rs
+++ b/crates/types/src/chain.rs
@@ -53,6 +53,8 @@ pub struct ChainSpec {
     pub max_transaction_size_bytes: usize,
     /// the block gas limit
     pub block_gas_limit: u64,
+    /// the transaction gas limit, 0 indicates no limit
+    pub transaction_gas_limit: u64,
     /// Intrinsic gas cost for a transaction
     pub transaction_intrinsic_gas: u64,
     /// Per user operation gas cost for v0.6
@@ -176,6 +178,7 @@ impl Default for ChainSpec {
             multicall3_address: Address::from_str(MULTICALL3_ADDRESS).unwrap(),
             flashblocks_enabled: false,
             deposit_transfer_overhead: 30_000,
+            transaction_gas_limit: 0,
             transaction_intrinsic_gas: 21_000,
             per_user_op_v0_6_gas: 18_300,
             per_user_op_v0_7_gas: 19_500,
@@ -218,6 +221,17 @@ impl ChainSpec {
     /// Get the transaction intrinsic gas
     pub fn transaction_intrinsic_gas(&self) -> u128 {
         self.transaction_intrinsic_gas as u128
+    }
+
+    /// Resolve the transaction gas limit
+    ///
+    /// If the transaction gas limit is 0, the block gas limit is returned.
+    pub fn transaction_gas_limit(&self) -> u128 {
+        if self.transaction_gas_limit > 0 {
+            self.transaction_gas_limit as u128
+        } else {
+            self.block_gas_limit as u128
+        }
     }
 
     /// Get the minimum max priority fee per gas
@@ -279,8 +293,8 @@ impl ChainSpec {
     }
 
     /// Calculate a multiple of the block limit
-    pub fn block_gas_limit_mult(&self, mult: f64) -> u128 {
-        (self.block_gas_limit as f64 * mult) as u128
+    pub fn transaction_gas_limit_mult(&self, mult: f64) -> u128 {
+        (self.transaction_gas_limit() as f64 * mult) as u128
     }
 
     /// Set signature aggregators


### PR DESCRIPTION
## Proposed Changes

  - Add a new transaction gas limit field to chain spec
  - Add a function to chain spec to resolve the maximum transaction gas between the txn limit and the block limit
  - [BREAKING] Modify the names of the CLI parameters to control the bundle gas limits
