### PR TITLE
fix(rpc): accept short EIP-7702 factory marker for gas estimation

### DIFF
--- a/crates/rpc/src/eth/server.rs
+++ b/crates/rpc/src/eth/server.rs
@@ -89,7 +89,7 @@ where
             "eth_estimateUserOperationGas",
             EthApi::estimate_user_operation_gas(
                 self,
-                op.into_rundler_type(&self.chain_spec, ep_version),
+                op.try_into_rundler_type(&self.chain_spec, ep_version)?,
                 entry_point,
                 state_override,
             ),

--- a/crates/rpc/src/types/mod.rs
+++ b/crates/rpc/src/types/mod.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
     eth::EthRpcError,
-    utils::{FromRpcType, IntoRundlerType, TryFromRpcType, TryIntoRundlerType},
+    utils::{IntoRundlerType, TryFromRpcType, TryIntoRundlerType},
 };
 
 mod permissions;
@@ -156,20 +156,20 @@ pub(crate) enum RpcUserOperationOptionalGas {
     V0_7(RpcUserOperationOptionalGasV0_7),
 }
 
-impl FromRpcType<RpcUserOperationOptionalGas> for UserOperationOptionalGas {
-    fn from_rpc_type(
+impl TryFromRpcType<RpcUserOperationOptionalGas> for UserOperationOptionalGas {
+    fn try_from_rpc_type(
         op: RpcUserOperationOptionalGas,
         chain_spec: &ChainSpec,
         ep_version: EntryPointVersion,
-    ) -> Self {
-        match op {
+    ) -> Result<Self, EthRpcError> {
+        Ok(match op {
             RpcUserOperationOptionalGas::V0_6(op) => {
                 UserOperationOptionalGas::V0_6(op.into_rundler_type(chain_spec, ep_version))
             }
             RpcUserOperationOptionalGas::V0_7(op) => {
-                UserOperationOptionalGas::V0_7(op.into_rundler_type(chain_spec, ep_version))
+                UserOperationOptionalGas::V0_7(op.try_into_rundler_type(chain_spec, ep_version)?)
             }
-        }
+        })
     }
 }
 

--- a/crates/rpc/src/types/v0_7.rs
+++ b/crates/rpc/src/types/v0_7.rs
@@ -23,10 +23,7 @@ use rundler_types::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    eth::EthRpcError,
-    utils::{FromRpcType, TryFromRpcType},
-};
+use crate::{eth::EthRpcError, utils::TryFromRpcType};
 
 /// User operation definition for RPC inputs
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -146,19 +143,10 @@ impl TryFromRpcType<RpcUserOperation> for UserOperation {
             );
         }
         if let Some(factory) = def.factory {
-            // special handling for "0x7702" shortened factory marker
-            let factory = if factory == bytes!("7702") {
-                EIP7702_FACTORY_MARKER
-            } else if factory.len() == 20 {
-                Address::from_slice(&factory)
-            } else {
-                return Err(EthRpcError::InvalidParams(format!(
-                    "Invalid factory length. Expected 20 bytes. Got: {:?}",
-                    factory.len()
-                )));
-            };
-
-            builder = builder.factory(factory, def.factory_data.unwrap_or_default());
+            builder = builder.factory(
+                decode_factory(factory)?,
+                def.factory_data.unwrap_or_default(),
+            );
         }
         if let Some(auth) = def.eip7702_auth {
             builder = builder.authorization_tuple(auth);
@@ -192,7 +180,7 @@ pub(crate) struct RpcUserOperationOptionalGas {
     pre_verification_gas: Option<U256>,
     max_priority_fee_per_gas: Option<U128>,
     max_fee_per_gas: Option<U128>,
-    factory: Option<Address>,
+    factory: Option<Bytes>,
     factory_data: Option<Bytes>,
     paymaster: Option<Address>,
     paymaster_verification_gas_limit: Option<U128>,
@@ -204,13 +192,15 @@ pub(crate) struct RpcUserOperationOptionalGas {
     paymaster_signature: Option<Bytes>,
 }
 
-impl FromRpcType<RpcUserOperationOptionalGas> for UserOperationOptionalGas {
-    fn from_rpc_type(
+impl TryFromRpcType<RpcUserOperationOptionalGas> for UserOperationOptionalGas {
+    fn try_from_rpc_type(
         def: RpcUserOperationOptionalGas,
         _chain_spec: &ChainSpec,
         ep_version: EntryPointVersion,
-    ) -> Self {
-        UserOperationOptionalGas {
+    ) -> Result<Self, EthRpcError> {
+        let factory = def.factory.map(decode_factory).transpose()?;
+
+        Ok(UserOperationOptionalGas {
             sender: def.sender,
             nonce: def.nonce,
             call_data: def.call_data,
@@ -219,7 +209,7 @@ impl FromRpcType<RpcUserOperationOptionalGas> for UserOperationOptionalGas {
             pre_verification_gas: def.pre_verification_gas.map(|x| x.to()),
             max_priority_fee_per_gas: def.max_priority_fee_per_gas.map(|x| x.to()),
             max_fee_per_gas: def.max_fee_per_gas.map(|x| x.to()),
-            factory: def.factory,
+            factory,
             factory_data: def.factory_data.unwrap_or_default(),
             paymaster: def.paymaster,
             paymaster_verification_gas_limit: def.paymaster_verification_gas_limit.map(|x| x.to()),
@@ -230,7 +220,20 @@ impl FromRpcType<RpcUserOperationOptionalGas> for UserOperationOptionalGas {
             aggregator: def.aggregator,
             paymaster_signature: def.paymaster_signature,
             entry_point_version: ep_version,
-        }
+        })
+    }
+}
+
+fn decode_factory(factory: Bytes) -> Result<Address, EthRpcError> {
+    if factory == bytes!("7702") {
+        Ok(EIP7702_FACTORY_MARKER)
+    } else if factory.len() == 20 {
+        Ok(Address::from_slice(&factory))
+    } else {
+        Err(EthRpcError::InvalidParams(format!(
+            "Invalid factory length. Expected 2-byte EIP-7702 marker or 20-byte address. Got: {:?}",
+            factory.len()
+        )))
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

  - Accept the shortened EIP-7702 factory marker (`0x7702`) in v0.8+ optional-gas RPC payloads.
  - Share factory decoding between `eth_sendUserOperation` and `eth_estimateUserOperationGas`.
  - Change v0.8+ optional-gas RPC conversion to `TryFromRpcType` so invalid factory lengths can be returned as `InvalidParams`.
  - Route `eth_estimateUserOperationGas` through fallible RPC conversion before estimating gas.

  ## Motivation

  Some clients, including viem account implementations via `account.getFactoryArgs()`, can provide the EIP-7702 factory marker as:

  factory: 0x7702

  instead of the padded 20-byte marker:

  factory: 0x7702000000000000000000000000000000000000

  eth_sendUserOperation already accepted this shortened marker, but eth_estimateUserOperationGas used Address for the v0.8+ optional-gas factory field. As a result, estimate requests with factory: 0x7702 failed
  during RPC deserialization/conversion before reaching simulation.

  This PR makes send and estimate use the same factory decoding behavior.

  ## Related Context

  - #1236 added support for the 0x7702 shortened factory address. This PR applies the same decoding behavior to the v0.8+ optional-gas RPC path used by eth_estimateUserOperationGas.

  ## Behavior

  Accepted factory values:
  - 0x7702
  - any 20-byte factory address

  Rejected factory values:
  - any non-empty factory value that is neither 0x7702 nor 20 bytes