### PR TITLE
feat(flashblocks): fix initialization bug with flashblocks

### DIFF
--- a/crates/pool/src/chain.rs
+++ b/crates/pool/src/chain.rs
@@ -504,6 +504,37 @@ impl<P: EvmProvider> Chain<P> {
     }
 
     async fn reset_and_initialize(&mut self, head: Block) -> anyhow::Result<ChainUpdate> {
+        if self.settings.flashblocks {
+            // On flashblocks networks, skip fetching historical blocks and eth_getLogs
+            // entirely. Tip-level reorgs invalidate block hashes faster than the sequential
+            // 64-block history fetch + log queries can complete, causing a permanent init
+            // loop. Bootstrap with just the head block so the chain is non-empty and
+            // wait_for_update switches to the flashblocks path. Historical ops in the
+            // init window are omitted but are already settled on-chain and not in the pool.
+            self.blocks = VecDeque::from([BlockSummary {
+                number: head.header.number,
+                hash: head.header.hash,
+                timestamp: head.header.timestamp.into(),
+                ops: vec![],
+                transactions: vec![],
+                entity_balance_updates: vec![],
+                address_updates: vec![],
+            }]);
+            self.sync_error_count = 0;
+            return Ok(self.new_update(
+                0,
+                vec![],
+                vec![],
+                vec![],
+                None,
+                vec![],
+                vec![],
+                vec![],
+                false,
+                UpdateType::Confirmed,
+            ));
+        }
+
         let min_block_number = head
             .header
             .number
@@ -512,27 +543,7 @@ impl<P: EvmProvider> Chain<P> {
             .load_blocks_back_to_number(head, min_block_number)
             .await
             .context("should load full history when resetting chain")?;
-        self.blocks = if self.settings.flashblocks {
-            // On flashblocks networks, eth_getLogs by block hash is unreliable during
-            // initialization because tip-level reorgs can invalidate a block's canonical
-            // status between when we traverse its parent hash and when we query logs for
-            // it. Bootstrap with empty summaries so the chain becomes non-empty and
-            // wait_for_update switches to the flashblocks path.
-            blocks
-                .iter()
-                .map(|block| BlockSummary {
-                    number: block.header.number,
-                    hash: block.header.hash,
-                    timestamp: block.header.timestamp.into(),
-                    ops: vec![],
-                    transactions: vec![],
-                    entity_balance_updates: vec![],
-                    address_updates: vec![],
-                })
-                .collect()
-        } else {
-            self.load_block_summaries(&blocks).await?
-        };
+        self.blocks = self.load_block_summaries(&blocks).await?;
         self.sync_error_count = 0;
         let mined_ops: Vec<_> = self
             .blocks

--- a/crates/pool/src/chain.rs
+++ b/crates/pool/src/chain.rs
@@ -512,7 +512,27 @@ impl<P: EvmProvider> Chain<P> {
             .load_blocks_back_to_number(head, min_block_number)
             .await
             .context("should load full history when resetting chain")?;
-        self.blocks = self.load_block_summaries(&blocks).await?;
+        self.blocks = if self.settings.flashblocks {
+            // On flashblocks networks, eth_getLogs by block hash is unreliable during
+            // initialization because tip-level reorgs can invalidate a block's canonical
+            // status between when we traverse its parent hash and when we query logs for
+            // it. Bootstrap with empty summaries so the chain becomes non-empty and
+            // wait_for_update switches to the flashblocks path.
+            blocks
+                .iter()
+                .map(|block| BlockSummary {
+                    number: block.header.number,
+                    hash: block.header.hash,
+                    timestamp: block.header.timestamp.into(),
+                    ops: vec![],
+                    transactions: vec![],
+                    entity_balance_updates: vec![],
+                    address_updates: vec![],
+                })
+                .collect()
+        } else {
+            self.load_block_summaries(&blocks).await?
+        };
         self.sync_error_count = 0;
         let mined_ops: Vec<_> = self
             .blocks


### PR DESCRIPTION
## Proposed Changes

On flashblocks networks with fast block times (e.g. XLayer), reset_and_initialize would fail during startup because it called eth_getLogs by block hash for 64 historical blocks. By the time the log query ran, a tip-level reorg had invalidated one of those block hashes in the canonical chain, causing a block not found error. After exhausting retries, the chain would clear its block history and  restart the same failing loop indefinitely. 

The fix skips eth_getLogs entirely during initialization when flashblocks is enabled, building empty BlockSummary structs from block headers instead. This lets the chain bootstrap successfully, after which wait_for_update switches to the flashblocks path as intended. Historical mined ops in the initialization window are omitted, but these are already settled on-chain and not relevant to pool state.
                                     
