### PR TITLE
fix(provider): don't count already-accepted-tx errors as RPC failures

### DIFF
--- a/crates/provider/src/alloy/metrics.rs
+++ b/crates/provider/src/alloy/metrics.rs
@@ -115,7 +115,10 @@ where
                     match e {
                         alloy_json_rpc::RpcError::ErrorResp(rpc_error) => {
                             method_logger.record_http(HttpCode::TwoHundreds);
-                            method_logger.record_rpc(get_rpc_status_from_code(rpc_error.code));
+                            method_logger.record_rpc(get_rpc_status_from_error(
+                                rpc_error.code,
+                                &rpc_error.message,
+                            ));
                         }
                         alloy_json_rpc::RpcError::Transport(TransportErrorKind::HttpError(
                             HttpError { status, body: _ },
@@ -165,6 +168,34 @@ fn get_rpc_status_from_code(code: i64) -> RpcCode {
     }
 }
 
+/// Some JSON-RPC "errors" returned when broadcasting a transaction actually
+/// mean the node already accepted it — i.e. rundler re-broadcast an in-flight
+/// or already-mined tx. These are not RPC-provider failures, so they're
+/// recorded under a dedicated `AlreadyExist` status code rather than
+/// `ServerError`, keeping them observable without counting against the RPC
+/// success-rate alert.
+///
+/// Covers the geth-family wordings ("nonce too low", "already known") and the
+/// Cosmos/Ethermint wording ("invalid sequence") seen on e.g. Cronos, where
+/// the node rejects a re-broadcast of an already-consumed account sequence
+/// with `-32000 invalid sequence`.
+fn is_already_known_tx_error(message: &str) -> bool {
+    let message = message.to_ascii_lowercase();
+    message.contains("nonce too low")
+        || message.contains("already known")
+        || message.contains("invalid sequence")
+}
+
+/// Classify a JSON-RPC error response into an `RpcCode`, treating
+/// already-accepted-transaction errors (see [`is_already_known_tx_error`]) as
+/// `AlreadyExist` rather than a server-side failure.
+fn get_rpc_status_from_error(code: i64, message: &str) -> RpcCode {
+    if is_already_known_tx_error(message) {
+        return RpcCode::AlreadyExist;
+    }
+    get_rpc_status_from_code(code)
+}
+
 fn get_http_status_from_code(code: u16) -> HttpCode {
     match code {
         x if (200..=299).contains(&x) => HttpCode::TwoHundreds,
@@ -184,9 +215,10 @@ fn get_rpc_status_code(response_packet: &ResponsePacket) -> RpcCode {
         }
         ResponsePacket::Single(resp) => resp,
     };
-    let response_code: i64 = match &response.payload {
-        alloy_json_rpc::ResponsePayload::Success(_) => 0,
-        alloy_json_rpc::ResponsePayload::Failure(error_payload) => error_payload.code,
-    };
-    get_rpc_status_from_code(response_code)
+    match &response.payload {
+        alloy_json_rpc::ResponsePayload::Success(_) => RpcCode::Success,
+        alloy_json_rpc::ResponsePayload::Failure(error_payload) => {
+            get_rpc_status_from_error(error_payload.code, &error_payload.message)
+        }
+    }
 }


### PR DESCRIPTION
## What

When rundler re-broadcasts an in-flight or already-mined transaction, the node rejects it with an error that actually means *"I already have this"*:

- `nonce too low` / `already known` on geth-family nodes
- `invalid sequence` (code `-32000`) on Cosmos/Ethermint chains (e.g. **Cronos**), whose strict monotonic account sequence rejects the duplicate

These were classified as `ServerError`. Because the bundle submission loop re-broadcasts each pending tx many times per second, a handful of in-flight txns on a low-volume network produced **thousands** of "failed" `eth_sendRawTransaction` RPC calls.

This PR inspects the JSON-RPC error message and records these under the existing `AlreadyExist` RPC status code (label `already_exist`) instead of `ServerError`. The provider correctly holds the tx state — it is not a provider failure. The signal stays observable under its own `status_code`, just out of the failure count.

## Why

On `cronos-testnet` this flapped `RundlerRPCProviderRPCSuccessRateBelowThreshold` (Tier 2) fire/resolve every 1–4h with no real failure — pure on-call channel noise. Investigation showed `bundle_txns_success ≈ 0–1/hr` while failed `eth_sendRawTransaction` spiked to thousands/burst, all `-32000 invalid sequence` re-broadcasts of already-accepted txns.

## Companion change

The alert's success filter is widened to `status_code =~ "success|already_exist"` in **txe-infra** (separate PR). The two are independent and safe to land in any order — until rundler ships this classification, the alert behaves exactly as today.

## Test

- `cargo check -p rundler-provider` ✅
- pre-commit hook (nightly `rustfmt` + `clippy`) ✅