### PR TITLE
feat(rpc): add block option parameter to user operation lookup methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5565,6 +5565,7 @@ version = "0.11.0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-rpc-types-eth",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5586,6 +5586,7 @@ dependencies = [
  "rundler-types",
  "rundler-utils",
  "serde",
+ "serde_json",
  "strum 0.26.3",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 alloy-consensus.workspace = true
 
 alloy-contract.workspace = true
+alloy-eips.workspace = true
 alloy-json-rpc.workspace = true
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -46,3 +46,4 @@ mockall.workspace = true
 rundler-provider = { workspace = true, features = ["test-utils"] }
 rundler-sim = { workspace = true, features = ["test-utils"] }
 rundler-types = { workspace = true, features = ["test-utils"] }
+serde_json.workspace = true

--- a/crates/rpc/src/eth/api.rs
+++ b/crates/rpc/src/eth/api.rs
@@ -292,8 +292,8 @@ mod tests {
     use mockall::predicate::eq;
     use rundler_contracts::v0_6::IEntryPoint::{IEntryPointCalls, handleOpsCall};
     use rundler_provider::{
-        AnyTxEnvelope, FilterBlockOption, Log, MockEntryPointV0_6, MockEvmProvider, Transaction,
-        WithOtherFields,
+        AnyTxEnvelope, FilterBlockOption, Log, MockEntryPointV0_6, MockEvmProvider, ProviderError,
+        Transaction, WithOtherFields,
     };
     use rundler_sim::MockGasEstimator;
     use rundler_types::{
@@ -775,6 +775,249 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_user_op_by_hash_fallback_retries_default_path() {
+        let cs = ChainSpec {
+            id: 1,
+            ..Default::default()
+        };
+        let ep = cs.entry_point_address_v0_6;
+        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
+        let hash = uo.hash();
+
+        let mut pool = MockPool::default();
+        pool.expect_get_op_by_hash()
+            .with(eq(hash))
+            .returning(move |_| Ok(None));
+
+        // With no caller-supplied block option, a failed primary query must retry with
+        // the configured fallback distance.
+        let mut provider = MockEvmProvider::default();
+        provider.expect_get_block_number().returning(|| Ok(1000));
+        provider
+            .expect_get_logs()
+            .withf(|filter| {
+                filter.block_option
+                    == FilterBlockOption::Range {
+                        from_block: Some(500u64.into()),
+                        to_block: Some(1000u64.into()),
+                    }
+            })
+            .times(1)
+            .returning(|_| Err(ProviderError::Other(anyhow::anyhow!("range too large"))));
+        provider
+            .expect_get_logs()
+            .withf(|filter| {
+                filter.block_option
+                    == FilterBlockOption::Range {
+                        from_block: Some(900u64.into()),
+                        to_block: Some(1000u64.into()),
+                    }
+            })
+            .times(1)
+            .returning(|_| Ok(vec![]));
+
+        let mut entry_point = MockEntryPointV0_6::default();
+        entry_point.expect_address().return_const(ep);
+
+        let api = create_api_with_event_distances(
+            provider,
+            entry_point,
+            pool,
+            MockGasEstimator::default(),
+            false,
+            Some(500),
+            Some(100),
+        );
+        let res = api
+            .get_user_operation_by_hash(hash, EventBlockOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(res, None);
+    }
+
+    #[tokio::test]
+    async fn test_get_user_op_by_hash_fallback_suppressed_with_block_option() {
+        let cs = ChainSpec {
+            id: 1,
+            ..Default::default()
+        };
+        let ep = cs.entry_point_address_v0_6;
+        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
+        let hash = uo.hash();
+
+        let mut pool = MockPool::default();
+        pool.expect_get_op_by_hash()
+            .with(eq(hash))
+            .returning(move |_| Ok(None));
+
+        // A caller-supplied block option must be used as-is: on error there is no
+        // fallback retry (a second get_logs call would fail the mock's times(1)).
+        let mut provider = MockEvmProvider::default();
+        provider
+            .expect_get_logs()
+            .withf(|filter| {
+                filter.block_option
+                    == FilterBlockOption::Range {
+                        from_block: Some(100u64.into()),
+                        to_block: Some(200u64.into()),
+                    }
+            })
+            .times(1)
+            .returning(|_| Err(ProviderError::Other(anyhow::anyhow!("boom"))));
+
+        let mut entry_point = MockEntryPointV0_6::default();
+        entry_point.expect_address().return_const(ep);
+
+        let api = create_api_with_event_distances(
+            provider,
+            entry_point,
+            pool,
+            MockGasEstimator::default(),
+            false,
+            None,
+            Some(100),
+        );
+        let res = api
+            .get_user_operation_by_hash(
+                hash,
+                EventBlockOptions {
+                    block_option: Some(FilterBlockOption::Range {
+                        from_block: Some(100u64.into()),
+                        to_block: Some(200u64.into()),
+                    }),
+                    max_block_range: None,
+                },
+            )
+            .await;
+        assert!(res.is_err(), "expected the provider error to propagate");
+    }
+
+    #[tokio::test]
+    async fn test_get_user_op_by_hash_fallback_capped_by_max_block_range() {
+        let cs = ChainSpec {
+            id: 1,
+            ..Default::default()
+        };
+        let ep = cs.entry_point_address_v0_6;
+        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
+        let hash = uo.hash();
+
+        let mut pool = MockPool::default();
+        pool.expect_get_op_by_hash()
+            .with(eq(hash))
+            .returning(move |_| Ok(None));
+
+        // The per-request max (50) bounds the primary window; the fallback retry (a
+        // larger configured 80) must be capped to it as well.
+        let mut provider = MockEvmProvider::default();
+        provider.expect_get_block_number().returning(|| Ok(1000));
+        provider
+            .expect_get_logs()
+            .withf(|filter| {
+                filter.block_option
+                    == FilterBlockOption::Range {
+                        from_block: Some(950u64.into()),
+                        to_block: Some(1000u64.into()),
+                    }
+            })
+            .times(2)
+            .returning({
+                let mut first = true;
+                move |_| {
+                    if first {
+                        first = false;
+                        Err(ProviderError::Other(anyhow::anyhow!("transient")))
+                    } else {
+                        Ok(vec![])
+                    }
+                }
+            });
+
+        let mut entry_point = MockEntryPointV0_6::default();
+        entry_point.expect_address().return_const(ep);
+
+        let api = create_api_with_event_distances(
+            provider,
+            entry_point,
+            pool,
+            MockGasEstimator::default(),
+            false,
+            None,
+            Some(80),
+        );
+        let res = api
+            .get_user_operation_by_hash(
+                hash,
+                EventBlockOptions {
+                    block_option: None,
+                    max_block_range: Some(50),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(res, None);
+    }
+
+    #[tokio::test]
+    async fn test_get_user_op_by_hash_empty_range_treated_as_omitted() {
+        let cs = ChainSpec {
+            id: 1,
+            ..Default::default()
+        };
+        let ep = cs.entry_point_address_v0_6;
+        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
+        let hash = uo.hash();
+
+        let mut pool = MockPool::default();
+        pool.expect_get_op_by_hash()
+            .with(eq(hash))
+            .returning(move |_| Ok(None));
+
+        // An empty range `{}` carries no information: the default search window must be
+        // used, not the node's getLogs defaults.
+        let mut provider = MockEvmProvider::default();
+        provider.expect_get_block_number().returning(|| Ok(1000));
+        provider
+            .expect_get_logs()
+            .withf(|filter| {
+                filter.block_option
+                    == FilterBlockOption::Range {
+                        from_block: Some(900u64.into()),
+                        to_block: Some(1000u64.into()),
+                    }
+            })
+            .times(1)
+            .returning(|_| Ok(vec![]));
+
+        let mut entry_point = MockEntryPointV0_6::default();
+        entry_point.expect_address().return_const(ep);
+
+        let api = create_api_with_event_distances(
+            provider,
+            entry_point,
+            pool,
+            MockGasEstimator::default(),
+            false,
+            Some(100),
+            None,
+        );
+        let res = api
+            .get_user_operation_by_hash(
+                hash,
+                EventBlockOptions {
+                    block_option: Some(FilterBlockOption::Range {
+                        from_block: None,
+                        to_block: None,
+                    }),
+                    max_block_range: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(res, None);
+    }
+
+    #[tokio::test]
     async fn test_send_user_op_header_permissions_take_precedence() {
         use std::sync::Mutex;
 
@@ -859,6 +1102,26 @@ mod tests {
         gas_estimator: MockGasEstimator,
         permissions_enabled: bool,
     ) -> EthApi<MockPool, Arc<MockEvmProvider>> {
+        create_api_with_event_distances(
+            provider,
+            ep,
+            pool,
+            gas_estimator,
+            permissions_enabled,
+            None,
+            None,
+        )
+    }
+
+    fn create_api_with_event_distances(
+        provider: MockEvmProvider,
+        ep: MockEntryPointV0_6,
+        pool: MockPool,
+        gas_estimator: MockGasEstimator,
+        permissions_enabled: bool,
+        event_block_distance: Option<u64>,
+        event_block_distance_fallback: Option<u64>,
+    ) -> EthApi<MockPool, Arc<MockEvmProvider>> {
         let ep = Arc::new(ep);
         let provider = Arc::new(provider);
         let chain_spec = ChainSpec {
@@ -874,8 +1137,8 @@ mod tests {
                     chain_spec.clone(),
                     chain_spec.entry_point_address_v0_6,
                     provider.clone(),
-                    None,
-                    None,
+                    event_block_distance,
+                    event_block_distance_fallback,
                 ),
             ))
             .build();

--- a/crates/rpc/src/eth/api.rs
+++ b/crates/rpc/src/eth/api.rs
@@ -15,7 +15,7 @@ use std::{future::Future, pin::Pin};
 
 use alloy_primitives::{Address, B256, U64};
 use futures_util::future;
-use rundler_provider::StateOverride;
+use rundler_provider::{FilterBlockOption, StateOverride};
 use rundler_types::{
     BlockTag, UserOperation, UserOperationOptionalGas, UserOperationPermissions,
     UserOperationVariant, chain::ChainSpec, pool::Pool,
@@ -132,6 +132,7 @@ where
     pub(crate) async fn get_user_operation_by_hash(
         &self,
         hash: B256,
+        block_option: Option<FilterBlockOption>,
     ) -> EthResult<Option<RpcUserOperationByHash>> {
         if hash == B256::ZERO {
             return Err(EthRpcError::InvalidParams(
@@ -148,7 +149,7 @@ where
         for ep in self.router.entry_points() {
             futs.push(Box::pin(async move {
                 self.router
-                    .get_mined_by_hash(ep, hash)
+                    .get_mined_by_hash(ep, hash, block_option)
                     .await
                     .map_err(EthRpcError::from)
             }));
@@ -164,6 +165,7 @@ where
         &self,
         hash: B256,
         tag: Option<BlockTag>,
+        block_option: Option<FilterBlockOption>,
     ) -> EthResult<Option<RpcUserOperationReceipt>> {
         if hash == B256::ZERO {
             return Err(EthRpcError::InvalidParams(
@@ -191,7 +193,12 @@ where
             {
                 let ret = self
                     .router
-                    .get_receipt(&op_status.entry_point, hash, Some(preconf_info.tx_hash))
+                    .get_receipt(
+                        &op_status.entry_point,
+                        hash,
+                        Some(preconf_info.tx_hash),
+                        None,
+                    )
                     .await;
                 match ret {
                     Ok(Some(receipt)) => return Ok(Some(receipt)),
@@ -217,7 +224,7 @@ where
         let futs = self
             .router
             .entry_points()
-            .map(|ep| self.router.get_receipt(ep, hash, None));
+            .map(|ep| self.router.get_receipt(ep, hash, None, block_option));
         let results = future::try_join_all(futs).await?;
         Ok(results.into_iter().find_map(|x| x))
     }
@@ -328,7 +335,7 @@ mod tests {
             MockGasEstimator::default(),
             false,
         );
-        let res = api.get_user_operation_by_hash(hash).await.unwrap();
+        let res = api.get_user_operation_by_hash(hash, None).await.unwrap();
         let ro = RpcUserOperationByHash {
             user_operation: UserOperationVariant::from(uo).into(),
             entry_point: ep.into(),
@@ -412,7 +419,7 @@ mod tests {
             MockGasEstimator::default(),
             false,
         );
-        let res = api.get_user_operation_by_hash(hash).await.unwrap();
+        let res = api.get_user_operation_by_hash(hash, None).await.unwrap();
         let ro = RpcUserOperationByHash {
             user_operation: UserOperationVariant::from(uo).into(),
             entry_point: ep.into(),
@@ -453,8 +460,56 @@ mod tests {
             MockGasEstimator::default(),
             false,
         );
-        let res = api.get_user_operation_by_hash(hash).await.unwrap();
+        let res = api.get_user_operation_by_hash(hash, None).await.unwrap();
         assert_eq!(res, None);
+    }
+
+    #[tokio::test]
+    async fn test_get_user_op_by_hash_with_block_option() {
+        let cs = ChainSpec {
+            id: 1,
+            ..Default::default()
+        };
+        let ep = cs.entry_point_address_v0_6;
+        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
+        let hash = uo.hash();
+
+        for block_option in [
+            FilterBlockOption::Range {
+                from_block: Some(100u64.into()),
+                to_block: Some(200u64.into()),
+            },
+            FilterBlockOption::AtBlockHash(B256::random()),
+        ] {
+            let mut pool = MockPool::default();
+            pool.expect_get_op_by_hash()
+                .with(eq(hash))
+                .returning(move |_| Ok(None));
+
+            // no `expect_get_block_number`: a caller-supplied block option must skip
+            // the latest-block lookup used to compute the default search window
+            let mut provider = MockEvmProvider::default();
+            provider
+                .expect_get_logs()
+                .withf(move |filter| filter.block_option == block_option)
+                .returning(move |_| Ok(vec![]));
+
+            let mut entry_point = MockEntryPointV0_6::default();
+            entry_point.expect_address().return_const(ep);
+
+            let api = create_api(
+                provider,
+                entry_point,
+                pool,
+                MockGasEstimator::default(),
+                false,
+            );
+            let res = api
+                .get_user_operation_by_hash(hash, Some(block_option))
+                .await
+                .unwrap();
+            assert_eq!(res, None);
+        }
     }
 
     fn create_api(

--- a/crates/rpc/src/eth/api.rs
+++ b/crates/rpc/src/eth/api.rs
@@ -133,6 +133,7 @@ where
         &self,
         hash: B256,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EthResult<Option<RpcUserOperationByHash>> {
         if hash == B256::ZERO {
             return Err(EthRpcError::InvalidParams(
@@ -149,7 +150,7 @@ where
         for ep in self.router.entry_points() {
             futs.push(Box::pin(async move {
                 self.router
-                    .get_mined_by_hash(ep, hash, block_option)
+                    .get_mined_by_hash(ep, hash, block_option, max_block_range)
                     .await
                     .map_err(EthRpcError::from)
             }));
@@ -166,6 +167,7 @@ where
         hash: B256,
         tag: Option<BlockTag>,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EthResult<Option<RpcUserOperationReceipt>> {
         if hash == B256::ZERO {
             return Err(EthRpcError::InvalidParams(
@@ -198,6 +200,7 @@ where
                         hash,
                         Some(preconf_info.tx_hash),
                         None,
+                        max_block_range,
                     )
                     .await;
                 match ret {
@@ -221,10 +224,10 @@ where
             }
         };
 
-        let futs = self
-            .router
-            .entry_points()
-            .map(|ep| self.router.get_receipt(ep, hash, None, block_option));
+        let futs = self.router.entry_points().map(|ep| {
+            self.router
+                .get_receipt(ep, hash, None, block_option, max_block_range)
+        });
         let results = future::try_join_all(futs).await?;
         Ok(results.into_iter().find_map(|x| x))
     }
@@ -335,7 +338,10 @@ mod tests {
             MockGasEstimator::default(),
             false,
         );
-        let res = api.get_user_operation_by_hash(hash, None).await.unwrap();
+        let res = api
+            .get_user_operation_by_hash(hash, None, None)
+            .await
+            .unwrap();
         let ro = RpcUserOperationByHash {
             user_operation: UserOperationVariant::from(uo).into(),
             entry_point: ep.into(),
@@ -419,7 +425,10 @@ mod tests {
             MockGasEstimator::default(),
             false,
         );
-        let res = api.get_user_operation_by_hash(hash, None).await.unwrap();
+        let res = api
+            .get_user_operation_by_hash(hash, None, None)
+            .await
+            .unwrap();
         let ro = RpcUserOperationByHash {
             user_operation: UserOperationVariant::from(uo).into(),
             entry_point: ep.into(),
@@ -460,7 +469,10 @@ mod tests {
             MockGasEstimator::default(),
             false,
         );
-        let res = api.get_user_operation_by_hash(hash, None).await.unwrap();
+        let res = api
+            .get_user_operation_by_hash(hash, None, None)
+            .await
+            .unwrap();
         assert_eq!(res, None);
     }
 
@@ -505,11 +517,129 @@ mod tests {
                 false,
             );
             let res = api
-                .get_user_operation_by_hash(hash, Some(block_option))
+                .get_user_operation_by_hash(hash, Some(block_option), None)
                 .await
                 .unwrap();
             assert_eq!(res, None);
         }
+    }
+
+    #[tokio::test]
+    async fn test_get_user_op_by_hash_max_block_range_override() {
+        let cs = ChainSpec {
+            id: 1,
+            ..Default::default()
+        };
+        let ep = cs.entry_point_address_v0_6;
+        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
+        let hash = uo.hash();
+
+        let mut pool = MockPool::default();
+        pool.expect_get_op_by_hash()
+            .with(eq(hash))
+            .returning(move |_| Ok(None));
+
+        // The event provider is constructed with no static block distance, so a non-default
+        // search window proves the per-request override is applied.
+        let mut provider = MockEvmProvider::default();
+        provider.expect_get_block_number().returning(|| Ok(1000));
+        provider
+            .expect_get_logs()
+            .withf(|filter| {
+                filter.block_option
+                    == FilterBlockOption::Range {
+                        from_block: Some(900u64.into()),
+                        to_block: Some(1000u64.into()),
+                    }
+            })
+            .returning(move |_| Ok(vec![]));
+
+        let mut entry_point = MockEntryPointV0_6::default();
+        entry_point.expect_address().return_const(ep);
+
+        let api = create_api(
+            provider,
+            entry_point,
+            pool,
+            MockGasEstimator::default(),
+            false,
+        );
+        let res = api
+            .get_user_operation_by_hash(hash, None, Some(100))
+            .await
+            .unwrap();
+        assert_eq!(res, None);
+    }
+
+    #[tokio::test]
+    async fn test_send_user_op_header_permissions_take_precedence() {
+        use std::sync::Mutex;
+
+        use http::Extensions;
+        use rundler_types::EntryPointVersion;
+
+        use crate::{
+            eth::{EntryPointRouteImpl, EntryPointRouterBuilder, EthApiServer},
+            types::{RpcPermissions, RpcUserOperation},
+        };
+
+        let chain_spec = ChainSpec {
+            id: 1,
+            max_transaction_size_bytes: 1_000_000,
+            ..Default::default()
+        };
+        let ep = chain_spec.entry_point_address_v0_6;
+        let uo =
+            UserOperationBuilder::new(&chain_spec, UserOperationRequiredFields::default()).build();
+
+        let captured = Arc::new(Mutex::new(None));
+        let captured_clone = captured.clone();
+        let mut pool = MockPool::default();
+        pool.expect_add_op().returning(move |_, perms| {
+            *captured_clone.lock().unwrap() = Some(perms);
+            Ok(B256::ZERO)
+        });
+
+        let provider = Arc::new(MockEvmProvider::default());
+        let mut entry_point = MockEntryPointV0_6::default();
+        entry_point.expect_address().return_const(ep);
+        entry_point
+            .expect_version()
+            .return_const(EntryPointVersion::V0_6);
+
+        let router = EntryPointRouterBuilder::default()
+            .add_route(EntryPointRouteImpl::new(
+                Arc::new(entry_point),
+                MockGasEstimator::default(),
+                UserOperationEventProviderV0_6::new(chain_spec.clone(), ep, provider, None, None),
+            ))
+            .build();
+
+        let api = EthApi {
+            router,
+            chain_spec,
+            pool,
+            permissions_enabled: true,
+        };
+
+        // Positional parameter says untrusted; the header says trusted. The header must win.
+        let mut ext = Extensions::new();
+        ext.insert(RpcPermissions {
+            trusted: true,
+            ..Default::default()
+        });
+        let positional = RpcPermissions {
+            trusted: false,
+            ..Default::default()
+        };
+
+        let rpc_uo: RpcUserOperation = UserOperationVariant::from(uo).into();
+        EthApiServer::send_user_operation(&api, &ext, rpc_uo, ep, Some(positional))
+            .await
+            .unwrap();
+
+        let perms = captured.lock().unwrap().clone().unwrap();
+        assert!(perms.trusted, "header permissions should take precedence");
     }
 
     fn create_api(

--- a/crates/rpc/src/eth/api.rs
+++ b/crates/rpc/src/eth/api.rs
@@ -15,7 +15,7 @@ use std::{future::Future, pin::Pin};
 
 use alloy_primitives::{Address, B256, U64};
 use futures_util::future;
-use rundler_provider::{FilterBlockOption, StateOverride};
+use rundler_provider::{EvmProvider, FilterBlockOption, StateOverride};
 use rundler_types::{
     BlockTag, UserOperation, UserOperationOptionalGas, UserOperationPermissions,
     UserOperationVariant, chain::ChainSpec, pool::Pool,
@@ -28,31 +28,35 @@ use super::{
     router::EntryPointRouter,
 };
 use crate::{
-    eth::events::EventProviderError,
+    eth::events::{self, EventProviderError},
     types::{RpcGasEstimate, RpcUserOperationByHash, RpcUserOperationReceipt},
 };
 
-pub(crate) struct EthApi<P> {
+pub(crate) struct EthApi<P, E> {
     pub(crate) chain_spec: ChainSpec,
     pool: P,
     router: EntryPointRouter,
+    provider: E,
     pub(crate) permissions_enabled: bool,
 }
 
-impl<P> EthApi<P>
+impl<P, E> EthApi<P, E>
 where
     P: Pool,
+    E: EvmProvider,
 {
     pub(crate) fn new(
         chain_spec: ChainSpec,
         router: EntryPointRouter,
         pool: P,
+        provider: E,
         permissions_enabled: bool,
     ) -> Self {
         Self {
             router,
             pool,
             chain_spec,
+            provider,
             permissions_enabled,
         }
     }
@@ -141,6 +145,8 @@ where
             ));
         }
 
+        let block_option = self.resolve_block_option(block_option).await?;
+
         // check both entry points and pending for the user operation event
         #[allow(clippy::type_complexity)]
         let mut futs: Vec<
@@ -174,6 +180,8 @@ where
                 "Missing/invalid userOpHash".to_string(),
             ));
         }
+
+        let block_option = self.resolve_block_option(block_option).await?;
         let tag = tag.unwrap_or(BlockTag::Latest);
 
         if tag == BlockTag::Pending {
@@ -264,6 +272,22 @@ where
             block_hash: None,
             transaction_hash: None,
         }))
+    }
+
+    // Resolve block tags to concrete numbers once, before fanning out to the entry point
+    // routes, so each route doesn't re-resolve them via RPC.
+    async fn resolve_block_option(
+        &self,
+        block_option: Option<FilterBlockOption>,
+    ) -> EthResult<Option<FilterBlockOption>> {
+        match block_option {
+            Some(bo) => Ok(Some(
+                events::resolve_block_option(&self.provider, bo)
+                    .await
+                    .map_err(EthRpcError::from)?,
+            )),
+            None => Ok(None),
+        }
     }
 }
 
@@ -572,6 +596,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_user_op_by_hash_resolves_tags_once() {
+        use alloy_eips::BlockNumberOrTag;
+
+        let cs = ChainSpec {
+            id: 1,
+            ..Default::default()
+        };
+        let ep = cs.entry_point_address_v0_6;
+        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
+        let hash = uo.hash();
+
+        let mut pool = MockPool::default();
+        pool.expect_get_op_by_hash()
+            .with(eq(hash))
+            .returning(move |_| Ok(None));
+
+        // A latest..latest range must be resolved to concrete numbers with a single
+        // get_block call before the fan-out; the filter must see the numbers.
+        let mut inner = alloy_rpc_types_eth::Block::<
+            rundler_provider::AnyRpcTransaction,
+            rundler_provider::AnyRpcHeader,
+        >::default();
+        inner.header.inner.number = 1000;
+        let block = rundler_provider::Block::new(WithOtherFields::new(inner));
+        let mut provider = MockEvmProvider::default();
+        provider
+            .expect_get_block()
+            .times(1)
+            .returning(move |_| Ok(Some(block.clone())));
+        provider
+            .expect_get_logs()
+            .withf(|filter| {
+                filter.block_option
+                    == FilterBlockOption::Range {
+                        from_block: Some(1000u64.into()),
+                        to_block: Some(1000u64.into()),
+                    }
+            })
+            .returning(move |_| Ok(vec![]));
+
+        let mut entry_point = MockEntryPointV0_6::default();
+        entry_point.expect_address().return_const(ep);
+
+        let api = create_api(
+            provider,
+            entry_point,
+            pool,
+            MockGasEstimator::default(),
+            false,
+        );
+        let res = api
+            .get_user_operation_by_hash(
+                hash,
+                Some(FilterBlockOption::Range {
+                    from_block: Some(BlockNumberOrTag::Latest),
+                    to_block: Some(BlockNumberOrTag::Latest),
+                }),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(res, None);
+    }
+
+    #[tokio::test]
     async fn test_get_user_op_by_hash_block_option_invalid_ranges() {
         let cs = ChainSpec {
             id: 1,
@@ -663,7 +752,13 @@ mod tests {
             .add_route(EntryPointRouteImpl::new(
                 Arc::new(entry_point),
                 MockGasEstimator::default(),
-                UserOperationEventProviderV0_6::new(chain_spec.clone(), ep, provider, None, None),
+                UserOperationEventProviderV0_6::new(
+                    chain_spec.clone(),
+                    ep,
+                    provider.clone(),
+                    None,
+                    None,
+                ),
             ))
             .build();
 
@@ -671,6 +766,7 @@ mod tests {
             router,
             chain_spec,
             pool,
+            provider,
             permissions_enabled: true,
         };
 
@@ -700,7 +796,7 @@ mod tests {
         pool: MockPool,
         gas_estimator: MockGasEstimator,
         permissions_enabled: bool,
-    ) -> EthApi<MockPool> {
+    ) -> EthApi<MockPool, Arc<MockEvmProvider>> {
         let ep = Arc::new(ep);
         let provider = Arc::new(provider);
         let chain_spec = ChainSpec {
@@ -726,6 +822,7 @@ mod tests {
             router,
             chain_spec,
             pool,
+            provider,
             permissions_enabled,
         }
     }

--- a/crates/rpc/src/eth/api.rs
+++ b/crates/rpc/src/eth/api.rs
@@ -572,6 +572,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_user_op_by_hash_block_option_invalid_ranges() {
+        let cs = ChainSpec {
+            id: 1,
+            ..Default::default()
+        };
+        let ep = cs.entry_point_address_v0_6;
+        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
+        let hash = uo.hash();
+
+        // Wider than the max block range, missing a bound while a max is enforced, and
+        // reversed: all must surface as invalid params, not an internal error.
+        for block_option in [
+            FilterBlockOption::Range {
+                from_block: Some(100u64.into()),
+                to_block: Some(300u64.into()),
+            },
+            FilterBlockOption::Range {
+                from_block: Some(100u64.into()),
+                to_block: None,
+            },
+            FilterBlockOption::Range {
+                from_block: Some(300u64.into()),
+                to_block: Some(100u64.into()),
+            },
+        ] {
+            let mut pool = MockPool::default();
+            pool.expect_get_op_by_hash()
+                .with(eq(hash))
+                .returning(move |_| Ok(None));
+
+            let mut entry_point = MockEntryPointV0_6::default();
+            entry_point.expect_address().return_const(ep);
+
+            let api = create_api(
+                MockEvmProvider::default(),
+                entry_point,
+                pool,
+                MockGasEstimator::default(),
+                false,
+            );
+            let err = api
+                .get_user_operation_by_hash(hash, Some(block_option), Some(100))
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, EthRpcError::InvalidParams(_)),
+                "expected invalid params, got {err:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn test_send_user_op_header_permissions_take_precedence() {
         use std::sync::Mutex;
 

--- a/crates/rpc/src/eth/api.rs
+++ b/crates/rpc/src/eth/api.rs
@@ -15,7 +15,7 @@ use std::{future::Future, pin::Pin};
 
 use alloy_primitives::{Address, B256, U64};
 use futures_util::future;
-use rundler_provider::{EvmProvider, FilterBlockOption, StateOverride};
+use rundler_provider::{EvmProvider, StateOverride};
 use rundler_types::{
     BlockTag, UserOperation, UserOperationOptionalGas, UserOperationPermissions,
     UserOperationVariant, chain::ChainSpec, pool::Pool,
@@ -28,7 +28,7 @@ use super::{
     router::EntryPointRouter,
 };
 use crate::{
-    eth::events::{self, EventProviderError},
+    eth::events::{self, EventBlockOptions, EventProviderError},
     types::{RpcGasEstimate, RpcUserOperationByHash, RpcUserOperationReceipt},
 };
 
@@ -136,8 +136,7 @@ where
     pub(crate) async fn get_user_operation_by_hash(
         &self,
         hash: B256,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EthResult<Option<RpcUserOperationByHash>> {
         if hash == B256::ZERO {
             return Err(EthRpcError::InvalidParams(
@@ -145,7 +144,7 @@ where
             ));
         }
 
-        let block_option = self.resolve_block_option(block_option).await?;
+        let block_options = self.resolve_block_options(block_options).await?;
 
         // check both entry points and pending for the user operation event
         #[allow(clippy::type_complexity)]
@@ -156,7 +155,7 @@ where
         for ep in self.router.entry_points() {
             futs.push(Box::pin(async move {
                 self.router
-                    .get_mined_by_hash(ep, hash, block_option, max_block_range)
+                    .get_mined_by_hash(ep, hash, block_options)
                     .await
                     .map_err(EthRpcError::from)
             }));
@@ -172,8 +171,7 @@ where
         &self,
         hash: B256,
         tag: Option<BlockTag>,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EthResult<Option<RpcUserOperationReceipt>> {
         if hash == B256::ZERO {
             return Err(EthRpcError::InvalidParams(
@@ -181,7 +179,7 @@ where
             ));
         }
 
-        let block_option = self.resolve_block_option(block_option).await?;
+        let block_options = self.resolve_block_options(block_options).await?;
         let tag = tag.unwrap_or(BlockTag::Latest);
 
         if tag == BlockTag::Pending {
@@ -207,8 +205,10 @@ where
                         &op_status.entry_point,
                         hash,
                         Some(preconf_info.tx_hash),
-                        None,
-                        max_block_range,
+                        EventBlockOptions {
+                            block_option: None,
+                            ..block_options
+                        },
                     )
                     .await;
                 match ret {
@@ -232,10 +232,10 @@ where
             }
         };
 
-        let futs = self.router.entry_points().map(|ep| {
-            self.router
-                .get_receipt(ep, hash, None, block_option, max_block_range)
-        });
+        let futs = self
+            .router
+            .entry_points()
+            .map(|ep| self.router.get_receipt(ep, hash, None, block_options));
         let results = future::try_join_all(futs).await?;
         Ok(results.into_iter().find_map(|x| x))
     }
@@ -276,18 +276,22 @@ where
 
     // Resolve block tags to concrete numbers once, before fanning out to the entry point
     // routes, so each route doesn't re-resolve them via RPC.
-    async fn resolve_block_option(
+    async fn resolve_block_options(
         &self,
-        block_option: Option<FilterBlockOption>,
-    ) -> EthResult<Option<FilterBlockOption>> {
-        match block_option {
-            Some(bo) => Ok(Some(
+        block_options: EventBlockOptions,
+    ) -> EthResult<EventBlockOptions> {
+        let block_option = match block_options.block_option {
+            Some(bo) => Some(
                 events::resolve_block_option(&self.provider, bo)
                     .await
                     .map_err(EthRpcError::from)?,
-            )),
-            None => Ok(None),
-        }
+            ),
+            None => None,
+        };
+        Ok(EventBlockOptions {
+            block_option,
+            ..block_options
+        })
     }
 }
 
@@ -302,7 +306,8 @@ mod tests {
     use mockall::predicate::eq;
     use rundler_contracts::v0_6::IEntryPoint::{IEntryPointCalls, handleOpsCall};
     use rundler_provider::{
-        AnyTxEnvelope, Log, MockEntryPointV0_6, MockEvmProvider, Transaction, WithOtherFields,
+        AnyTxEnvelope, FilterBlockOption, Log, MockEntryPointV0_6, MockEvmProvider, Transaction,
+        WithOtherFields,
     };
     use rundler_sim::MockGasEstimator;
     use rundler_types::{
@@ -363,7 +368,7 @@ mod tests {
             false,
         );
         let res = api
-            .get_user_operation_by_hash(hash, None, None)
+            .get_user_operation_by_hash(hash, EventBlockOptions::default())
             .await
             .unwrap();
         let ro = RpcUserOperationByHash {
@@ -450,7 +455,7 @@ mod tests {
             false,
         );
         let res = api
-            .get_user_operation_by_hash(hash, None, None)
+            .get_user_operation_by_hash(hash, EventBlockOptions::default())
             .await
             .unwrap();
         let ro = RpcUserOperationByHash {
@@ -494,7 +499,7 @@ mod tests {
             false,
         );
         let res = api
-            .get_user_operation_by_hash(hash, None, None)
+            .get_user_operation_by_hash(hash, EventBlockOptions::default())
             .await
             .unwrap();
         assert_eq!(res, None);
@@ -541,7 +546,13 @@ mod tests {
                 false,
             );
             let res = api
-                .get_user_operation_by_hash(hash, Some(block_option), None)
+                .get_user_operation_by_hash(
+                    hash,
+                    EventBlockOptions {
+                        block_option: Some(block_option),
+                        max_block_range: None,
+                    },
+                )
                 .await
                 .unwrap();
             assert_eq!(res, None);
@@ -589,7 +600,13 @@ mod tests {
             false,
         );
         let res = api
-            .get_user_operation_by_hash(hash, None, Some(100))
+            .get_user_operation_by_hash(
+                hash,
+                EventBlockOptions {
+                    block_option: None,
+                    max_block_range: Some(100),
+                },
+            )
             .await
             .unwrap();
         assert_eq!(res, None);
@@ -649,11 +666,13 @@ mod tests {
         let res = api
             .get_user_operation_by_hash(
                 hash,
-                Some(FilterBlockOption::Range {
-                    from_block: Some(BlockNumberOrTag::Latest),
-                    to_block: Some(BlockNumberOrTag::Latest),
-                }),
-                None,
+                EventBlockOptions {
+                    block_option: Some(FilterBlockOption::Range {
+                        from_block: Some(BlockNumberOrTag::Latest),
+                        to_block: Some(BlockNumberOrTag::Latest),
+                    }),
+                    max_block_range: None,
+                },
             )
             .await
             .unwrap();
@@ -702,7 +721,13 @@ mod tests {
                 false,
             );
             let err = api
-                .get_user_operation_by_hash(hash, Some(block_option), Some(100))
+                .get_user_operation_by_hash(
+                    hash,
+                    EventBlockOptions {
+                        block_option: Some(block_option),
+                        max_block_range: Some(100),
+                    },
+                )
                 .await
                 .unwrap_err();
             assert!(

--- a/crates/rpc/src/eth/api.rs
+++ b/crates/rpc/src/eth/api.rs
@@ -286,6 +286,7 @@ mod tests {
     use std::sync::Arc;
 
     use alloy_consensus::{Signed, TxEip1559, transaction::Recovered};
+    use alloy_eips::BlockNumberOrTag;
     use alloy_primitives::{Log as PrimitiveLog, LogData, Signature, TxKind, U256};
     use alloy_rpc_types_eth::Transaction as AlloyTransaction;
     use alloy_sol_types::SolInterface;
@@ -491,54 +492,150 @@ mod tests {
         assert_eq!(res, None);
     }
 
-    #[tokio::test]
-    async fn test_get_user_op_by_hash_with_block_option() {
-        let cs = ChainSpec {
-            id: 1,
-            ..Default::default()
-        };
-        let ep = cs.entry_point_address_v0_6;
-        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
-        let hash = uo.hash();
+    /// Fixture for `get_user_operation_by_hash` lookup tests: a pool with no pending
+    /// op, a single v0.6 entry point, and per-test provider expectations.
+    struct LookupTest {
+        provider: MockEvmProvider,
+        event_block_distance: Option<u64>,
+        event_block_distance_fallback: Option<u64>,
+    }
 
-        for block_option in [
-            FilterBlockOption::Range {
-                from_block: Some(100u64.into()),
-                to_block: Some(200u64.into()),
-            },
-            FilterBlockOption::AtBlockHash(B256::random()),
-        ] {
+    fn range(from: u64, to: u64) -> FilterBlockOption {
+        FilterBlockOption::Range {
+            from_block: Some(from.into()),
+            to_block: Some(to.into()),
+        }
+    }
+
+    impl LookupTest {
+        fn new() -> Self {
+            Self {
+                provider: MockEvmProvider::default(),
+                event_block_distance: None,
+                event_block_distance_fallback: None,
+            }
+        }
+
+        fn distances(mut self, distance: Option<u64>, fallback: Option<u64>) -> Self {
+            self.event_block_distance = distance;
+            self.event_block_distance_fallback = fallback;
+            self
+        }
+
+        /// The provider's latest block number, used to compute default search windows.
+        fn latest_block(mut self, number: u64) -> Self {
+            self.provider
+                .expect_get_block_number()
+                .returning(move || Ok(number));
+            self
+        }
+
+        /// Expect exactly one tag-resolving `get_block` call, resolving to `number`.
+        fn resolves_tag_to(mut self, number: u64) -> Self {
+            let mut inner = alloy_rpc_types_eth::Block::<
+                rundler_provider::AnyRpcTransaction,
+                rundler_provider::AnyRpcHeader,
+            >::default();
+            inner.header.inner.number = number;
+            let block = rundler_provider::Block::new(WithOtherFields::new(inner));
+            self.provider
+                .expect_get_block()
+                .times(1)
+                .returning(move |_| Ok(Some(block.clone())));
+            self
+        }
+
+        /// Tag resolution finds no block.
+        fn tag_unresolvable(mut self) -> Self {
+            self.provider.expect_get_block().returning(|_| Ok(None));
+            self
+        }
+
+        /// Expect exactly one `get_logs` call for `block_option`, returning no logs.
+        fn logs_empty(mut self, block_option: FilterBlockOption) -> Self {
+            self.provider
+                .expect_get_logs()
+                .withf(move |filter| filter.block_option == block_option)
+                .times(1)
+                .returning(|_| Ok(vec![]));
+            self
+        }
+
+        /// Expect exactly one `get_logs` call for `block_option`, returning an error.
+        fn logs_error(mut self, block_option: FilterBlockOption) -> Self {
+            self.provider
+                .expect_get_logs()
+                .withf(move |filter| filter.block_option == block_option)
+                .times(1)
+                .returning(|_| Err(ProviderError::Other(anyhow::anyhow!("getLogs failed"))));
+            self
+        }
+
+        /// Expect exactly two `get_logs` calls for `block_option`: an error, then no logs.
+        fn logs_error_then_empty(mut self, block_option: FilterBlockOption) -> Self {
+            let mut first = true;
+            self.provider
+                .expect_get_logs()
+                .withf(move |filter| filter.block_option == block_option)
+                .times(2)
+                .returning(move |_| {
+                    if first {
+                        first = false;
+                        Err(ProviderError::Other(anyhow::anyhow!("getLogs failed")))
+                    } else {
+                        Ok(vec![])
+                    }
+                });
+            self
+        }
+
+        async fn run(
+            self,
+            block_options: EventBlockOptions,
+        ) -> EthResult<Option<RpcUserOperationByHash>> {
+            let cs = ChainSpec {
+                id: 1,
+                ..Default::default()
+            };
+            let ep = cs.entry_point_address_v0_6;
+            let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
+            let hash = uo.hash();
+
             let mut pool = MockPool::default();
             pool.expect_get_op_by_hash()
                 .with(eq(hash))
                 .returning(move |_| Ok(None));
 
-            // no `expect_get_block_number`: a caller-supplied block option must skip
-            // the latest-block lookup used to compute the default search window
-            let mut provider = MockEvmProvider::default();
-            provider
-                .expect_get_logs()
-                .withf(move |filter| filter.block_option == block_option)
-                .returning(move |_| Ok(vec![]));
-
             let mut entry_point = MockEntryPointV0_6::default();
             entry_point.expect_address().return_const(ep);
 
-            let api = create_api(
-                provider,
+            let api = create_api_with_event_distances(
+                self.provider,
                 entry_point,
                 pool,
                 MockGasEstimator::default(),
                 false,
+                self.event_block_distance,
+                self.event_block_distance_fallback,
             );
-            let res = api
-                .get_user_operation_by_hash(
-                    hash,
-                    EventBlockOptions {
-                        block_option: Some(block_option),
-                        max_block_range: None,
-                    },
-                )
+            api.get_user_operation_by_hash(hash, block_options).await
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_user_op_by_hash_with_block_option() {
+        // A caller-supplied block option must reach the getLogs filter as-is and skip
+        // the latest-block lookup used to compute the default search window.
+        for block_option in [
+            range(100, 200),
+            FilterBlockOption::AtBlockHash(B256::random()),
+        ] {
+            let res = LookupTest::new()
+                .logs_empty(block_option)
+                .run(EventBlockOptions {
+                    block_option: Some(block_option),
+                    max_block_range: None,
+                })
                 .await
                 .unwrap();
             assert_eq!(res, None);
@@ -547,52 +644,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_user_op_by_hash_max_block_range_override() {
-        let cs = ChainSpec {
-            id: 1,
-            ..Default::default()
-        };
-        let ep = cs.entry_point_address_v0_6;
-        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
-        let hash = uo.hash();
-
-        let mut pool = MockPool::default();
-        pool.expect_get_op_by_hash()
-            .with(eq(hash))
-            .returning(move |_| Ok(None));
-
-        // The event provider is constructed with no static block distance, so a non-default
-        // search window proves the per-request override is applied.
-        let mut provider = MockEvmProvider::default();
-        provider.expect_get_block_number().returning(|| Ok(1000));
-        provider
-            .expect_get_logs()
-            .withf(|filter| {
-                filter.block_option
-                    == FilterBlockOption::Range {
-                        from_block: Some(900u64.into()),
-                        to_block: Some(1000u64.into()),
-                    }
+        // No static block distance is configured, so a non-default search window proves
+        // the per-request override is applied.
+        let res = LookupTest::new()
+            .latest_block(1000)
+            .logs_empty(range(900, 1000))
+            .run(EventBlockOptions {
+                block_option: None,
+                max_block_range: Some(100),
             })
-            .returning(move |_| Ok(vec![]));
-
-        let mut entry_point = MockEntryPointV0_6::default();
-        entry_point.expect_address().return_const(ep);
-
-        let api = create_api(
-            provider,
-            entry_point,
-            pool,
-            MockGasEstimator::default(),
-            false,
-        );
-        let res = api
-            .get_user_operation_by_hash(
-                hash,
-                EventBlockOptions {
-                    block_option: None,
-                    max_block_range: Some(100),
-                },
-            )
             .await
             .unwrap();
         assert_eq!(res, None);
@@ -600,66 +660,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_user_op_by_hash_resolves_tags_once() {
-        use alloy_eips::BlockNumberOrTag;
-
-        let cs = ChainSpec {
-            id: 1,
-            ..Default::default()
-        };
-        let ep = cs.entry_point_address_v0_6;
-        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
-        let hash = uo.hash();
-
-        let mut pool = MockPool::default();
-        pool.expect_get_op_by_hash()
-            .with(eq(hash))
-            .returning(move |_| Ok(None));
-
         // A latest..latest range must be resolved to concrete numbers with a single
         // get_block call before the fan-out; the filter must see the numbers.
-        let mut inner = alloy_rpc_types_eth::Block::<
-            rundler_provider::AnyRpcTransaction,
-            rundler_provider::AnyRpcHeader,
-        >::default();
-        inner.header.inner.number = 1000;
-        let block = rundler_provider::Block::new(WithOtherFields::new(inner));
-        let mut provider = MockEvmProvider::default();
-        provider
-            .expect_get_block()
-            .times(1)
-            .returning(move |_| Ok(Some(block.clone())));
-        provider
-            .expect_get_logs()
-            .withf(|filter| {
-                filter.block_option
-                    == FilterBlockOption::Range {
-                        from_block: Some(1000u64.into()),
-                        to_block: Some(1000u64.into()),
-                    }
+        let res = LookupTest::new()
+            .resolves_tag_to(1000)
+            .logs_empty(range(1000, 1000))
+            .run(EventBlockOptions {
+                block_option: Some(FilterBlockOption::Range {
+                    from_block: Some(BlockNumberOrTag::Latest),
+                    to_block: Some(BlockNumberOrTag::Latest),
+                }),
+                max_block_range: None,
             })
-            .returning(move |_| Ok(vec![]));
-
-        let mut entry_point = MockEntryPointV0_6::default();
-        entry_point.expect_address().return_const(ep);
-
-        let api = create_api(
-            provider,
-            entry_point,
-            pool,
-            MockGasEstimator::default(),
-            false,
-        );
-        let res = api
-            .get_user_operation_by_hash(
-                hash,
-                EventBlockOptions {
-                    block_option: Some(FilterBlockOption::Range {
-                        from_block: Some(BlockNumberOrTag::Latest),
-                        to_block: Some(BlockNumberOrTag::Latest),
-                    }),
-                    max_block_range: None,
-                },
-            )
             .await
             .unwrap();
         assert_eq!(res, None);
@@ -667,47 +679,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_user_op_by_hash_unresolvable_tag_is_invalid_params() {
-        use alloy_eips::BlockNumberOrTag;
-
-        let cs = ChainSpec {
-            id: 1,
-            ..Default::default()
-        };
-        let ep = cs.entry_point_address_v0_6;
-        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
-        let hash = uo.hash();
-
-        let mut pool = MockPool::default();
-        pool.expect_get_op_by_hash()
-            .with(eq(hash))
-            .returning(move |_| Ok(None));
-
         // The tag is caller-supplied, so a provider returning no block for it must
         // surface as invalid params, not an internal error.
-        let mut provider = MockEvmProvider::default();
-        provider.expect_get_block().returning(|_| Ok(None));
-
-        let mut entry_point = MockEntryPointV0_6::default();
-        entry_point.expect_address().return_const(ep);
-
-        let api = create_api(
-            provider,
-            entry_point,
-            pool,
-            MockGasEstimator::default(),
-            false,
-        );
-        let err = api
-            .get_user_operation_by_hash(
-                hash,
-                EventBlockOptions {
-                    block_option: Some(FilterBlockOption::Range {
-                        from_block: Some(BlockNumberOrTag::Pending),
-                        to_block: Some(BlockNumberOrTag::Pending),
-                    }),
-                    max_block_range: None,
-                },
-            )
+        let err = LookupTest::new()
+            .tag_unresolvable()
+            .run(EventBlockOptions {
+                block_option: Some(FilterBlockOption::Range {
+                    from_block: Some(BlockNumberOrTag::Pending),
+                    to_block: Some(BlockNumberOrTag::Pending),
+                }),
+                max_block_range: None,
+            })
             .await
             .unwrap_err();
         assert!(
@@ -718,53 +700,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_user_op_by_hash_block_option_invalid_ranges() {
-        let cs = ChainSpec {
-            id: 1,
-            ..Default::default()
-        };
-        let ep = cs.entry_point_address_v0_6;
-        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
-        let hash = uo.hash();
-
         // Wider than the max block range, missing a bound while a max is enforced, and
         // reversed: all must surface as invalid params, not an internal error.
         for block_option in [
-            FilterBlockOption::Range {
-                from_block: Some(100u64.into()),
-                to_block: Some(300u64.into()),
-            },
+            range(100, 300),
             FilterBlockOption::Range {
                 from_block: Some(100u64.into()),
                 to_block: None,
             },
-            FilterBlockOption::Range {
-                from_block: Some(300u64.into()),
-                to_block: Some(100u64.into()),
-            },
+            range(300, 100),
         ] {
-            let mut pool = MockPool::default();
-            pool.expect_get_op_by_hash()
-                .with(eq(hash))
-                .returning(move |_| Ok(None));
-
-            let mut entry_point = MockEntryPointV0_6::default();
-            entry_point.expect_address().return_const(ep);
-
-            let api = create_api(
-                MockEvmProvider::default(),
-                entry_point,
-                pool,
-                MockGasEstimator::default(),
-                false,
-            );
-            let err = api
-                .get_user_operation_by_hash(
-                    hash,
-                    EventBlockOptions {
-                        block_option: Some(block_option),
-                        max_block_range: Some(100),
-                    },
-                )
+            let err = LookupTest::new()
+                .run(EventBlockOptions {
+                    block_option: Some(block_option),
+                    max_block_range: Some(100),
+                })
                 .await
                 .unwrap_err();
             assert!(
@@ -776,60 +726,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_user_op_by_hash_fallback_retries_default_path() {
-        let cs = ChainSpec {
-            id: 1,
-            ..Default::default()
-        };
-        let ep = cs.entry_point_address_v0_6;
-        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
-        let hash = uo.hash();
-
-        let mut pool = MockPool::default();
-        pool.expect_get_op_by_hash()
-            .with(eq(hash))
-            .returning(move |_| Ok(None));
-
         // With no caller-supplied block option, a failed primary query must retry with
         // the configured fallback distance.
-        let mut provider = MockEvmProvider::default();
-        provider.expect_get_block_number().returning(|| Ok(1000));
-        provider
-            .expect_get_logs()
-            .withf(|filter| {
-                filter.block_option
-                    == FilterBlockOption::Range {
-                        from_block: Some(500u64.into()),
-                        to_block: Some(1000u64.into()),
-                    }
-            })
-            .times(1)
-            .returning(|_| Err(ProviderError::Other(anyhow::anyhow!("range too large"))));
-        provider
-            .expect_get_logs()
-            .withf(|filter| {
-                filter.block_option
-                    == FilterBlockOption::Range {
-                        from_block: Some(900u64.into()),
-                        to_block: Some(1000u64.into()),
-                    }
-            })
-            .times(1)
-            .returning(|_| Ok(vec![]));
-
-        let mut entry_point = MockEntryPointV0_6::default();
-        entry_point.expect_address().return_const(ep);
-
-        let api = create_api_with_event_distances(
-            provider,
-            entry_point,
-            pool,
-            MockGasEstimator::default(),
-            false,
-            Some(500),
-            Some(100),
-        );
-        let res = api
-            .get_user_operation_by_hash(hash, EventBlockOptions::default())
+        let res = LookupTest::new()
+            .distances(Some(500), Some(100))
+            .latest_block(1000)
+            .logs_error(range(500, 1000))
+            .logs_empty(range(900, 1000))
+            .run(EventBlockOptions::default())
             .await
             .unwrap();
         assert_eq!(res, None);
@@ -837,122 +741,31 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_user_op_by_hash_fallback_suppressed_with_block_option() {
-        let cs = ChainSpec {
-            id: 1,
-            ..Default::default()
-        };
-        let ep = cs.entry_point_address_v0_6;
-        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
-        let hash = uo.hash();
-
-        let mut pool = MockPool::default();
-        pool.expect_get_op_by_hash()
-            .with(eq(hash))
-            .returning(move |_| Ok(None));
-
         // A caller-supplied block option must be used as-is: on error there is no
         // fallback retry (a second get_logs call would fail the mock's times(1)).
-        let mut provider = MockEvmProvider::default();
-        provider
-            .expect_get_logs()
-            .withf(|filter| {
-                filter.block_option
-                    == FilterBlockOption::Range {
-                        from_block: Some(100u64.into()),
-                        to_block: Some(200u64.into()),
-                    }
+        let res = LookupTest::new()
+            .distances(None, Some(100))
+            .logs_error(range(100, 200))
+            .run(EventBlockOptions {
+                block_option: Some(range(100, 200)),
+                max_block_range: None,
             })
-            .times(1)
-            .returning(|_| Err(ProviderError::Other(anyhow::anyhow!("boom"))));
-
-        let mut entry_point = MockEntryPointV0_6::default();
-        entry_point.expect_address().return_const(ep);
-
-        let api = create_api_with_event_distances(
-            provider,
-            entry_point,
-            pool,
-            MockGasEstimator::default(),
-            false,
-            None,
-            Some(100),
-        );
-        let res = api
-            .get_user_operation_by_hash(
-                hash,
-                EventBlockOptions {
-                    block_option: Some(FilterBlockOption::Range {
-                        from_block: Some(100u64.into()),
-                        to_block: Some(200u64.into()),
-                    }),
-                    max_block_range: None,
-                },
-            )
             .await;
         assert!(res.is_err(), "expected the provider error to propagate");
     }
 
     #[tokio::test]
     async fn test_get_user_op_by_hash_fallback_capped_by_max_block_range() {
-        let cs = ChainSpec {
-            id: 1,
-            ..Default::default()
-        };
-        let ep = cs.entry_point_address_v0_6;
-        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
-        let hash = uo.hash();
-
-        let mut pool = MockPool::default();
-        pool.expect_get_op_by_hash()
-            .with(eq(hash))
-            .returning(move |_| Ok(None));
-
         // The per-request max (50) bounds the primary window; the fallback retry (a
         // larger configured 80) must be capped to it as well.
-        let mut provider = MockEvmProvider::default();
-        provider.expect_get_block_number().returning(|| Ok(1000));
-        provider
-            .expect_get_logs()
-            .withf(|filter| {
-                filter.block_option
-                    == FilterBlockOption::Range {
-                        from_block: Some(950u64.into()),
-                        to_block: Some(1000u64.into()),
-                    }
+        let res = LookupTest::new()
+            .distances(None, Some(80))
+            .latest_block(1000)
+            .logs_error_then_empty(range(950, 1000))
+            .run(EventBlockOptions {
+                block_option: None,
+                max_block_range: Some(50),
             })
-            .times(2)
-            .returning({
-                let mut first = true;
-                move |_| {
-                    if first {
-                        first = false;
-                        Err(ProviderError::Other(anyhow::anyhow!("transient")))
-                    } else {
-                        Ok(vec![])
-                    }
-                }
-            });
-
-        let mut entry_point = MockEntryPointV0_6::default();
-        entry_point.expect_address().return_const(ep);
-
-        let api = create_api_with_event_distances(
-            provider,
-            entry_point,
-            pool,
-            MockGasEstimator::default(),
-            false,
-            None,
-            Some(80),
-        );
-        let res = api
-            .get_user_operation_by_hash(
-                hash,
-                EventBlockOptions {
-                    block_option: None,
-                    max_block_range: Some(50),
-                },
-            )
             .await
             .unwrap();
         assert_eq!(res, None);
@@ -960,58 +773,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_user_op_by_hash_empty_range_treated_as_omitted() {
-        let cs = ChainSpec {
-            id: 1,
-            ..Default::default()
-        };
-        let ep = cs.entry_point_address_v0_6;
-        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
-        let hash = uo.hash();
-
-        let mut pool = MockPool::default();
-        pool.expect_get_op_by_hash()
-            .with(eq(hash))
-            .returning(move |_| Ok(None));
-
         // An empty range `{}` carries no information: the default search window must be
         // used, not the node's getLogs defaults.
-        let mut provider = MockEvmProvider::default();
-        provider.expect_get_block_number().returning(|| Ok(1000));
-        provider
-            .expect_get_logs()
-            .withf(|filter| {
-                filter.block_option
-                    == FilterBlockOption::Range {
-                        from_block: Some(900u64.into()),
-                        to_block: Some(1000u64.into()),
-                    }
+        let res = LookupTest::new()
+            .distances(Some(100), None)
+            .latest_block(1000)
+            .logs_empty(range(900, 1000))
+            .run(EventBlockOptions {
+                block_option: Some(FilterBlockOption::Range {
+                    from_block: None,
+                    to_block: None,
+                }),
+                max_block_range: None,
             })
-            .times(1)
-            .returning(|_| Ok(vec![]));
-
-        let mut entry_point = MockEntryPointV0_6::default();
-        entry_point.expect_address().return_const(ep);
-
-        let api = create_api_with_event_distances(
-            provider,
-            entry_point,
-            pool,
-            MockGasEstimator::default(),
-            false,
-            Some(100),
-            None,
-        );
-        let res = api
-            .get_user_operation_by_hash(
-                hash,
-                EventBlockOptions {
-                    block_option: Some(FilterBlockOption::Range {
-                        from_block: None,
-                        to_block: None,
-                    }),
-                    max_block_range: None,
-                },
-            )
             .await
             .unwrap();
         assert_eq!(res, None);

--- a/crates/rpc/src/eth/api.rs
+++ b/crates/rpc/src/eth/api.rs
@@ -28,7 +28,7 @@ use super::{
     router::EntryPointRouter,
 };
 use crate::{
-    eth::events::{self, EventBlockOptions, EventProviderError},
+    eth::events::{EventBlockOptions, EventProviderError},
     types::{RpcGasEstimate, RpcUserOperationByHash, RpcUserOperationReceipt},
 };
 
@@ -144,7 +144,10 @@ where
             ));
         }
 
-        let block_options = self.resolve_block_options(block_options).await?;
+        let block_options = block_options
+            .resolve(&self.provider)
+            .await
+            .map_err(EthRpcError::from)?;
 
         // check both entry points and pending for the user operation event
         #[allow(clippy::type_complexity)]
@@ -179,7 +182,10 @@ where
             ));
         }
 
-        let block_options = self.resolve_block_options(block_options).await?;
+        let block_options = block_options
+            .resolve(&self.provider)
+            .await
+            .map_err(EthRpcError::from)?;
         let tag = tag.unwrap_or(BlockTag::Latest);
 
         if tag == BlockTag::Pending {
@@ -272,26 +278,6 @@ where
             block_hash: None,
             transaction_hash: None,
         }))
-    }
-
-    // Resolve block tags to concrete numbers once, before fanning out to the entry point
-    // routes, so each route doesn't re-resolve them via RPC.
-    async fn resolve_block_options(
-        &self,
-        block_options: EventBlockOptions,
-    ) -> EthResult<EventBlockOptions> {
-        let block_option = match block_options.block_option {
-            Some(bo) => Some(
-                events::resolve_block_option(&self.provider, bo)
-                    .await
-                    .map_err(EthRpcError::from)?,
-            ),
-            None => None,
-        };
-        Ok(EventBlockOptions {
-            block_option,
-            ..block_options
-        })
     }
 }
 
@@ -677,6 +663,57 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res, None);
+    }
+
+    #[tokio::test]
+    async fn test_get_user_op_by_hash_unresolvable_tag_is_invalid_params() {
+        use alloy_eips::BlockNumberOrTag;
+
+        let cs = ChainSpec {
+            id: 1,
+            ..Default::default()
+        };
+        let ep = cs.entry_point_address_v0_6;
+        let uo = UserOperationBuilder::new(&cs, UserOperationRequiredFields::default()).build();
+        let hash = uo.hash();
+
+        let mut pool = MockPool::default();
+        pool.expect_get_op_by_hash()
+            .with(eq(hash))
+            .returning(move |_| Ok(None));
+
+        // The tag is caller-supplied, so a provider returning no block for it must
+        // surface as invalid params, not an internal error.
+        let mut provider = MockEvmProvider::default();
+        provider.expect_get_block().returning(|_| Ok(None));
+
+        let mut entry_point = MockEntryPointV0_6::default();
+        entry_point.expect_address().return_const(ep);
+
+        let api = create_api(
+            provider,
+            entry_point,
+            pool,
+            MockGasEstimator::default(),
+            false,
+        );
+        let err = api
+            .get_user_operation_by_hash(
+                hash,
+                EventBlockOptions {
+                    block_option: Some(FilterBlockOption::Range {
+                        from_block: Some(BlockNumberOrTag::Pending),
+                        to_block: Some(BlockNumberOrTag::Pending),
+                    }),
+                    max_block_range: None,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, EthRpcError::InvalidParams(_)),
+            "expected invalid params, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/rpc/src/eth/error.rs
+++ b/crates/rpc/src/eth/error.rs
@@ -532,6 +532,8 @@ impl From<EventProviderError> for EthRpcError {
                 error: provider_err,
                 context: None,
             }),
+            // Caller-supplied request was invalid, return invalid params
+            EventProviderError::InvalidRequest(message) => Self::InvalidParams(message),
             // Log full details server-side, return generic message to user
             other => {
                 tracing::error!("event provider error: {}", other);

--- a/crates/rpc/src/eth/events/common.rs
+++ b/crates/rpc/src/eth/events/common.rs
@@ -344,27 +344,8 @@ where
                     ));
                 };
 
-                let from = match from {
-                    BlockNumberOrTag::Number(from) => from,
-                    _ => {
-                        return Err(EventProviderError::InvalidRequest(format!(
-                            "max event block distance set to {max_distance}, fromBlock cannot be block tag"
-                        )));
-                    }
-                };
-
-                let to = match to {
-                    BlockNumberOrTag::Number(to) => to,
-                    _ => {
-                        let Some(block) = self.provider.get_block(BlockId::Number(to)).await?
-                        else {
-                            return Err(EventProviderError::Provider(ProviderError::Other(
-                                anyhow::anyhow!("provider returned null block"),
-                            )));
-                        };
-                        block.number()
-                    }
-                };
+                let from = self.resolve_block_number(from).await?;
+                let to = self.resolve_block_number(to).await?;
 
                 if to.saturating_sub(from) > max_distance {
                     return Err(EventProviderError::InvalidRequest(format!(
@@ -591,5 +572,19 @@ where
         }
 
         Ok(None)
+    }
+
+    async fn resolve_block_number(&self, block: BlockNumberOrTag) -> EventProviderResult<u64> {
+        match block {
+            BlockNumberOrTag::Number(block) => Ok(block),
+            _ => {
+                let Some(block) = self.provider.get_block(BlockId::Number(block)).await? else {
+                    return Err(EventProviderError::Provider(ProviderError::Other(
+                        anyhow::anyhow!("provider returned null block"),
+                    )));
+                };
+                Ok(block.number())
+            }
+        }
     }
 }

--- a/crates/rpc/src/eth/events/common.rs
+++ b/crates/rpc/src/eth/events/common.rs
@@ -28,7 +28,9 @@ use rundler_types::{
 use rundler_utils::log::LogOnError;
 use tracing::instrument;
 
-use super::{EventProviderError, EventProviderResult, UserOperationEventProvider};
+use super::{
+    EventBlockOptions, EventProviderError, EventProviderResult, UserOperationEventProvider,
+};
 use crate::types::{RpcUserOperationByHash, RpcUserOperationReceipt, UOStatusEnum};
 
 #[derive(Debug)]
@@ -73,12 +75,11 @@ where
     async fn get_mined_by_hash(
         &self,
         hash: B256,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EventProviderResult<Option<RpcUserOperationByHash>> {
         // Get event associated with hash (need to check all entry point addresses associated with this API)
         let event = self
-            .get_event_by_hash(hash, block_option, max_block_range)
+            .get_event_by_hash(hash, block_options)
             .await
             .log_on_error("should have successfully queried for user op events by hash")?;
 
@@ -115,11 +116,10 @@ where
     async fn get_receipt(
         &self,
         hash: B256,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EventProviderResult<Option<RpcUserOperationReceipt>> {
         let event = self
-            .get_event_by_hash(hash, block_option, max_block_range)
+            .get_event_by_hash(hash, block_options)
             .await
             .log_on_error("should have successfully queried for user op events by hash")?;
         let Some(event) = event else { return Ok(None) };
@@ -186,15 +186,14 @@ where
         &self,
         hash: B256,
         preconfirmed_bundle_transaction: Option<B256>,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EventProviderResult<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>> {
         // Step 1: Get tx_hash (preconfirmed: passed in, pending: find event first)
         let (tx_hash, event_from_logs) = if let Some(bundle_tx) = preconfirmed_bundle_transaction {
             (bundle_tx, None)
         } else {
             let event = self
-                .get_event_by_hash(hash, block_option, max_block_range)
+                .get_event_by_hash(hash, block_options)
                 .await
                 .log_on_error("should have successfully queried for user op events by hash")?;
 
@@ -324,48 +323,51 @@ where
     async fn get_event_by_hash(
         &self,
         hash: B256,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EventProviderResult<Option<Log>> {
         // A per-request override (e.g. from a trusted gateway) takes precedence over the
         // statically configured event block distance.
-        let event_block_distance = max_block_range.or(self.event_block_distance);
-        let has_block_option = block_option.is_some();
-        let block_option = if let Some(bo) = block_option {
+        let event_block_distance = block_options.max_block_range.or(self.event_block_distance);
+        let has_block_option = block_options.block_option.is_some();
+        let block_option = if let Some(bo) = block_options.block_option {
+            // No-op when the RPC handler already resolved the tags before fanning out.
+            let bo = super::resolve_block_option(&self.provider, bo).await?;
+
             if let FilterBlockOption::Range {
                 from_block,
                 to_block,
             } = bo
-                && let Some(max_distance) = event_block_distance
             {
-                let (Some(from), Some(to)) = (from_block, to_block) else {
-                    return Err(EventProviderError::InvalidRequest(
-                        "fromBlock and toBlock must both be populated in event request".to_string(),
-                    ));
-                };
-
-                let from = super::resolve_block_number(&self.provider, from).await?;
-                let to = super::resolve_block_number(&self.provider, to).await?;
-
-                if from > to {
+                if let (Some(BlockNumberOrTag::Number(from)), Some(BlockNumberOrTag::Number(to))) =
+                    (from_block, to_block)
+                    && from > to
+                {
                     return Err(EventProviderError::InvalidRequest(format!(
                         "fromBlock: {from} is greater than toBlock: {to}"
                     )));
                 }
 
-                if to - from > max_distance {
-                    return Err(EventProviderError::InvalidRequest(format!(
-                        "fromBlock: {from}, toBlock: {to} larger than max block distance {max_distance}, reduce block range"
-                    )));
-                }
+                if let Some(max_distance) = event_block_distance {
+                    // Resolution guarantees populated bounds are numbers, so this only
+                    // rejects missing bounds.
+                    let (Some(BlockNumberOrTag::Number(from)), Some(BlockNumberOrTag::Number(to))) =
+                        (from_block, to_block)
+                    else {
+                        return Err(EventProviderError::InvalidRequest(
+                            "fromBlock and toBlock must both be populated in event request"
+                                .to_string(),
+                        ));
+                    };
 
-                FilterBlockOption::Range {
-                    from_block: Some(from.into()),
-                    to_block: Some(to.into()),
+                    if to - from > max_distance {
+                        return Err(EventProviderError::InvalidRequest(format!(
+                            "fromBlock: {from}, toBlock: {to} larger than max block distance {max_distance}, reduce block range"
+                        )));
+                    }
                 }
-            } else {
-                bo
             }
+
+            bo
         } else {
             let to_block = self.provider.get_block_number().await?;
             let from_block = match event_block_distance {

--- a/crates/rpc/src/eth/events/common.rs
+++ b/crates/rpc/src/eth/events/common.rs
@@ -14,13 +14,13 @@
 use std::{collections::VecDeque, marker::PhantomData};
 
 use alloy_consensus::Transaction;
-use alloy_eips::{BlockId, BlockNumberOrTag};
+use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_sol_types::SolEvent;
 use itertools::Itertools;
 use rundler_provider::{
     EvmProvider, Filter, FilterBlockOption, GethDebugBuiltInTracerType, GethDebugTracerType,
-    GethDebugTracingOptions, GethTrace, Log, ProviderError, TransactionReceipt,
+    GethDebugTracingOptions, GethTrace, Log, TransactionReceipt,
 };
 use rundler_types::{
     UserOperation, UserOperationVariant, authorization::Eip7702Auth, chain::ChainSpec,
@@ -344,8 +344,8 @@ where
                     ));
                 };
 
-                let from = self.resolve_block_number(from).await?;
-                let to = self.resolve_block_number(to).await?;
+                let from = super::resolve_block_number(&self.provider, from).await?;
+                let to = super::resolve_block_number(&self.provider, to).await?;
 
                 if from > to {
                     return Err(EventProviderError::InvalidRequest(format!(
@@ -578,19 +578,5 @@ where
         }
 
         Ok(None)
-    }
-
-    async fn resolve_block_number(&self, block: BlockNumberOrTag) -> EventProviderResult<u64> {
-        match block {
-            BlockNumberOrTag::Number(block) => Ok(block),
-            _ => {
-                let Some(block) = self.provider.get_block(BlockId::Number(block)).await? else {
-                    return Err(EventProviderError::Provider(ProviderError::Other(
-                        anyhow::anyhow!("provider returned null block"),
-                    )));
-                };
-                Ok(block.number())
-            }
-        }
     }
 }

--- a/crates/rpc/src/eth/events/common.rs
+++ b/crates/rpc/src/eth/events/common.rs
@@ -74,10 +74,11 @@ where
         &self,
         hash: B256,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EventProviderResult<Option<RpcUserOperationByHash>> {
         // Get event associated with hash (need to check all entry point addresses associated with this API)
         let event = self
-            .get_event_by_hash(hash, block_option)
+            .get_event_by_hash(hash, block_option, max_block_range)
             .await
             .log_on_error("should have successfully queried for user op events by hash")?;
 
@@ -115,9 +116,10 @@ where
         &self,
         hash: B256,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EventProviderResult<Option<RpcUserOperationReceipt>> {
         let event = self
-            .get_event_by_hash(hash, block_option)
+            .get_event_by_hash(hash, block_option, max_block_range)
             .await
             .log_on_error("should have successfully queried for user op events by hash")?;
         let Some(event) = event else { return Ok(None) };
@@ -185,13 +187,14 @@ where
         hash: B256,
         preconfirmed_bundle_transaction: Option<B256>,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EventProviderResult<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>> {
         // Step 1: Get tx_hash (preconfirmed: passed in, pending: find event first)
         let (tx_hash, event_from_logs) = if let Some(bundle_tx) = preconfirmed_bundle_transaction {
             (bundle_tx, None)
         } else {
             let event = self
-                .get_event_by_hash(hash, block_option)
+                .get_event_by_hash(hash, block_option, max_block_range)
                 .await
                 .log_on_error("should have successfully queried for user op events by hash")?;
 
@@ -322,14 +325,18 @@ where
         &self,
         hash: B256,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EventProviderResult<Option<Log>> {
+        // A per-request override (e.g. from a trusted gateway) takes precedence over the
+        // statically configured event block distance.
+        let event_block_distance = max_block_range.or(self.event_block_distance);
         let has_block_option = block_option.is_some();
         let block_option = if let Some(bo) = block_option {
             if let FilterBlockOption::Range {
                 from_block,
                 to_block,
             } = bo
-                && let Some(max_distance) = self.event_block_distance
+                && let Some(max_distance) = event_block_distance
             {
                 let (Some(from), Some(to)) = (from_block, to_block) else {
                     return Err(EventProviderError::InvalidRequest(
@@ -374,7 +381,7 @@ where
             }
         } else {
             let to_block = self.provider.get_block_number().await?;
-            let from_block = match self.event_block_distance {
+            let from_block = match event_block_distance {
                 Some(distance) => to_block.saturating_sub(distance),
                 None => 0,
             };

--- a/crates/rpc/src/eth/events/common.rs
+++ b/crates/rpc/src/eth/events/common.rs
@@ -14,13 +14,13 @@
 use std::{collections::VecDeque, marker::PhantomData};
 
 use alloy_consensus::Transaction;
-use alloy_eips::BlockNumberOrTag;
+use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_sol_types::SolEvent;
 use itertools::Itertools;
 use rundler_provider::{
     EvmProvider, Filter, FilterBlockOption, GethDebugBuiltInTracerType, GethDebugTracerType,
-    GethDebugTracingOptions, GethTrace, Log, TransactionReceipt,
+    GethDebugTracingOptions, GethTrace, Log, ProviderError, TransactionReceipt,
 };
 use rundler_types::{
     UserOperation, UserOperationVariant, authorization::Eip7702Auth, chain::ChainSpec,
@@ -325,7 +325,53 @@ where
     ) -> EventProviderResult<Option<Log>> {
         let has_block_option = block_option.is_some();
         let block_option = if let Some(bo) = block_option {
-            bo
+            if let FilterBlockOption::Range {
+                from_block,
+                to_block,
+            } = bo
+                && let Some(max_distance) = self.event_block_distance
+            {
+                let (Some(from), Some(to)) = (from_block, to_block) else {
+                    return Err(EventProviderError::InvalidRequest(
+                        "fromBlock and toBlock must both be populated in event request".to_string(),
+                    ));
+                };
+
+                let from = match from {
+                    BlockNumberOrTag::Number(from) => from,
+                    _ => {
+                        return Err(EventProviderError::InvalidRequest(format!(
+                            "max event block distance set to {max_distance}, fromBlock cannot be block tag"
+                        )));
+                    }
+                };
+
+                let to = match to {
+                    BlockNumberOrTag::Number(to) => to,
+                    _ => {
+                        let Some(block) = self.provider.get_block(BlockId::Number(to)).await?
+                        else {
+                            return Err(EventProviderError::Provider(ProviderError::Other(
+                                anyhow::anyhow!("provider returned null block"),
+                            )));
+                        };
+                        block.number()
+                    }
+                };
+
+                if to.saturating_sub(from) > max_distance {
+                    return Err(EventProviderError::InvalidRequest(format!(
+                        "fromBlock: {from}, toBlock: {to} larger than max block distance {max_distance}, reduce block range"
+                    )));
+                }
+
+                FilterBlockOption::Range {
+                    from_block: Some(from.into()),
+                    to_block: Some(to.into()),
+                }
+            } else {
+                bo
+            }
         } else {
             let to_block = self.provider.get_block_number().await?;
             let from_block = match self.event_block_distance {

--- a/crates/rpc/src/eth/events/common.rs
+++ b/crates/rpc/src/eth/events/common.rs
@@ -347,7 +347,13 @@ where
                 let from = self.resolve_block_number(from).await?;
                 let to = self.resolve_block_number(to).await?;
 
-                if to.saturating_sub(from) > max_distance {
+                if from > to {
+                    return Err(EventProviderError::InvalidRequest(format!(
+                        "fromBlock: {from} is greater than toBlock: {to}"
+                    )));
+                }
+
+                if to - from > max_distance {
                     return Err(EventProviderError::InvalidRequest(format!(
                         "fromBlock: {from}, toBlock: {to} larger than max block distance {max_distance}, reduce block range"
                     )));

--- a/crates/rpc/src/eth/events/common.rs
+++ b/crates/rpc/src/eth/events/common.rs
@@ -328,8 +328,20 @@ where
         // A per-request override (e.g. from a trusted gateway) takes precedence over the
         // statically configured event block distance.
         let event_block_distance = block_options.max_block_range.or(self.event_block_distance);
-        let has_block_option = block_options.block_option.is_some();
-        let block_option = if let Some(bo) = block_options.block_option {
+        // An empty range `{}` carries no information: treat it exactly like an omitted
+        // parameter (default window + fallback retry) instead of delegating both bounds
+        // to the node's getLogs defaults (typically latest..latest).
+        let supplied_block_option = block_options.block_option.filter(|bo| {
+            !matches!(
+                bo,
+                FilterBlockOption::Range {
+                    from_block: None,
+                    to_block: None,
+                }
+            )
+        });
+        let has_block_option = supplied_block_option.is_some();
+        let block_option = if let Some(bo) = supplied_block_option {
             // No-op when the RPC handler already resolved the tags before fanning out.
             let bo = super::resolve_block_option(&self.provider, bo).await?;
 
@@ -390,6 +402,13 @@ where
                     && !has_block_option
                     && let Some(fallback_distance) = self.event_block_distance_fallback
                 {
+                    // The per-request override is a hard cap on the search window; the
+                    // retry must not exceed it. The statically configured fallback is
+                    // deliberately not capped by the static distance (operator's choice).
+                    let fallback_distance = match block_options.max_block_range {
+                        Some(max) => fallback_distance.min(max),
+                        None => fallback_distance,
+                    };
                     tracing::warn!(
                         "Error querying for event at from block {from_block:?} to block {to_block:?} falling back to a distance of {fallback_distance:?}. Error {e:?}"
                     );

--- a/crates/rpc/src/eth/events/common.rs
+++ b/crates/rpc/src/eth/events/common.rs
@@ -14,12 +14,13 @@
 use std::{collections::VecDeque, marker::PhantomData};
 
 use alloy_consensus::Transaction;
+use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_sol_types::SolEvent;
 use itertools::Itertools;
 use rundler_provider::{
-    EvmProvider, Filter, GethDebugBuiltInTracerType, GethDebugTracerType, GethDebugTracingOptions,
-    GethTrace, Log, TransactionReceipt,
+    EvmProvider, Filter, FilterBlockOption, GethDebugBuiltInTracerType, GethDebugTracerType,
+    GethDebugTracingOptions, GethTrace, Log, TransactionReceipt,
 };
 use rundler_types::{
     UserOperation, UserOperationVariant, authorization::Eip7702Auth, chain::ChainSpec,
@@ -72,10 +73,11 @@ where
     async fn get_mined_by_hash(
         &self,
         hash: B256,
+        block_option: Option<FilterBlockOption>,
     ) -> EventProviderResult<Option<RpcUserOperationByHash>> {
         // Get event associated with hash (need to check all entry point addresses associated with this API)
         let event = self
-            .get_event_by_hash(hash)
+            .get_event_by_hash(hash, block_option)
             .await
             .log_on_error("should have successfully queried for user op events by hash")?;
 
@@ -112,9 +114,10 @@ where
     async fn get_receipt(
         &self,
         hash: B256,
+        block_option: Option<FilterBlockOption>,
     ) -> EventProviderResult<Option<RpcUserOperationReceipt>> {
         let event = self
-            .get_event_by_hash(hash)
+            .get_event_by_hash(hash, block_option)
             .await
             .log_on_error("should have successfully queried for user op events by hash")?;
         let Some(event) = event else { return Ok(None) };
@@ -181,13 +184,14 @@ where
         &self,
         hash: B256,
         preconfirmed_bundle_transaction: Option<B256>,
+        block_option: Option<FilterBlockOption>,
     ) -> EventProviderResult<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>> {
         // Step 1: Get tx_hash (preconfirmed: passed in, pending: find event first)
         let (tx_hash, event_from_logs) = if let Some(bundle_tx) = preconfirmed_bundle_transaction {
             (bundle_tx, None)
         } else {
             let event = self
-                .get_event_by_hash(hash)
+                .get_event_by_hash(hash, block_option)
                 .await
                 .log_on_error("should have successfully queried for user op events by hash")?;
 
@@ -314,30 +318,52 @@ where
     }
 
     #[instrument(skip_all)]
-    async fn get_event_by_hash(&self, hash: B256) -> EventProviderResult<Option<Log>> {
-        let to_block = self.provider.get_block_number().await?;
-
-        let from_block = match self.event_block_distance {
-            Some(distance) => to_block.saturating_sub(distance),
-            None => 0,
+    async fn get_event_by_hash(
+        &self,
+        hash: B256,
+        block_option: Option<FilterBlockOption>,
+    ) -> EventProviderResult<Option<Log>> {
+        let has_block_option = block_option.is_some();
+        let block_option = if let Some(bo) = block_option {
+            bo
+        } else {
+            let to_block = self.provider.get_block_number().await?;
+            let from_block = match self.event_block_distance {
+                Some(distance) => to_block.saturating_sub(distance),
+                None => 0,
+            };
+            FilterBlockOption::Range {
+                from_block: Some(from_block.into()),
+                to_block: Some(to_block.into()),
+            }
         };
 
-        match self.get_event_by_hash_at(hash, from_block, to_block).await {
+        match self.get_event_by_hash_at(hash, block_option).await {
             Ok(logs) => Ok(logs),
             Err(e) => {
-                if let Some(fallback_distance) = self.event_block_distance_fallback {
+                if let FilterBlockOption::Range {
+                    from_block: Some(BlockNumberOrTag::Number(from_block)),
+                    to_block: Some(BlockNumberOrTag::Number(to_block)),
+                } = block_option
+                    && !has_block_option
+                    && let Some(fallback_distance) = self.event_block_distance_fallback
+                {
                     tracing::warn!(
                         "Error querying for event at from block {from_block:?} to block {to_block:?} falling back to a distance of {fallback_distance:?}. Error {e:?}"
                     );
-                    self.get_event_by_hash_at(
-                        hash,
-                        to_block.saturating_sub(fallback_distance),
-                        to_block,
-                    )
-                    .await
-                } else {
-                    Err(e)
+                    return self
+                        .get_event_by_hash_at(
+                            hash,
+                            FilterBlockOption::Range {
+                                from_block: Some(
+                                    (to_block.saturating_sub(fallback_distance)).into(),
+                                ),
+                                to_block: Some(to_block.into()),
+                            },
+                        )
+                        .await;
                 }
+                Err(e)
             }
         }
     }
@@ -346,14 +372,12 @@ where
     async fn get_event_by_hash_at(
         &self,
         hash: B256,
-        from_block: u64,
-        to_block: u64,
+        block_option: FilterBlockOption,
     ) -> EventProviderResult<Option<Log>> {
         let filter = Filter::new()
             .address(vec![self.entry_point_address])
             .event_signature(E::UserOperationEvent::SIGNATURE_HASH)
-            .from_block(from_block)
-            .to_block(to_block)
+            .select(block_option)
             .topic1(hash);
 
         Ok(self.provider.get_logs(&filter).await?.into_iter().next())

--- a/crates/rpc/src/eth/events/mod.rs
+++ b/crates/rpc/src/eth/events/mod.rs
@@ -31,6 +31,7 @@ pub(crate) trait UserOperationEventProvider: Send + Sync {
         &self,
         hash: B256,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EventProviderResult<Option<RpcUserOperationByHash>>;
 
     async fn get_mined_from_tx_receipt(
@@ -43,6 +44,7 @@ pub(crate) trait UserOperationEventProvider: Send + Sync {
         &self,
         hash: B256,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EventProviderResult<Option<RpcUserOperationReceipt>>;
 
     async fn get_receipt_from_tx_hash(
@@ -64,6 +66,7 @@ pub(crate) trait UserOperationEventProvider: Send + Sync {
         hash: B256,
         bundle_transaction: Option<B256>,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EventProviderResult<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>>;
 }
 

--- a/crates/rpc/src/eth/events/mod.rs
+++ b/crates/rpc/src/eth/events/mod.rs
@@ -26,13 +26,22 @@ pub(crate) use v0_6::UserOperationEventProviderV0_6;
 mod v0_7;
 pub(crate) use v0_7::UserOperationEventProviderV0_7;
 
+/// Options scoping the block window searched for user operation events.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct EventBlockOptions {
+    /// Caller-supplied block range or hash to search. When set, the fallback retry is
+    /// disabled and the option is used as-is (after tag resolution and validation).
+    pub(crate) block_option: Option<FilterBlockOption>,
+    /// Per-request override of the maximum event block distance.
+    pub(crate) max_block_range: Option<u64>,
+}
+
 #[async_trait::async_trait]
 pub(crate) trait UserOperationEventProvider: Send + Sync {
     async fn get_mined_by_hash(
         &self,
         hash: B256,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EventProviderResult<Option<RpcUserOperationByHash>>;
 
     async fn get_mined_from_tx_receipt(
@@ -44,8 +53,7 @@ pub(crate) trait UserOperationEventProvider: Send + Sync {
     async fn get_receipt(
         &self,
         hash: B256,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EventProviderResult<Option<RpcUserOperationReceipt>>;
 
     async fn get_receipt_from_tx_hash(
@@ -66,8 +74,7 @@ pub(crate) trait UserOperationEventProvider: Send + Sync {
         &self,
         hash: B256,
         bundle_transaction: Option<B256>,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EventProviderResult<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>>;
 }
 

--- a/crates/rpc/src/eth/events/mod.rs
+++ b/crates/rpc/src/eth/events/mod.rs
@@ -97,6 +97,10 @@ pub enum EventProviderError {
     /// Error processing logs (includes invalid sequence, no matching logs, decode failures)
     #[error("log processing error: {0}")]
     LogProcessingError(String),
+
+    /// Invalid request
+    #[error("invalid event request: {0}")]
+    InvalidRequest(String),
 }
 
 /// Type alias for results from event provider operations

--- a/crates/rpc/src/eth/events/mod.rs
+++ b/crates/rpc/src/eth/events/mod.rs
@@ -36,6 +36,22 @@ pub(crate) struct EventBlockOptions {
     pub(crate) max_block_range: Option<u64>,
 }
 
+impl EventBlockOptions {
+    /// Resolve any block tags in the block option to concrete block numbers.
+    ///
+    /// RPC handlers call this once per request so the resolved options can be fanned out
+    /// to multiple entry point routes without each route re-resolving the tags via RPC.
+    pub(crate) async fn resolve<P: EvmProvider>(self, provider: &P) -> EventProviderResult<Self> {
+        Ok(Self {
+            block_option: match self.block_option {
+                Some(bo) => Some(resolve_block_option(provider, bo).await?),
+                None => None,
+            },
+            ..self
+        })
+    }
+}
+
 #[async_trait::async_trait]
 pub(crate) trait UserOperationEventProvider: Send + Sync {
     async fn get_mined_by_hash(
@@ -164,10 +180,13 @@ pub(crate) async fn resolve_block_number<P: EvmProvider>(
 ) -> EventProviderResult<u64> {
     match block {
         BlockNumberOrTag::Number(block) => Ok(block),
-        _ => {
-            let Some(block) = provider.get_block(BlockId::Number(block)).await? else {
-                return Err(EventProviderError::Provider(ProviderError::Other(
-                    anyhow::anyhow!("provider returned null block"),
+        tag => {
+            // The tag is caller-supplied, so an unresolvable tag (e.g. "pending" on a
+            // chain whose node returns no pending block) is an invalid request, not an
+            // internal error.
+            let Some(block) = provider.get_block(BlockId::Number(tag)).await? else {
+                return Err(EventProviderError::InvalidRequest(format!(
+                    "block \"{tag}\" not found"
                 )));
             };
             Ok(block.number())

--- a/crates/rpc/src/eth/events/mod.rs
+++ b/crates/rpc/src/eth/events/mod.rs
@@ -11,8 +11,9 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
+use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, B256};
-use rundler_provider::{FilterBlockOption, Log, ProviderError, TransactionReceipt};
+use rundler_provider::{EvmProvider, FilterBlockOption, Log, ProviderError, TransactionReceipt};
 use thiserror::Error;
 use tracing::instrument;
 
@@ -108,6 +109,64 @@ pub enum EventProviderError {
 
 /// Type alias for results from event provider operations
 pub(crate) type EventProviderResult<T> = Result<T, EventProviderError>;
+
+/// Resolve any block tags in a filter block option to concrete block numbers.
+///
+/// RPC handlers call this once per request so the resolved option can be fanned out to
+/// multiple entry point routes without each route re-resolving the tags via RPC.
+pub(crate) async fn resolve_block_option<P: EvmProvider>(
+    provider: &P,
+    block_option: FilterBlockOption,
+) -> EventProviderResult<FilterBlockOption> {
+    match block_option {
+        FilterBlockOption::Range {
+            from_block,
+            to_block,
+        } => {
+            let (from_block, to_block) = match (from_block, to_block) {
+                // both bounds are the same tag: resolve once
+                (Some(from), Some(to)) if from == to => {
+                    let number = resolve_block_number(provider, from).await?;
+                    (Some(number.into()), Some(number.into()))
+                }
+                (from, to) => {
+                    let from = match from {
+                        Some(block) => Some(resolve_block_number(provider, block).await?.into()),
+                        None => None,
+                    };
+                    let to = match to {
+                        Some(block) => Some(resolve_block_number(provider, block).await?.into()),
+                        None => None,
+                    };
+                    (from, to)
+                }
+            };
+            Ok(FilterBlockOption::Range {
+                from_block,
+                to_block,
+            })
+        }
+        FilterBlockOption::AtBlockHash(_) => Ok(block_option),
+    }
+}
+
+/// Resolve a block number or tag to a concrete block number.
+pub(crate) async fn resolve_block_number<P: EvmProvider>(
+    provider: &P,
+    block: BlockNumberOrTag,
+) -> EventProviderResult<u64> {
+    match block {
+        BlockNumberOrTag::Number(block) => Ok(block),
+        _ => {
+            let Some(block) = provider.get_block(BlockId::Number(block)).await? else {
+                return Err(EventProviderError::Provider(ProviderError::Other(
+                    anyhow::anyhow!("provider returned null block"),
+                )));
+            };
+            Ok(block.number())
+        }
+    }
+}
 
 // This method takes a user operation event and a transaction receipt and filters out all the logs
 // relevant to the user operation. Since there are potentially many user operations in a transaction,

--- a/crates/rpc/src/eth/events/mod.rs
+++ b/crates/rpc/src/eth/events/mod.rs
@@ -12,7 +12,7 @@
 // If not, see https://www.gnu.org/licenses/.
 
 use alloy_primitives::{Address, B256};
-use rundler_provider::{Log, ProviderError, TransactionReceipt};
+use rundler_provider::{FilterBlockOption, Log, ProviderError, TransactionReceipt};
 use thiserror::Error;
 use tracing::instrument;
 
@@ -30,6 +30,7 @@ pub(crate) trait UserOperationEventProvider: Send + Sync {
     async fn get_mined_by_hash(
         &self,
         hash: B256,
+        block_option: Option<FilterBlockOption>,
     ) -> EventProviderResult<Option<RpcUserOperationByHash>>;
 
     async fn get_mined_from_tx_receipt(
@@ -38,8 +39,11 @@ pub(crate) trait UserOperationEventProvider: Send + Sync {
         tx_receipt: TransactionReceipt,
     ) -> EventProviderResult<Option<RpcUserOperationByHash>>;
 
-    async fn get_receipt(&self, hash: B256)
-    -> EventProviderResult<Option<RpcUserOperationReceipt>>;
+    async fn get_receipt(
+        &self,
+        hash: B256,
+        block_option: Option<FilterBlockOption>,
+    ) -> EventProviderResult<Option<RpcUserOperationReceipt>>;
 
     async fn get_receipt_from_tx_hash(
         &self,
@@ -59,6 +63,7 @@ pub(crate) trait UserOperationEventProvider: Send + Sync {
         &self,
         hash: B256,
         bundle_transaction: Option<B256>,
+        block_option: Option<FilterBlockOption>,
     ) -> EventProviderResult<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>>;
 }
 

--- a/crates/rpc/src/eth/mod.rs
+++ b/crates/rpc/src/eth/mod.rs
@@ -28,8 +28,8 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use rundler_provider::StateOverride;
 
 use crate::types::{
-    RpcBlockOption, RpcBlockOptionOrTag, RpcGasEstimate, RpcUserOperation, RpcUserOperationByHash,
-    RpcUserOperationOptionalGas, RpcUserOperationPermissions, RpcUserOperationReceipt,
+    RpcBlockOption, RpcBlockOptionOrTag, RpcGasEstimate, RpcPermissions, RpcUserOperation,
+    RpcUserOperationByHash, RpcUserOperationOptionalGas, RpcUserOperationReceipt,
 };
 
 /// Eth API
@@ -37,12 +37,12 @@ use crate::types::{
 #[cfg_attr(test, automock)]
 pub trait EthApi {
     /// Sends a user operation to the pool.
-    #[method(name = "sendUserOperation")]
+    #[method(name = "sendUserOperation", with_extensions)]
     async fn send_user_operation(
         &self,
         op: RpcUserOperation,
         entry_point: Address,
-        permissions: Option<RpcUserOperationPermissions>,
+        permissions: Option<RpcPermissions>,
     ) -> RpcResult<B256>;
 
     /// Estimates the gas fields for a user operation.
@@ -55,7 +55,7 @@ pub trait EthApi {
     ) -> RpcResult<RpcGasEstimate>;
 
     /// Returns the user operation with the given hash.
-    #[method(name = "getUserOperationByHash")]
+    #[method(name = "getUserOperationByHash", with_extensions)]
     async fn get_user_operation_by_hash(
         &self,
         hash: B256,
@@ -63,7 +63,7 @@ pub trait EthApi {
     ) -> RpcResult<Option<RpcUserOperationByHash>>;
 
     /// Returns the user operation receipt with the given hash.
-    #[method(name = "getUserOperationReceipt")]
+    #[method(name = "getUserOperationReceipt", with_extensions)]
     async fn get_user_operation_receipt(
         &self,
         hash: B256,

--- a/crates/rpc/src/eth/mod.rs
+++ b/crates/rpc/src/eth/mod.rs
@@ -20,7 +20,9 @@ pub(crate) use router::*;
 mod error;
 pub(crate) use error::{EthResult, EthRpcError};
 mod events;
-pub(crate) use events::{UserOperationEventProviderV0_6, UserOperationEventProviderV0_7};
+pub(crate) use events::{
+    UserOperationEventProviderV0_6, UserOperationEventProviderV0_7, resolve_block_option,
+};
 mod server;
 
 use alloy_primitives::{Address, B256, U64};

--- a/crates/rpc/src/eth/mod.rs
+++ b/crates/rpc/src/eth/mod.rs
@@ -22,7 +22,6 @@ pub(crate) use error::{EthResult, EthRpcError};
 mod events;
 pub(crate) use events::{
     EventBlockOptions, UserOperationEventProviderV0_6, UserOperationEventProviderV0_7,
-    resolve_block_option,
 };
 mod server;
 

--- a/crates/rpc/src/eth/mod.rs
+++ b/crates/rpc/src/eth/mod.rs
@@ -26,11 +26,10 @@ mod server;
 use alloy_primitives::{Address, B256, U64};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use rundler_provider::StateOverride;
-use rundler_types::BlockTag;
 
 use crate::types::{
-    RpcGasEstimate, RpcUserOperation, RpcUserOperationByHash, RpcUserOperationOptionalGas,
-    RpcUserOperationPermissions, RpcUserOperationReceipt,
+    RpcBlockOption, RpcBlockOptionOrTag, RpcGasEstimate, RpcUserOperation, RpcUserOperationByHash,
+    RpcUserOperationOptionalGas, RpcUserOperationPermissions, RpcUserOperationReceipt,
 };
 
 /// Eth API
@@ -60,6 +59,7 @@ pub trait EthApi {
     async fn get_user_operation_by_hash(
         &self,
         hash: B256,
+        block_option: Option<RpcBlockOption>,
     ) -> RpcResult<Option<RpcUserOperationByHash>>;
 
     /// Returns the user operation receipt with the given hash.
@@ -67,7 +67,7 @@ pub trait EthApi {
     async fn get_user_operation_receipt(
         &self,
         hash: B256,
-        tag: Option<BlockTag>,
+        block_option_or_tag: Option<RpcBlockOptionOrTag>,
     ) -> RpcResult<Option<RpcUserOperationReceipt>>;
 
     /// Returns the supported entry points addresses

--- a/crates/rpc/src/eth/mod.rs
+++ b/crates/rpc/src/eth/mod.rs
@@ -21,7 +21,8 @@ mod error;
 pub(crate) use error::{EthResult, EthRpcError};
 mod events;
 pub(crate) use events::{
-    UserOperationEventProviderV0_6, UserOperationEventProviderV0_7, resolve_block_option,
+    EventBlockOptions, UserOperationEventProviderV0_6, UserOperationEventProviderV0_7,
+    resolve_block_option,
 };
 mod server;
 

--- a/crates/rpc/src/eth/mod.rs
+++ b/crates/rpc/src/eth/mod.rs
@@ -65,11 +65,15 @@ pub trait EthApi {
     ) -> RpcResult<Option<RpcUserOperationByHash>>;
 
     /// Returns the user operation receipt with the given hash.
+    ///
+    /// NOTE: the parameter identifier `tag` is part of the named-params wire API
+    /// (jsonrpsee matches object-form params by argument name) and predates the block
+    /// option — do not rename it.
     #[method(name = "getUserOperationReceipt", with_extensions)]
     async fn get_user_operation_receipt(
         &self,
         hash: B256,
-        block_option_or_tag: Option<RpcBlockOptionOrTag>,
+        tag: Option<RpcBlockOptionOrTag>,
     ) -> RpcResult<Option<RpcUserOperationReceipt>>;
 
     /// Returns the supported entry points addresses

--- a/crates/rpc/src/eth/router.rs
+++ b/crates/rpc/src/eth/router.rs
@@ -114,9 +114,10 @@ impl EntryPointRouter {
         entry_point: &Address,
         hash: B256,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> Result<Option<RpcUserOperationByHash>, EventProviderError> {
         self.get_event_route(entry_point)?
-            .get_mined_by_hash(hash, block_option)
+            .get_mined_by_hash(hash, block_option, max_block_range)
             .await
     }
 
@@ -137,9 +138,10 @@ impl EntryPointRouter {
         hash: B256,
         bundle_transaction: Option<B256>,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> Result<Option<RpcUserOperationReceipt>, EventProviderError> {
         self.get_event_route(entry_point)?
-            .get_receipt(hash, bundle_transaction, block_option)
+            .get_receipt(hash, bundle_transaction, block_option, max_block_range)
             .await
     }
 
@@ -162,9 +164,10 @@ impl EntryPointRouter {
         hash: B256,
         bundle_transaction: Option<B256>,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> Result<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>, EventProviderError> {
         self.get_event_route(entry_point)?
-            .get_mined_and_receipt(hash, bundle_transaction, block_option)
+            .get_mined_and_receipt(hash, bundle_transaction, block_option, max_block_range)
             .await
     }
 
@@ -240,6 +243,7 @@ pub(crate) trait EntryPointRoute: Send + Sync {
         &self,
         hash: B256,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EventProviderResult<Option<RpcUserOperationByHash>>;
 
     async fn get_mined_from_tx_receipt(
@@ -253,6 +257,7 @@ pub(crate) trait EntryPointRoute: Send + Sync {
         hash: B256,
         bundle_transaction: Option<B256>,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EventProviderResult<Option<RpcUserOperationReceipt>>;
 
     async fn get_receipt_from_tx_receipt(
@@ -268,6 +273,7 @@ pub(crate) trait EntryPointRoute: Send + Sync {
         hash: B256,
         bundle_transaction: Option<B256>,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EventProviderResult<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>>;
 
     async fn estimate_gas(
@@ -308,9 +314,10 @@ where
         &self,
         hash: B256,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EventProviderResult<Option<RpcUserOperationByHash>> {
         self.event_provider
-            .get_mined_by_hash(hash, block_option)
+            .get_mined_by_hash(hash, block_option, max_block_range)
             .await
     }
 
@@ -329,13 +336,16 @@ where
         hash: B256,
         bundle_transaction: Option<B256>,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EventProviderResult<Option<RpcUserOperationReceipt>> {
         if let Some(bundle_transaction) = bundle_transaction {
             self.event_provider
                 .get_receipt_from_tx_hash(hash, bundle_transaction)
                 .await
         } else {
-            self.event_provider.get_receipt(hash, block_option).await
+            self.event_provider
+                .get_receipt(hash, block_option, max_block_range)
+                .await
         }
     }
 
@@ -354,9 +364,10 @@ where
         hash: B256,
         bundle_transaction: Option<B256>,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EventProviderResult<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>> {
         self.event_provider
-            .get_mined_and_receipt(hash, bundle_transaction, block_option)
+            .get_mined_and_receipt(hash, bundle_transaction, block_option, max_block_range)
             .await
     }
 

--- a/crates/rpc/src/eth/router.rs
+++ b/crates/rpc/src/eth/router.rs
@@ -20,8 +20,7 @@ use std::{
 
 use alloy_primitives::{Address, B256};
 use rundler_provider::{
-    EntryPoint, FilterBlockOption, ProviderError, SimulationProvider, StateOverride,
-    TransactionReceipt,
+    EntryPoint, ProviderError, SimulationProvider, StateOverride, TransactionReceipt,
 };
 use rundler_sim::{GasEstimationError, GasEstimator};
 use rundler_types::{
@@ -29,7 +28,9 @@ use rundler_types::{
     UserOperationVariant,
 };
 
-use super::events::{EventProviderError, EventProviderResult, UserOperationEventProvider};
+use super::events::{
+    EventBlockOptions, EventProviderError, EventProviderResult, UserOperationEventProvider,
+};
 use crate::{
     eth::{EthRpcError, error::EthResult},
     types::{
@@ -113,11 +114,10 @@ impl EntryPointRouter {
         &self,
         entry_point: &Address,
         hash: B256,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> Result<Option<RpcUserOperationByHash>, EventProviderError> {
         self.get_event_route(entry_point)?
-            .get_mined_by_hash(hash, block_option, max_block_range)
+            .get_mined_by_hash(hash, block_options)
             .await
     }
 
@@ -137,11 +137,10 @@ impl EntryPointRouter {
         entry_point: &Address,
         hash: B256,
         bundle_transaction: Option<B256>,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> Result<Option<RpcUserOperationReceipt>, EventProviderError> {
         self.get_event_route(entry_point)?
-            .get_receipt(hash, bundle_transaction, block_option, max_block_range)
+            .get_receipt(hash, bundle_transaction, block_options)
             .await
     }
 
@@ -163,11 +162,10 @@ impl EntryPointRouter {
         entry_point: &Address,
         hash: B256,
         bundle_transaction: Option<B256>,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> Result<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>, EventProviderError> {
         self.get_event_route(entry_point)?
-            .get_mined_and_receipt(hash, bundle_transaction, block_option, max_block_range)
+            .get_mined_and_receipt(hash, bundle_transaction, block_options)
             .await
     }
 
@@ -242,8 +240,7 @@ pub(crate) trait EntryPointRoute: Send + Sync {
     async fn get_mined_by_hash(
         &self,
         hash: B256,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EventProviderResult<Option<RpcUserOperationByHash>>;
 
     async fn get_mined_from_tx_receipt(
@@ -256,8 +253,7 @@ pub(crate) trait EntryPointRoute: Send + Sync {
         &self,
         hash: B256,
         bundle_transaction: Option<B256>,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EventProviderResult<Option<RpcUserOperationReceipt>>;
 
     async fn get_receipt_from_tx_receipt(
@@ -272,8 +268,7 @@ pub(crate) trait EntryPointRoute: Send + Sync {
         &self,
         hash: B256,
         bundle_transaction: Option<B256>,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EventProviderResult<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>>;
 
     async fn estimate_gas(
@@ -313,11 +308,10 @@ where
     async fn get_mined_by_hash(
         &self,
         hash: B256,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EventProviderResult<Option<RpcUserOperationByHash>> {
         self.event_provider
-            .get_mined_by_hash(hash, block_option, max_block_range)
+            .get_mined_by_hash(hash, block_options)
             .await
     }
 
@@ -335,17 +329,14 @@ where
         &self,
         hash: B256,
         bundle_transaction: Option<B256>,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EventProviderResult<Option<RpcUserOperationReceipt>> {
         if let Some(bundle_transaction) = bundle_transaction {
             self.event_provider
                 .get_receipt_from_tx_hash(hash, bundle_transaction)
                 .await
         } else {
-            self.event_provider
-                .get_receipt(hash, block_option, max_block_range)
-                .await
+            self.event_provider.get_receipt(hash, block_options).await
         }
     }
 
@@ -363,11 +354,10 @@ where
         &self,
         hash: B256,
         bundle_transaction: Option<B256>,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EventProviderResult<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>> {
         self.event_provider
-            .get_mined_and_receipt(hash, bundle_transaction, block_option, max_block_range)
+            .get_mined_and_receipt(hash, bundle_transaction, block_options)
             .await
     }
 

--- a/crates/rpc/src/eth/router.rs
+++ b/crates/rpc/src/eth/router.rs
@@ -20,7 +20,8 @@ use std::{
 
 use alloy_primitives::{Address, B256};
 use rundler_provider::{
-    EntryPoint, ProviderError, SimulationProvider, StateOverride, TransactionReceipt,
+    EntryPoint, FilterBlockOption, ProviderError, SimulationProvider, StateOverride,
+    TransactionReceipt,
 };
 use rundler_sim::{GasEstimationError, GasEstimator};
 use rundler_types::{
@@ -112,9 +113,10 @@ impl EntryPointRouter {
         &self,
         entry_point: &Address,
         hash: B256,
+        block_option: Option<FilterBlockOption>,
     ) -> Result<Option<RpcUserOperationByHash>, EventProviderError> {
         self.get_event_route(entry_point)?
-            .get_mined_by_hash(hash)
+            .get_mined_by_hash(hash, block_option)
             .await
     }
 
@@ -134,9 +136,10 @@ impl EntryPointRouter {
         entry_point: &Address,
         hash: B256,
         bundle_transaction: Option<B256>,
+        block_option: Option<FilterBlockOption>,
     ) -> Result<Option<RpcUserOperationReceipt>, EventProviderError> {
         self.get_event_route(entry_point)?
-            .get_receipt(hash, bundle_transaction)
+            .get_receipt(hash, bundle_transaction, block_option)
             .await
     }
 
@@ -158,9 +161,10 @@ impl EntryPointRouter {
         entry_point: &Address,
         hash: B256,
         bundle_transaction: Option<B256>,
+        block_option: Option<FilterBlockOption>,
     ) -> Result<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>, EventProviderError> {
         self.get_event_route(entry_point)?
-            .get_mined_and_receipt(hash, bundle_transaction)
+            .get_mined_and_receipt(hash, bundle_transaction, block_option)
             .await
     }
 
@@ -235,6 +239,7 @@ pub(crate) trait EntryPointRoute: Send + Sync {
     async fn get_mined_by_hash(
         &self,
         hash: B256,
+        block_option: Option<FilterBlockOption>,
     ) -> EventProviderResult<Option<RpcUserOperationByHash>>;
 
     async fn get_mined_from_tx_receipt(
@@ -247,6 +252,7 @@ pub(crate) trait EntryPointRoute: Send + Sync {
         &self,
         hash: B256,
         bundle_transaction: Option<B256>,
+        block_option: Option<FilterBlockOption>,
     ) -> EventProviderResult<Option<RpcUserOperationReceipt>>;
 
     async fn get_receipt_from_tx_receipt(
@@ -261,6 +267,7 @@ pub(crate) trait EntryPointRoute: Send + Sync {
         &self,
         hash: B256,
         bundle_transaction: Option<B256>,
+        block_option: Option<FilterBlockOption>,
     ) -> EventProviderResult<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>>;
 
     async fn estimate_gas(
@@ -300,8 +307,11 @@ where
     async fn get_mined_by_hash(
         &self,
         hash: B256,
+        block_option: Option<FilterBlockOption>,
     ) -> EventProviderResult<Option<RpcUserOperationByHash>> {
-        self.event_provider.get_mined_by_hash(hash).await
+        self.event_provider
+            .get_mined_by_hash(hash, block_option)
+            .await
     }
 
     async fn get_mined_from_tx_receipt(
@@ -318,13 +328,14 @@ where
         &self,
         hash: B256,
         bundle_transaction: Option<B256>,
+        block_option: Option<FilterBlockOption>,
     ) -> EventProviderResult<Option<RpcUserOperationReceipt>> {
         if let Some(bundle_transaction) = bundle_transaction {
             self.event_provider
                 .get_receipt_from_tx_hash(hash, bundle_transaction)
                 .await
         } else {
-            self.event_provider.get_receipt(hash).await
+            self.event_provider.get_receipt(hash, block_option).await
         }
     }
 
@@ -342,9 +353,10 @@ where
         &self,
         hash: B256,
         bundle_transaction: Option<B256>,
+        block_option: Option<FilterBlockOption>,
     ) -> EventProviderResult<Option<(RpcUserOperationByHash, RpcUserOperationReceipt)>> {
         self.event_provider
-            .get_mined_and_receipt(hash, bundle_transaction)
+            .get_mined_and_receipt(hash, bundle_transaction, block_option)
             .await
     }
 

--- a/crates/rpc/src/eth/server.rs
+++ b/crates/rpc/src/eth/server.rs
@@ -13,16 +13,17 @@
 
 use alloy_primitives::{Address, B256, U64};
 use jsonrpsee::core::RpcResult;
-use rundler_provider::StateOverride;
-use rundler_types::{BlockTag, UserOperationPermissions, pool::Pool};
+use rundler_provider::{FilterBlockOption, StateOverride};
+use rundler_types::{UserOperationPermissions, pool::Pool};
 use tracing::instrument;
 
 use super::{EthApiServer, api::EthApi};
 use crate::{
     eth::EthRpcError,
     types::{
-        RpcGasEstimate, RpcUserOperation, RpcUserOperationByHash, RpcUserOperationOptionalGas,
-        RpcUserOperationPermissions, RpcUserOperationReceipt,
+        RpcBlockOption, RpcBlockOptionOrTag, RpcGasEstimate, RpcUserOperation,
+        RpcUserOperationByHash, RpcUserOperationOptionalGas, RpcUserOperationPermissions,
+        RpcUserOperationReceipt,
     },
     utils::{self, IntoRundlerType, TryIntoRundlerType},
 };
@@ -101,10 +102,11 @@ where
     async fn get_user_operation_by_hash(
         &self,
         hash: B256,
+        block_option: Option<RpcBlockOption>,
     ) -> RpcResult<Option<RpcUserOperationByHash>> {
         utils::safe_call_rpc_handler(
             "eth_getUserOperationByHash",
-            EthApi::get_user_operation_by_hash(self, hash),
+            EthApi::get_user_operation_by_hash(self, hash, block_option.map(|o| o.into())),
         )
         .await
     }
@@ -113,11 +115,27 @@ where
     async fn get_user_operation_receipt(
         &self,
         hash: B256,
-        tag: Option<BlockTag>,
+        block_option_or_tag: Option<RpcBlockOptionOrTag>,
     ) -> RpcResult<Option<RpcUserOperationReceipt>> {
+        let (tag, block_option) = match block_option_or_tag {
+            None => (None, None),
+            Some(RpcBlockOptionOrTag::BlockTag(t)) => (Some(t), None),
+            Some(RpcBlockOptionOrTag::BlockHash(h)) => (None, Some(h.into())),
+            Some(RpcBlockOptionOrTag::Range {
+                from_block,
+                to_block,
+            }) => (
+                None,
+                Some(FilterBlockOption::Range {
+                    from_block,
+                    to_block,
+                }),
+            ),
+        };
+
         utils::safe_call_rpc_handler(
             "eth_getUserOperationReceipt",
-            EthApi::get_user_operation_receipt(self, hash, tag),
+            EthApi::get_user_operation_receipt(self, hash, tag, block_option),
         )
         .await
     }

--- a/crates/rpc/src/eth/server.rs
+++ b/crates/rpc/src/eth/server.rs
@@ -14,16 +14,17 @@
 use alloy_primitives::{Address, B256, U64};
 use http::Extensions;
 use jsonrpsee::core::RpcResult;
-use rundler_provider::{EvmProvider, FilterBlockOption, StateOverride};
+use rundler_provider::{EvmProvider, StateOverride};
 use rundler_types::{UserOperationPermissions, pool::Pool};
 use tracing::instrument;
 
 use super::{EthApiServer, api::EthApi};
 use crate::{
-    eth::EthRpcError,
+    eth::{EthRpcError, events::EventBlockOptions},
     types::{
-        RpcBlockOption, RpcBlockOptionOrTag, RpcGasEstimate, RpcPermissions, RpcUserOperation,
-        RpcUserOperationByHash, RpcUserOperationOptionalGas, RpcUserOperationReceipt,
+        MaxBlockRange, RpcBlockOption, RpcBlockOptionOrTag, RpcGasEstimate, RpcPermissions,
+        RpcUserOperation, RpcUserOperationByHash, RpcUserOperationOptionalGas,
+        RpcUserOperationReceipt,
     },
     utils::{self, IntoRundlerType, TryIntoRundlerType},
 };
@@ -111,17 +112,13 @@ where
         hash: B256,
         block_option: Option<RpcBlockOption>,
     ) -> RpcResult<Option<RpcUserOperationByHash>> {
-        let max_block_range = ext
-            .get::<RpcPermissions>()
-            .and_then(|p| p.max_block_range());
+        let block_options = EventBlockOptions {
+            block_option: block_option.map(|o| o.into()),
+            max_block_range: ext.get::<MaxBlockRange>().map(|r| r.0),
+        };
         utils::safe_call_rpc_handler(
             "eth_getUserOperationByHash",
-            EthApi::get_user_operation_by_hash(
-                self,
-                hash,
-                block_option.map(|o| o.into()),
-                max_block_range,
-            ),
+            EthApi::get_user_operation_by_hash(self, hash, block_options),
         )
         .await
     }
@@ -133,28 +130,19 @@ where
         hash: B256,
         block_option_or_tag: Option<RpcBlockOptionOrTag>,
     ) -> RpcResult<Option<RpcUserOperationReceipt>> {
-        let max_block_range = ext
-            .get::<RpcPermissions>()
-            .and_then(|p| p.max_block_range());
         let (tag, block_option) = match block_option_or_tag {
             None => (None, None),
             Some(RpcBlockOptionOrTag::BlockTag(t)) => (Some(t), None),
-            Some(RpcBlockOptionOrTag::BlockHash(h)) => (None, Some(h.into())),
-            Some(RpcBlockOptionOrTag::Range {
-                from_block,
-                to_block,
-            }) => (
-                None,
-                Some(FilterBlockOption::Range {
-                    from_block,
-                    to_block,
-                }),
-            ),
+            Some(RpcBlockOptionOrTag::BlockOption(bo)) => (None, Some(bo.into())),
+        };
+        let block_options = EventBlockOptions {
+            block_option,
+            max_block_range: ext.get::<MaxBlockRange>().map(|r| r.0),
         };
 
         utils::safe_call_rpc_handler(
             "eth_getUserOperationReceipt",
-            EthApi::get_user_operation_receipt(self, hash, tag, block_option, max_block_range),
+            EthApi::get_user_operation_receipt(self, hash, tag, block_options),
         )
         .await
     }

--- a/crates/rpc/src/eth/server.rs
+++ b/crates/rpc/src/eth/server.rs
@@ -14,7 +14,7 @@
 use alloy_primitives::{Address, B256, U64};
 use http::Extensions;
 use jsonrpsee::core::RpcResult;
-use rundler_provider::{FilterBlockOption, StateOverride};
+use rundler_provider::{EvmProvider, FilterBlockOption, StateOverride};
 use rundler_types::{UserOperationPermissions, pool::Pool};
 use tracing::instrument;
 
@@ -29,9 +29,10 @@ use crate::{
 };
 
 #[async_trait::async_trait]
-impl<P> EthApiServer for EthApi<P>
+impl<P, E> EthApiServer for EthApi<P, E>
 where
     P: Pool + 'static,
+    E: EvmProvider + 'static,
 {
     #[instrument(skip_all, fields(rpc_method = "eth_sendUserOperation"))]
     async fn send_user_operation(

--- a/crates/rpc/src/eth/server.rs
+++ b/crates/rpc/src/eth/server.rs
@@ -12,6 +12,7 @@
 // If not, see https://www.gnu.org/licenses/.
 
 use alloy_primitives::{Address, B256, U64};
+use http::Extensions;
 use jsonrpsee::core::RpcResult;
 use rundler_provider::{FilterBlockOption, StateOverride};
 use rundler_types::{UserOperationPermissions, pool::Pool};
@@ -21,9 +22,8 @@ use super::{EthApiServer, api::EthApi};
 use crate::{
     eth::EthRpcError,
     types::{
-        RpcBlockOption, RpcBlockOptionOrTag, RpcGasEstimate, RpcUserOperation,
-        RpcUserOperationByHash, RpcUserOperationOptionalGas, RpcUserOperationPermissions,
-        RpcUserOperationReceipt,
+        RpcBlockOption, RpcBlockOptionOrTag, RpcGasEstimate, RpcPermissions, RpcUserOperation,
+        RpcUserOperationByHash, RpcUserOperationOptionalGas, RpcUserOperationReceipt,
     },
     utils::{self, IntoRundlerType, TryIntoRundlerType},
 };
@@ -36,9 +36,10 @@ where
     #[instrument(skip_all, fields(rpc_method = "eth_sendUserOperation"))]
     async fn send_user_operation(
         &self,
+        ext: &Extensions,
         op: RpcUserOperation,
         entry_point: Address,
-        permissions: Option<RpcUserOperationPermissions>,
+        permissions: Option<RpcPermissions>,
     ) -> RpcResult<B256> {
         let Some(ep_version) = self.chain_spec.entry_point_version(entry_point) else {
             Err(EthRpcError::InvalidParams(format!(
@@ -47,9 +48,13 @@ where
             )))?
         };
 
+        // Header-supplied permissions (parsed into the request extensions by the transport
+        // middleware) take precedence over the legacy positional parameter.
+        let rpc_permissions = ext.get::<RpcPermissions>().cloned().or(permissions);
+
         // if permissions are not enabled, default them
         let mut permissions = if self.permissions_enabled {
-            permissions
+            rpc_permissions
                 .map(|p| p.into_rundler_type(&self.chain_spec, ep_version))
                 .unwrap_or_default()
         } else {
@@ -101,12 +106,21 @@ where
     #[instrument(skip_all, fields(rpc_method = "eth_getUserOperationByHash"))]
     async fn get_user_operation_by_hash(
         &self,
+        ext: &Extensions,
         hash: B256,
         block_option: Option<RpcBlockOption>,
     ) -> RpcResult<Option<RpcUserOperationByHash>> {
+        let max_block_range = ext
+            .get::<RpcPermissions>()
+            .and_then(|p| p.max_block_range());
         utils::safe_call_rpc_handler(
             "eth_getUserOperationByHash",
-            EthApi::get_user_operation_by_hash(self, hash, block_option.map(|o| o.into())),
+            EthApi::get_user_operation_by_hash(
+                self,
+                hash,
+                block_option.map(|o| o.into()),
+                max_block_range,
+            ),
         )
         .await
     }
@@ -114,9 +128,13 @@ where
     #[instrument(skip_all, fields(rpc_method = "eth_getUserOperationReceipt"))]
     async fn get_user_operation_receipt(
         &self,
+        ext: &Extensions,
         hash: B256,
         block_option_or_tag: Option<RpcBlockOptionOrTag>,
     ) -> RpcResult<Option<RpcUserOperationReceipt>> {
+        let max_block_range = ext
+            .get::<RpcPermissions>()
+            .and_then(|p| p.max_block_range());
         let (tag, block_option) = match block_option_or_tag {
             None => (None, None),
             Some(RpcBlockOptionOrTag::BlockTag(t)) => (Some(t), None),
@@ -135,7 +153,7 @@ where
 
         utils::safe_call_rpc_handler(
             "eth_getUserOperationReceipt",
-            EthApi::get_user_operation_receipt(self, hash, tag, block_option),
+            EthApi::get_user_operation_receipt(self, hash, tag, block_option, max_block_range),
         )
         .await
     }

--- a/crates/rpc/src/eth/server.rs
+++ b/crates/rpc/src/eth/server.rs
@@ -128,9 +128,9 @@ where
         &self,
         ext: &Extensions,
         hash: B256,
-        block_option_or_tag: Option<RpcBlockOptionOrTag>,
+        tag: Option<RpcBlockOptionOrTag>,
     ) -> RpcResult<Option<RpcUserOperationReceipt>> {
-        let (tag, block_option) = match block_option_or_tag {
+        let (tag, block_option) = match tag {
             None => (None, None),
             Some(RpcBlockOptionOrTag::BlockTag(t)) => (Some(t), None),
             Some(RpcBlockOptionOrTag::BlockOption(bo)) => (None, Some(bo.into())),

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -39,6 +39,7 @@ pub use types::RpcDelegationStatus;
 mod task;
 pub use task::{Args as RpcTaskArgs, RpcTask};
 
+mod permissions_middleware;
 mod rpc_metrics;
 mod types;
 mod utils;

--- a/crates/rpc/src/permissions_middleware.rs
+++ b/crates/rpc/src/permissions_middleware.rs
@@ -205,18 +205,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn no_headers_does_not_insert_permissions() {
-        let inner = RecordingService::default();
-        let saw = inner.saw_permissions.clone();
-        let mut svc = PermissionsHeaderLayer::new(true).layer(inner);
-
-        let resp = svc.call(request_with(&[])).await.unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        assert_eq!(*saw.lock().unwrap(), Some(false));
-    }
-
-    #[tokio::test]
     async fn malformed_header_returns_400_without_calling_inner() {
         let inner = RecordingService::default();
         let called = inner.called.clone();

--- a/crates/rpc/src/permissions_middleware.rs
+++ b/crates/rpc/src/permissions_middleware.rs
@@ -79,6 +79,11 @@ where
     }
 
     fn call(&mut self, mut req: HttpRequest<RequestBody>) -> Self::Future {
+        // `poll_ready` was driven on `self.service`, so take it and leave the fresh
+        // (not-yet-ready) clone behind for the next call.
+        let clone = self.service.clone();
+        let mut svc = std::mem::replace(&mut self.service, clone);
+
         if self.enabled {
             match RpcPermissions::from_headers(req.headers()) {
                 Ok(Some(perms)) => {
@@ -98,7 +103,6 @@ where
             }
         }
 
-        let mut svc = self.service.clone();
         async move { svc.call(req).await }.boxed()
     }
 }

--- a/crates/rpc/src/permissions_middleware.rs
+++ b/crates/rpc/src/permissions_middleware.rs
@@ -1,0 +1,203 @@
+// This file is part of Rundler.
+//
+// Rundler is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Rundler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Rundler.
+// If not, see https://www.gnu.org/licenses/.
+
+//! Transport-level middleware that parses per-request user operation permissions from
+//! HTTP headers and stores them in the request extensions for RPC handlers to read.
+//!
+//! The headers are only honored when permissions are enabled (Rundler sits behind a trusted
+//! gateway). When disabled, the headers are ignored entirely. A malformed header — or only one
+//! of the coupled sponsorship header pair — fails the request closed with `400 Bad Request`.
+
+use futures_util::{FutureExt, future::BoxFuture};
+use http::{Request as HttpRequest, Response as HttpResponse, StatusCode, header::CONTENT_TYPE};
+use jsonrpsee::server::HttpBody;
+use tower::{Layer, Service};
+
+use crate::types::RpcPermissions;
+
+/// Tower layer that installs the [`PermissionsHeaderMiddleware`].
+#[derive(Clone)]
+pub(crate) struct PermissionsHeaderLayer {
+    enabled: bool,
+}
+
+impl PermissionsHeaderLayer {
+    /// Create a new layer. When `enabled` is false the middleware is a pass-through.
+    pub(crate) fn new(enabled: bool) -> Self {
+        Self { enabled }
+    }
+}
+
+impl<S> Layer<S> for PermissionsHeaderLayer {
+    type Service = PermissionsHeaderMiddleware<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        PermissionsHeaderMiddleware {
+            service,
+            enabled: self.enabled,
+        }
+    }
+}
+
+/// Middleware that parses the `X-Rundler-*` permission headers into
+/// [`RpcPermissions`] and inserts them into the request extensions.
+#[derive(Clone)]
+pub(crate) struct PermissionsHeaderMiddleware<S> {
+    service: S,
+    enabled: bool,
+}
+
+impl<S, RequestBody> Service<HttpRequest<RequestBody>> for PermissionsHeaderMiddleware<S>
+where
+    S: Service<HttpRequest<RequestBody>, Response = HttpResponse<HttpBody>>
+        + Send
+        + Sync
+        + Clone
+        + 'static,
+    S::Future: Send,
+    RequestBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: HttpRequest<RequestBody>) -> Self::Future {
+        if self.enabled {
+            match RpcPermissions::from_headers(req.headers()) {
+                Ok(Some(perms)) => {
+                    req.extensions_mut().insert(perms);
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    // Fail closed: a malformed policy header must not silently fall through
+                    // to defaults.
+                    let resp = HttpResponse::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .header(CONTENT_TYPE, "text/plain")
+                        .body(HttpBody::from(err.to_string()))
+                        .expect("failed to build bad request response");
+                    return async move { Ok(resp) }.boxed();
+                }
+            }
+        }
+
+        let mut svc = self.service.clone();
+        async move { svc.call(req).await }.boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        convert::Infallible,
+        sync::{Arc, Mutex},
+        task::{Context, Poll},
+    };
+
+    use super::*;
+
+    #[derive(Clone, Default)]
+    struct RecordingService {
+        saw_permissions: Arc<Mutex<Option<bool>>>,
+        called: Arc<Mutex<bool>>,
+    }
+
+    impl Service<HttpRequest<()>> for RecordingService {
+        type Response = HttpResponse<HttpBody>;
+        type Error = Infallible;
+        type Future = futures_util::future::Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: HttpRequest<()>) -> Self::Future {
+            *self.called.lock().unwrap() = true;
+            *self.saw_permissions.lock().unwrap() =
+                Some(req.extensions().get::<RpcPermissions>().is_some());
+            futures_util::future::ready(Ok(HttpResponse::new(HttpBody::from("ok".to_string()))))
+        }
+    }
+
+    fn request_with(headers: &[(&str, &str)]) -> HttpRequest<()> {
+        let mut builder = HttpRequest::builder();
+        for (name, value) in headers {
+            builder = builder.header(*name, *value);
+        }
+        builder.body(()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn enabled_inserts_permissions_into_extensions() {
+        let inner = RecordingService::default();
+        let saw = inner.saw_permissions.clone();
+        let mut svc = PermissionsHeaderLayer::new(true).layer(inner);
+
+        let resp = svc
+            .call(request_with(&[("x-rundler-trusted", "true")]))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(*saw.lock().unwrap(), Some(true));
+    }
+
+    #[tokio::test]
+    async fn disabled_ignores_headers() {
+        let inner = RecordingService::default();
+        let saw = inner.saw_permissions.clone();
+        let mut svc = PermissionsHeaderLayer::new(false).layer(inner);
+
+        let resp = svc
+            .call(request_with(&[("x-rundler-trusted", "true")]))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(*saw.lock().unwrap(), Some(false));
+    }
+
+    #[tokio::test]
+    async fn no_headers_does_not_insert_permissions() {
+        let inner = RecordingService::default();
+        let saw = inner.saw_permissions.clone();
+        let mut svc = PermissionsHeaderLayer::new(true).layer(inner);
+
+        let resp = svc.call(request_with(&[])).await.unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(*saw.lock().unwrap(), Some(false));
+    }
+
+    #[tokio::test]
+    async fn malformed_header_returns_400_without_calling_inner() {
+        let inner = RecordingService::default();
+        let called = inner.called.clone();
+        let mut svc = PermissionsHeaderLayer::new(true).layer(inner);
+
+        let resp = svc
+            .call(request_with(&[("x-rundler-trusted", "maybe")]))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert!(!*called.lock().unwrap());
+    }
+}

--- a/crates/rpc/src/permissions_middleware.rs
+++ b/crates/rpc/src/permissions_middleware.rs
@@ -23,7 +23,7 @@ use http::{Request as HttpRequest, Response as HttpResponse, StatusCode, header:
 use jsonrpsee::server::HttpBody;
 use tower::{Layer, Service};
 
-use crate::types::RpcPermissions;
+use crate::types::{MaxBlockRange, RpcPermissions};
 
 /// Tower layer that installs the [`PermissionsHeaderMiddleware`].
 #[derive(Clone)]
@@ -85,11 +85,17 @@ where
         let mut svc = std::mem::replace(&mut self.service, clone);
 
         if self.enabled {
-            match RpcPermissions::from_headers(req.headers()) {
-                Ok(Some(perms)) => {
-                    req.extensions_mut().insert(perms);
+            let parsed = RpcPermissions::from_headers(req.headers())
+                .and_then(|perms| Ok((perms, MaxBlockRange::from_headers(req.headers())?)));
+            match parsed {
+                Ok((perms, max_block_range)) => {
+                    if let Some(perms) = perms {
+                        req.extensions_mut().insert(perms);
+                    }
+                    if let Some(max_block_range) = max_block_range {
+                        req.extensions_mut().insert(max_block_range);
+                    }
                 }
-                Ok(None) => {}
                 Err(err) => {
                     // Fail closed: a malformed policy header must not silently fall through
                     // to defaults.
@@ -120,6 +126,7 @@ mod tests {
     #[derive(Clone, Default)]
     struct RecordingService {
         saw_permissions: Arc<Mutex<Option<bool>>>,
+        saw_max_block_range: Arc<Mutex<Option<u64>>>,
         called: Arc<Mutex<bool>>,
     }
 
@@ -136,6 +143,8 @@ mod tests {
             *self.called.lock().unwrap() = true;
             *self.saw_permissions.lock().unwrap() =
                 Some(req.extensions().get::<RpcPermissions>().is_some());
+            *self.saw_max_block_range.lock().unwrap() =
+                req.extensions().get::<MaxBlockRange>().map(|r| r.0);
             futures_util::future::ready(Ok(HttpResponse::new(HttpBody::from("ok".to_string()))))
         }
     }
@@ -176,6 +185,23 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(*saw.lock().unwrap(), Some(false));
+    }
+
+    #[tokio::test]
+    async fn max_block_range_does_not_count_as_permissions() {
+        let inner = RecordingService::default();
+        let saw_perms = inner.saw_permissions.clone();
+        let saw_range = inner.saw_max_block_range.clone();
+        let mut svc = PermissionsHeaderLayer::new(true).layer(inner);
+
+        let resp = svc
+            .call(request_with(&[("x-rundler-max-block-range", "1000")]))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(*saw_perms.lock().unwrap(), Some(false));
+        assert_eq!(*saw_range.lock().unwrap(), Some(1000));
     }
 
     #[tokio::test]

--- a/crates/rpc/src/rundler.rs
+++ b/crates/rpc/src/rundler.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use futures_util::future;
 use http::Extensions;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use rundler_provider::{EvmProvider, FeeEstimator, FilterBlockOption};
+use rundler_provider::{EvmProvider, FeeEstimator};
 use rundler_types::{
     GasFees, UserOperation, UserOperationId, UserOperationVariant,
     authorization::Eip7702Auth,
@@ -30,9 +30,9 @@ use rundler_types::{
 use tracing::instrument;
 
 use crate::{
-    eth::{EntryPointRouter, EthResult, EthRpcError, resolve_block_option},
+    eth::{EntryPointRouter, EthResult, EthRpcError, EventBlockOptions, resolve_block_option},
     types::{
-        RpcBlockOption, RpcDelegationStatus, RpcMinedUserOperation, RpcPermissions,
+        MaxBlockRange, RpcBlockOption, RpcDelegationStatus, RpcMinedUserOperation,
         RpcSuggestedGasFees, RpcUserOperation, RpcUserOperationGasPrice, RpcUserOperationStatus,
         UOStatusEnum, UserOperationStatusEnum,
     },
@@ -194,17 +194,13 @@ where
         uo_hash: B256,
         block_option: Option<RpcBlockOption>,
     ) -> RpcResult<RpcUserOperationStatus> {
-        let max_block_range = ext
-            .get::<RpcPermissions>()
-            .and_then(|p| p.max_block_range());
+        let block_options = EventBlockOptions {
+            block_option: block_option.map(|o| o.into()),
+            max_block_range: ext.get::<MaxBlockRange>().map(|r| r.0),
+        };
         utils::safe_call_rpc_handler(
             "rundler_getUserOperationStatus",
-            RundlerApi::get_user_operation_status(
-                self,
-                uo_hash,
-                block_option.map(|o| o.into()),
-                max_block_range,
-            ),
+            RundlerApi::get_user_operation_status(self, uo_hash, block_options),
         )
         .await
     }
@@ -392,18 +388,20 @@ where
     async fn get_user_operation_status(
         &self,
         uo_hash: B256,
-        block_option: Option<FilterBlockOption>,
-        max_block_range: Option<u64>,
+        block_options: EventBlockOptions,
     ) -> EthResult<RpcUserOperationStatus> {
         // Resolve block tags to concrete numbers once, before fanning out to the entry
         // point routes, so each route doesn't re-resolve them via RPC.
-        let block_option = match block_option {
-            Some(bo) => Some(
-                resolve_block_option(&self.evm_provider, bo)
-                    .await
-                    .map_err(EthRpcError::from)?,
-            ),
-            None => None,
+        let block_options = EventBlockOptions {
+            block_option: match block_options.block_option {
+                Some(bo) => Some(
+                    resolve_block_option(&self.evm_provider, bo)
+                        .await
+                        .map_err(EthRpcError::from)?,
+                ),
+                None => None,
+            },
+            ..block_options
         };
 
         // Fetch pool status first to get preconf info for the mined query
@@ -426,8 +424,10 @@ where
                     &pool_status.entry_point,
                     uo_hash,
                     Some(preconf_info.tx_hash),
-                    None,
-                    max_block_range,
+                    EventBlockOptions {
+                        block_option: None,
+                        ..block_options
+                    },
                 )
                 .await;
             match ret {
@@ -441,13 +441,8 @@ where
             }
         } else {
             let mined_futs = self.entry_point_router.entry_points().map(|ep| {
-                self.entry_point_router.get_mined_and_receipt(
-                    ep,
-                    uo_hash,
-                    None,
-                    block_option,
-                    max_block_range,
-                )
+                self.entry_point_router
+                    .get_mined_and_receipt(ep, uo_hash, None, block_options)
             });
             future::try_join_all(mined_futs)
                 .await

--- a/crates/rpc/src/rundler.rs
+++ b/crates/rpc/src/rundler.rs
@@ -17,6 +17,7 @@ use alloy_primitives::{Address, B256, U64, U128, U256};
 use anyhow::Context;
 use async_trait::async_trait;
 use futures_util::future;
+use http::Extensions;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use rundler_provider::{EvmProvider, FeeEstimator, FilterBlockOption};
 use rundler_types::{
@@ -31,9 +32,9 @@ use tracing::instrument;
 use crate::{
     eth::{EntryPointRouter, EthResult, EthRpcError},
     types::{
-        RpcBlockOption, RpcDelegationStatus, RpcMinedUserOperation, RpcSuggestedGasFees,
-        RpcUserOperation, RpcUserOperationGasPrice, RpcUserOperationStatus, UOStatusEnum,
-        UserOperationStatusEnum,
+        RpcBlockOption, RpcDelegationStatus, RpcMinedUserOperation, RpcPermissions,
+        RpcSuggestedGasFees, RpcUserOperation, RpcUserOperationGasPrice, RpcUserOperationStatus,
+        UOStatusEnum, UserOperationStatusEnum,
     },
     utils::{self, TryIntoRundlerType},
 };
@@ -94,7 +95,7 @@ pub trait RundlerApi {
     ) -> RpcResult<Option<RpcMinedUserOperation>>;
 
     /// Gets the status of a user operation by user operation hash
-    #[method(name = "getUserOperationStatus")]
+    #[method(name = "getUserOperationStatus", with_extensions)]
     async fn get_user_operation_status(
         &self,
         uo_hash: B256,
@@ -189,12 +190,21 @@ where
     #[instrument(skip_all, fields(rpc_method = "rundler_getUserOperationStatus"))]
     async fn get_user_operation_status(
         &self,
+        ext: &Extensions,
         uo_hash: B256,
         block_option: Option<RpcBlockOption>,
     ) -> RpcResult<RpcUserOperationStatus> {
+        let max_block_range = ext
+            .get::<RpcPermissions>()
+            .and_then(|p| p.max_block_range());
         utils::safe_call_rpc_handler(
             "rundler_getUserOperationStatus",
-            RundlerApi::get_user_operation_status(self, uo_hash, block_option.map(|o| o.into())),
+            RundlerApi::get_user_operation_status(
+                self,
+                uo_hash,
+                block_option.map(|o| o.into()),
+                max_block_range,
+            ),
         )
         .await
     }
@@ -383,6 +393,7 @@ where
         &self,
         uo_hash: B256,
         block_option: Option<FilterBlockOption>,
+        max_block_range: Option<u64>,
     ) -> EthResult<RpcUserOperationStatus> {
         // Fetch pool status first to get preconf info for the mined query
         let op_status = self
@@ -405,6 +416,7 @@ where
                     uo_hash,
                     Some(preconf_info.tx_hash),
                     None,
+                    max_block_range,
                 )
                 .await;
             match ret {
@@ -418,8 +430,13 @@ where
             }
         } else {
             let mined_futs = self.entry_point_router.entry_points().map(|ep| {
-                self.entry_point_router
-                    .get_mined_and_receipt(ep, uo_hash, None, block_option)
+                self.entry_point_router.get_mined_and_receipt(
+                    ep,
+                    uo_hash,
+                    None,
+                    block_option,
+                    max_block_range,
+                )
             });
             future::try_join_all(mined_futs)
                 .await

--- a/crates/rpc/src/rundler.rs
+++ b/crates/rpc/src/rundler.rs
@@ -18,7 +18,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use futures_util::future;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use rundler_provider::{EvmProvider, FeeEstimator};
+use rundler_provider::{EvmProvider, FeeEstimator, FilterBlockOption};
 use rundler_types::{
     GasFees, UserOperation, UserOperationId, UserOperationVariant,
     authorization::Eip7702Auth,
@@ -31,8 +31,9 @@ use tracing::instrument;
 use crate::{
     eth::{EntryPointRouter, EthResult, EthRpcError},
     types::{
-        RpcDelegationStatus, RpcMinedUserOperation, RpcSuggestedGasFees, RpcUserOperation,
-        RpcUserOperationGasPrice, RpcUserOperationStatus, UOStatusEnum, UserOperationStatusEnum,
+        RpcBlockOption, RpcDelegationStatus, RpcMinedUserOperation, RpcSuggestedGasFees,
+        RpcUserOperation, RpcUserOperationGasPrice, RpcUserOperationStatus, UOStatusEnum,
+        UserOperationStatusEnum,
     },
     utils::{self, TryIntoRundlerType},
 };
@@ -94,7 +95,11 @@ pub trait RundlerApi {
 
     /// Gets the status of a user operation by user operation hash
     #[method(name = "getUserOperationStatus")]
-    async fn get_user_operation_status(&self, uo_hash: B256) -> RpcResult<RpcUserOperationStatus>;
+    async fn get_user_operation_status(
+        &self,
+        uo_hash: B256,
+        block_option: Option<RpcBlockOption>,
+    ) -> RpcResult<RpcUserOperationStatus>;
 
     /// Gets the required fees for a sender nonce
     #[method(name = "getPendingUserOperationBySenderNonce")]
@@ -182,10 +187,14 @@ where
     }
 
     #[instrument(skip_all, fields(rpc_method = "rundler_getUserOperationStatus"))]
-    async fn get_user_operation_status(&self, uo_hash: B256) -> RpcResult<RpcUserOperationStatus> {
+    async fn get_user_operation_status(
+        &self,
+        uo_hash: B256,
+        block_option: Option<RpcBlockOption>,
+    ) -> RpcResult<RpcUserOperationStatus> {
         utils::safe_call_rpc_handler(
             "rundler_getUserOperationStatus",
-            RundlerApi::get_user_operation_status(self, uo_hash),
+            RundlerApi::get_user_operation_status(self, uo_hash, block_option.map(|o| o.into())),
         )
         .await
     }
@@ -370,7 +379,11 @@ where
         }
     }
 
-    async fn get_user_operation_status(&self, uo_hash: B256) -> EthResult<RpcUserOperationStatus> {
+    async fn get_user_operation_status(
+        &self,
+        uo_hash: B256,
+        block_option: Option<FilterBlockOption>,
+    ) -> EthResult<RpcUserOperationStatus> {
         // Fetch pool status first to get preconf info for the mined query
         let op_status = self
             .pool_server
@@ -391,6 +404,7 @@ where
                     &pool_status.entry_point,
                     uo_hash,
                     Some(preconf_info.tx_hash),
+                    None,
                 )
                 .await;
             match ret {
@@ -405,7 +419,7 @@ where
         } else {
             let mined_futs = self.entry_point_router.entry_points().map(|ep| {
                 self.entry_point_router
-                    .get_mined_and_receipt(ep, uo_hash, None)
+                    .get_mined_and_receipt(ep, uo_hash, None, block_option)
             });
             future::try_join_all(mined_futs)
                 .await

--- a/crates/rpc/src/rundler.rs
+++ b/crates/rpc/src/rundler.rs
@@ -30,7 +30,7 @@ use rundler_types::{
 use tracing::instrument;
 
 use crate::{
-    eth::{EntryPointRouter, EthResult, EthRpcError, EventBlockOptions, resolve_block_option},
+    eth::{EntryPointRouter, EthResult, EthRpcError, EventBlockOptions},
     types::{
         MaxBlockRange, RpcBlockOption, RpcDelegationStatus, RpcMinedUserOperation,
         RpcSuggestedGasFees, RpcUserOperation, RpcUserOperationGasPrice, RpcUserOperationStatus,
@@ -390,19 +390,10 @@ where
         uo_hash: B256,
         block_options: EventBlockOptions,
     ) -> EthResult<RpcUserOperationStatus> {
-        // Resolve block tags to concrete numbers once, before fanning out to the entry
-        // point routes, so each route doesn't re-resolve them via RPC.
-        let block_options = EventBlockOptions {
-            block_option: match block_options.block_option {
-                Some(bo) => Some(
-                    resolve_block_option(&self.evm_provider, bo)
-                        .await
-                        .map_err(EthRpcError::from)?,
-                ),
-                None => None,
-            },
-            ..block_options
-        };
+        let block_options = block_options
+            .resolve(&self.evm_provider)
+            .await
+            .map_err(EthRpcError::from)?;
 
         // Fetch pool status first to get preconf info for the mined query
         let op_status = self

--- a/crates/rpc/src/rundler.rs
+++ b/crates/rpc/src/rundler.rs
@@ -30,7 +30,7 @@ use rundler_types::{
 use tracing::instrument;
 
 use crate::{
-    eth::{EntryPointRouter, EthResult, EthRpcError},
+    eth::{EntryPointRouter, EthResult, EthRpcError, resolve_block_option},
     types::{
         RpcBlockOption, RpcDelegationStatus, RpcMinedUserOperation, RpcPermissions,
         RpcSuggestedGasFees, RpcUserOperation, RpcUserOperationGasPrice, RpcUserOperationStatus,
@@ -395,6 +395,17 @@ where
         block_option: Option<FilterBlockOption>,
         max_block_range: Option<u64>,
     ) -> EthResult<RpcUserOperationStatus> {
+        // Resolve block tags to concrete numbers once, before fanning out to the entry
+        // point routes, so each route doesn't re-resolve them via RPC.
+        let block_option = match block_option {
+            Some(bo) => Some(
+                resolve_block_option(&self.evm_provider, bo)
+                    .await
+                    .map_err(EthRpcError::from)?,
+            ),
+            None => None,
+        };
+
         // Fetch pool status first to get preconf info for the mined query
         let op_status = self
             .pool_server

--- a/crates/rpc/src/task.rs
+++ b/crates/rpc/src/task.rs
@@ -40,6 +40,7 @@ use crate::{
         EthApiSettings, UserOperationEventProviderV0_6, UserOperationEventProviderV0_7,
     },
     health::{HealthChecker, SystemApiServer},
+    permissions_middleware::PermissionsHeaderLayer,
     rpc_metrics::{HttpMetricMiddlewareLayer, RpcMetricsMiddlewareLayer},
     rundler::{RundlerApi, RundlerApiServer, RundlerApiSettings},
     types::ApiNamespace,
@@ -222,6 +223,11 @@ where
             .timeout(self.args.rpc_timeout)
             .layer(HttpMetricMiddlewareLayer::new(
                 "rundler-rpc-service-http".to_string(),
+            ))
+            // Parse per-request permission headers into request extensions. Only honored when
+            // permissions are enabled (Rundler behind a trusted gateway).
+            .layer(PermissionsHeaderLayer::new(
+                self.args.eth_api_settings.permissions_enabled,
             ));
 
         let rpc_metric_middleware = RpcServiceBuilder::new().layer(RpcMetricsMiddlewareLayer::new(

--- a/crates/rpc/src/task.rs
+++ b/crates/rpc/src/task.rs
@@ -278,6 +278,7 @@ where
                     self.args.chain_spec.clone(),
                     entry_point_router.clone(),
                     self.pool.clone(),
+                    self.providers.evm().clone(),
                     permissions_enabled,
                 )
                 .into_rpc(),

--- a/crates/rpc/src/types/mod.rs
+++ b/crates/rpc/src/types/mod.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 mod permissions;
-pub(crate) use permissions::RpcPermissions;
+pub(crate) use permissions::{MaxBlockRange, RpcPermissions};
 
 mod v0_6;
 pub(crate) use v0_6::{
@@ -432,15 +432,25 @@ pub enum RpcDelegationStatus {
     Unknown,
 }
 
+/// A block range for scoping user operation event lookups.
+///
+/// `deny_unknown_fields` keeps this from swallowing arbitrary JSON objects (e.g. a
+/// `{"blockHash": ...}` getLogs-style filter) as an empty range when used in the
+/// untagged unions below.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[serde(untagged, rename_all_fields = "camelCase")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub(crate) struct RpcBlockRange {
+    /// The block number or tag this filter should start at.
+    pub(crate) from_block: Option<BlockNumberOrTag>,
+    /// The block number that this filter should end at.
+    pub(crate) to_block: Option<BlockNumberOrTag>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
 pub(crate) enum RpcBlockOption {
-    Range {
-        /// The block number or tag this filter should start at.
-        from_block: Option<BlockNumberOrTag>,
-        /// The block number that this filter should end at.
-        to_block: Option<BlockNumberOrTag>,
-    },
+    /// The block range this filter should search
+    Range(RpcBlockRange),
     /// The hash of the block if the filter only targets a single block
     AtBlockHash(BlockHash),
 }
@@ -448,10 +458,10 @@ pub(crate) enum RpcBlockOption {
 impl From<RpcBlockOption> for FilterBlockOption {
     fn from(rpc: RpcBlockOption) -> FilterBlockOption {
         match rpc {
-            RpcBlockOption::Range {
+            RpcBlockOption::Range(RpcBlockRange {
                 from_block,
                 to_block,
-            } => FilterBlockOption::Range {
+            }) => FilterBlockOption::Range {
                 from_block,
                 to_block,
             },
@@ -461,16 +471,10 @@ impl From<RpcBlockOption> for FilterBlockOption {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[serde(untagged, rename_all_fields = "camelCase")]
+#[serde(untagged)]
 pub(crate) enum RpcBlockOptionOrTag {
-    Range {
-        /// The block number or tag this filter should start at.
-        from_block: Option<BlockNumberOrTag>,
-        /// The block number that this filter should end at.
-        to_block: Option<BlockNumberOrTag>,
-    },
-    /// The hash of the block if the filter only targets a single block
-    BlockHash(BlockHash),
+    /// A block range or block hash
+    BlockOption(RpcBlockOption),
     /// The block tag to use for this request
     BlockTag(BlockTag),
 }
@@ -485,29 +489,29 @@ mod tests {
             serde_json::from_str(r#"{"fromBlock": "0x64", "toBlock": "0xc8"}"#).unwrap();
         assert!(matches!(
             full,
-            RpcBlockOption::Range {
+            RpcBlockOption::Range(RpcBlockRange {
                 from_block: Some(BlockNumberOrTag::Number(100)),
                 to_block: Some(BlockNumberOrTag::Number(200)),
-            }
+            })
         ));
 
         // The documented range fields are optional; a one-sided range must deserialize.
         let from_only: RpcBlockOption = serde_json::from_str(r#"{"fromBlock": "0x64"}"#).unwrap();
         assert!(matches!(
             from_only,
-            RpcBlockOption::Range {
+            RpcBlockOption::Range(RpcBlockRange {
                 from_block: Some(BlockNumberOrTag::Number(100)),
                 to_block: None,
-            }
+            })
         ));
 
         let to_only: RpcBlockOption = serde_json::from_str(r#"{"toBlock": "latest"}"#).unwrap();
         assert!(matches!(
             to_only,
-            RpcBlockOption::Range {
+            RpcBlockOption::Range(RpcBlockRange {
                 from_block: None,
                 to_block: Some(BlockNumberOrTag::Latest),
-            }
+            })
         ));
     }
 
@@ -516,5 +520,61 @@ mod tests {
         let hash = B256::repeat_byte(0xab);
         let parsed: RpcBlockOption = serde_json::from_str(&format!("\"{hash}\"")).unwrap();
         assert!(matches!(parsed, RpcBlockOption::AtBlockHash(h) if h == hash));
+    }
+
+    #[test]
+    fn block_option_rejects_unknown_object_keys() {
+        // A getLogs-style {"blockHash": ...} object must not silently match as an
+        // empty range.
+        let res: Result<RpcBlockOption, _> = serde_json::from_str(
+            r#"{"blockHash": "0xabababababababababababababababababababababababababababababababab"}"#,
+        );
+        assert!(res.is_err());
+
+        let res: Result<RpcBlockOptionOrTag, _> =
+            serde_json::from_str(r#"{"fromBlock": "0x64", "unknown": 1}"#);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn block_option_or_tag_deserializes_legacy_tags() {
+        // Backwards compatibility: every previously-valid eth_getUserOperationReceipt
+        // 2nd positional parameter must keep parsing as a tag.
+        for (raw, expected) in [
+            (r#""LATEST""#, BlockTag::Latest),
+            (r#""latest""#, BlockTag::Latest),
+            (r#""PENDING""#, BlockTag::Pending),
+            (r#""pending""#, BlockTag::Pending),
+        ] {
+            let parsed: RpcBlockOptionOrTag = serde_json::from_str(raw).unwrap();
+            assert!(
+                matches!(parsed, RpcBlockOptionOrTag::BlockTag(t) if t == expected),
+                "{raw} did not parse as {expected:?}: {parsed:?}"
+            );
+        }
+
+        // Previously-invalid inputs must still be rejected.
+        assert!(serde_json::from_str::<RpcBlockOptionOrTag>(r#""Latest""#).is_err());
+        assert!(serde_json::from_str::<RpcBlockOptionOrTag>("100").is_err());
+    }
+
+    #[test]
+    fn block_option_or_tag_deserializes_block_options() {
+        let range: RpcBlockOptionOrTag =
+            serde_json::from_str(r#"{"fromBlock": "0x64", "toBlock": "0xc8"}"#).unwrap();
+        assert!(matches!(
+            range,
+            RpcBlockOptionOrTag::BlockOption(RpcBlockOption::Range(RpcBlockRange {
+                from_block: Some(BlockNumberOrTag::Number(100)),
+                to_block: Some(BlockNumberOrTag::Number(200)),
+            }))
+        ));
+
+        let hash = B256::repeat_byte(0xab);
+        let parsed: RpcBlockOptionOrTag = serde_json::from_str(&format!("\"{hash}\"")).unwrap();
+        assert!(matches!(
+            parsed,
+            RpcBlockOptionOrTag::BlockOption(RpcBlockOption::AtBlockHash(h)) if h == hash
+        ));
     }
 }

--- a/crates/rpc/src/types/mod.rs
+++ b/crates/rpc/src/types/mod.rs
@@ -560,14 +560,12 @@ mod tests {
 
     #[test]
     fn block_option_or_tag_deserializes_block_options() {
-        let range: RpcBlockOptionOrTag =
+        // Outer-union routing only: field parsing is covered on RpcBlockOption directly.
+        let parsed: RpcBlockOptionOrTag =
             serde_json::from_str(r#"{"fromBlock": "0x64", "toBlock": "0xc8"}"#).unwrap();
         assert!(matches!(
-            range,
-            RpcBlockOptionOrTag::BlockOption(RpcBlockOption::Range(RpcBlockRange {
-                from_block: Some(BlockNumberOrTag::Number(100)),
-                to_block: Some(BlockNumberOrTag::Number(200)),
-            }))
+            parsed,
+            RpcBlockOptionOrTag::BlockOption(RpcBlockOption::Range(_))
         ));
 
         let hash = B256::repeat_byte(0xab);

--- a/crates/rpc/src/types/mod.rs
+++ b/crates/rpc/src/types/mod.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 mod permissions;
-pub(crate) use permissions::RpcUserOperationPermissions;
+pub(crate) use permissions::RpcPermissions;
 
 mod v0_6;
 pub(crate) use v0_6::{

--- a/crates/rpc/src/types/mod.rs
+++ b/crates/rpc/src/types/mod.rs
@@ -437,9 +437,9 @@ pub enum RpcDelegationStatus {
 pub(crate) enum RpcBlockOption {
     Range {
         /// The block number or tag this filter should start at.
-        from_block: BlockNumberOrTag,
+        from_block: Option<BlockNumberOrTag>,
         /// The block number that this filter should end at.
-        to_block: BlockNumberOrTag,
+        to_block: Option<BlockNumberOrTag>,
     },
     /// The hash of the block if the filter only targets a single block
     AtBlockHash(BlockHash),
@@ -452,8 +452,8 @@ impl From<RpcBlockOption> for FilterBlockOption {
                 from_block,
                 to_block,
             } => FilterBlockOption::Range {
-                from_block: Some(from_block),
-                to_block: Some(to_block),
+                from_block,
+                to_block,
             },
             RpcBlockOption::AtBlockHash(block_hash) => FilterBlockOption::AtBlockHash(block_hash),
         }
@@ -473,4 +473,48 @@ pub(crate) enum RpcBlockOptionOrTag {
     BlockHash(BlockHash),
     /// The block tag to use for this request
     BlockTag(BlockTag),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_option_deserializes_partial_ranges() {
+        let full: RpcBlockOption =
+            serde_json::from_str(r#"{"fromBlock": "0x64", "toBlock": "0xc8"}"#).unwrap();
+        assert!(matches!(
+            full,
+            RpcBlockOption::Range {
+                from_block: Some(BlockNumberOrTag::Number(100)),
+                to_block: Some(BlockNumberOrTag::Number(200)),
+            }
+        ));
+
+        // The documented range fields are optional; a one-sided range must deserialize.
+        let from_only: RpcBlockOption = serde_json::from_str(r#"{"fromBlock": "0x64"}"#).unwrap();
+        assert!(matches!(
+            from_only,
+            RpcBlockOption::Range {
+                from_block: Some(BlockNumberOrTag::Number(100)),
+                to_block: None,
+            }
+        ));
+
+        let to_only: RpcBlockOption = serde_json::from_str(r#"{"toBlock": "latest"}"#).unwrap();
+        assert!(matches!(
+            to_only,
+            RpcBlockOption::Range {
+                from_block: None,
+                to_block: Some(BlockNumberOrTag::Latest),
+            }
+        ));
+    }
+
+    #[test]
+    fn block_option_deserializes_block_hash() {
+        let hash = B256::repeat_byte(0xab);
+        let parsed: RpcBlockOption = serde_json::from_str(&format!("\"{hash}\"")).unwrap();
+        assert!(matches!(parsed, RpcBlockOption::AtBlockHash(h) if h == hash));
+    }
 }

--- a/crates/rpc/src/types/mod.rs
+++ b/crates/rpc/src/types/mod.rs
@@ -11,10 +11,11 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use alloy_primitives::{Address, B256, U64, U128, U256};
-use rundler_provider::{Log, TransactionReceipt};
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::{Address, B256, BlockHash, U64, U128, U256};
+use rundler_provider::{FilterBlockOption, Log, TransactionReceipt};
 use rundler_types::{
-    EntryPointVersion, UserOperationOptionalGas, UserOperationVariant,
+    BlockTag, EntryPointVersion, UserOperationOptionalGas, UserOperationVariant,
     chain::ChainSpec,
     pool::{PendingBundleInfo, PoolOperationStatus, Reputation},
 };
@@ -429,4 +430,47 @@ pub enum RpcDelegationStatus {
     },
     /// Delegation status is unknown.
     Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(untagged, rename_all_fields = "camelCase")]
+pub(crate) enum RpcBlockOption {
+    Range {
+        /// The block number or tag this filter should start at.
+        from_block: Option<BlockNumberOrTag>,
+        /// The block number that this filter should end at.
+        to_block: Option<BlockNumberOrTag>,
+    },
+    /// The hash of the block if the filter only targets a single block
+    AtBlockHash(BlockHash),
+}
+
+impl From<RpcBlockOption> for FilterBlockOption {
+    fn from(rpc: RpcBlockOption) -> FilterBlockOption {
+        match rpc {
+            RpcBlockOption::Range {
+                from_block,
+                to_block,
+            } => FilterBlockOption::Range {
+                from_block,
+                to_block,
+            },
+            RpcBlockOption::AtBlockHash(block_hash) => FilterBlockOption::AtBlockHash(block_hash),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(untagged, rename_all_fields = "camelCase")]
+pub(crate) enum RpcBlockOptionOrTag {
+    Range {
+        /// The block number or tag this filter should start at.
+        from_block: Option<BlockNumberOrTag>,
+        /// The block number that this filter should end at.
+        to_block: Option<BlockNumberOrTag>,
+    },
+    /// The hash of the block if the filter only targets a single block
+    BlockHash(BlockHash),
+    /// The block tag to use for this request
+    BlockTag(BlockTag),
 }

--- a/crates/rpc/src/types/mod.rs
+++ b/crates/rpc/src/types/mod.rs
@@ -437,9 +437,9 @@ pub enum RpcDelegationStatus {
 pub(crate) enum RpcBlockOption {
     Range {
         /// The block number or tag this filter should start at.
-        from_block: Option<BlockNumberOrTag>,
+        from_block: BlockNumberOrTag,
         /// The block number that this filter should end at.
-        to_block: Option<BlockNumberOrTag>,
+        to_block: BlockNumberOrTag,
     },
     /// The hash of the block if the filter only targets a single block
     AtBlockHash(BlockHash),
@@ -452,8 +452,8 @@ impl From<RpcBlockOption> for FilterBlockOption {
                 from_block,
                 to_block,
             } => FilterBlockOption::Range {
-                from_block,
-                to_block,
+                from_block: Some(from_block),
+                to_block: Some(to_block),
             },
             RpcBlockOption::AtBlockHash(block_hash) => FilterBlockOption::AtBlockHash(block_hash),
         }

--- a/crates/rpc/src/types/permissions.rs
+++ b/crates/rpc/src/types/permissions.rs
@@ -195,6 +195,7 @@ fn header_str<'a>(
 }
 
 fn parse_bool(name: &'static str, s: &str) -> Result<bool, PermissionsHeaderError> {
+    let s = s.trim();
     if s.eq_ignore_ascii_case("true") {
         Ok(true)
     } else if s.eq_ignore_ascii_case("false") {
@@ -215,6 +216,7 @@ fn parse_u64(name: &'static str, s: &str) -> Result<u64, PermissionsHeaderError>
 }
 
 fn parse_u256_hex(name: &'static str, s: &str) -> Result<U256, PermissionsHeaderError> {
+    let s = s.trim();
     let stripped = s
         .strip_prefix("0x")
         .or_else(|| s.strip_prefix("0X"))

--- a/crates/rpc/src/types/permissions.rs
+++ b/crates/rpc/src/types/permissions.rs
@@ -366,20 +366,6 @@ mod tests {
     }
 
     #[test]
-    fn case_insensitive_bool() {
-        let headers = headers_from(&[(headers::TRUSTED, "TRUE")]);
-        let perms = RpcPermissions::from_headers(&headers).unwrap().unwrap();
-        assert!(perms.trusted);
-    }
-
-    #[test]
-    fn malformed_int_is_rejected() {
-        let headers = headers_from(&[(headers::MAX_OPS_IN_POOL_FOR_SENDER, "not-a-number")]);
-        let err = RpcPermissions::from_headers(&headers).unwrap_err();
-        assert_eq!(err.header, headers::MAX_OPS_IN_POOL_FOR_SENDER);
-    }
-
-    #[test]
     fn malformed_bool_is_rejected() {
         let headers = headers_from(&[(headers::TRUSTED, "yes")]);
         let err = RpcPermissions::from_headers(&headers).unwrap_err();

--- a/crates/rpc/src/types/permissions.rs
+++ b/crates/rpc/src/types/permissions.rs
@@ -20,9 +20,9 @@ use serde::{Deserialize, Serialize};
 use crate::utils::{FromRpcType, IntoRundlerType};
 
 /// User operation permissions
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct RpcUserOperationPermissions {
+pub(crate) struct RpcPermissions {
     /// Whether the user operation is trusted, allowing the bundler to skip untrusted simulation
     #[serde(default)]
     pub(crate) trusted: bool,
@@ -41,6 +41,173 @@ pub(crate) struct RpcUserOperationPermissions {
     /// Disable EIP-7702
     #[serde(default)]
     pub(crate) eip7702_disabled: Option<bool>,
+    /// Override for the maximum block range used when looking up user operation events
+    #[serde(default)]
+    pub(crate) max_block_range: Option<U64>,
+}
+
+/// HTTP header names carrying per-request user operation permissions.
+///
+/// Header lookups are case-insensitive, so these are stored lowercased.
+pub(crate) mod headers {
+    /// Override for the maximum block range used when looking up user operation events.
+    pub(crate) const MAX_BLOCK_RANGE: &str = "x-rundler-max-block-range";
+    /// Whether the user operation is trusted.
+    pub(crate) const TRUSTED: &str = "x-rundler-trusted";
+    /// Maximum number of user operations allowed for a sender in the mempool.
+    pub(crate) const MAX_OPS_IN_POOL_FOR_SENDER: &str = "x-rundler-max-ops-in-pool-for-sender";
+    /// Allowed percentage of underpriced fees accepted into the pool.
+    pub(crate) const UNDERPRICED_ACCEPT_PCT: &str = "x-rundler-underpriced-accept-pct";
+    /// Allowed percentage of underpriced fees that is bundled.
+    pub(crate) const UNDERPRICED_BUNDLE_PCT: &str = "x-rundler-underpriced-bundle-pct";
+    /// Whether EIP-7702 is disabled.
+    pub(crate) const EIP7702_DISABLED: &str = "x-rundler-eip7702-disabled";
+    /// Maximum cost the bundler is willing to pay (U256, 0x-hex).
+    pub(crate) const SPONSORSHIP_MAX_COST: &str = "x-rundler-sponsorship-max-cost";
+    /// Unix timestamp (seconds) until which the sponsorship is valid.
+    pub(crate) const SPONSORSHIP_VALID_UNTIL: &str = "x-rundler-sponsorship-valid-until";
+}
+
+/// Error parsing a permissions HTTP header.
+#[derive(Debug, thiserror::Error)]
+#[error("invalid permissions header `{header}`: {reason}")]
+pub(crate) struct PermissionsHeaderError {
+    pub(crate) header: &'static str,
+    pub(crate) reason: String,
+}
+
+impl RpcPermissions {
+    /// The override for the maximum event-lookup block range, if any.
+    pub(crate) fn max_block_range(&self) -> Option<u64> {
+        self.max_block_range.map(|v| v.to())
+    }
+
+    /// Parse per-request permissions from HTTP headers.
+    ///
+    /// Every header is optional; absent headers leave their field at the default. Returns
+    /// `Ok(None)` when no permissions header is present at all (so the caller can fall back to
+    /// the legacy positional parameter), `Ok(Some(_))` when at least one is present, and `Err`
+    /// when a header is malformed or only one of the coupled sponsorship pair is supplied.
+    pub(crate) fn from_headers(
+        headers: &http::HeaderMap,
+    ) -> Result<Option<Self>, PermissionsHeaderError> {
+        let mut present = false;
+        let mut perms = RpcPermissions::default();
+
+        if let Some(s) = header_str(headers, headers::MAX_BLOCK_RANGE)? {
+            present = true;
+            perms.max_block_range = Some(U64::from(parse_u64(headers::MAX_BLOCK_RANGE, s)?));
+        }
+        if let Some(s) = header_str(headers, headers::TRUSTED)? {
+            present = true;
+            perms.trusted = parse_bool(headers::TRUSTED, s)?;
+        }
+        if let Some(s) = header_str(headers, headers::MAX_OPS_IN_POOL_FOR_SENDER)? {
+            present = true;
+            perms.max_allowed_in_pool_for_sender = Some(U64::from(parse_u64(
+                headers::MAX_OPS_IN_POOL_FOR_SENDER,
+                s,
+            )?));
+        }
+        if let Some(s) = header_str(headers, headers::UNDERPRICED_ACCEPT_PCT)? {
+            present = true;
+            perms.underpriced_accept_pct =
+                Some(U64::from(parse_u64(headers::UNDERPRICED_ACCEPT_PCT, s)?));
+        }
+        if let Some(s) = header_str(headers, headers::UNDERPRICED_BUNDLE_PCT)? {
+            present = true;
+            perms.underpriced_bundle_pct =
+                Some(U64::from(parse_u64(headers::UNDERPRICED_BUNDLE_PCT, s)?));
+        }
+        if let Some(s) = header_str(headers, headers::EIP7702_DISABLED)? {
+            present = true;
+            perms.eip7702_disabled = Some(parse_bool(headers::EIP7702_DISABLED, s)?);
+        }
+
+        // Sponsorship is a coupled pair: both or neither, never exactly one.
+        let max_cost = header_str(headers, headers::SPONSORSHIP_MAX_COST)?;
+        let valid_until = header_str(headers, headers::SPONSORSHIP_VALID_UNTIL)?;
+        match (max_cost, valid_until) {
+            (Some(mc), Some(vu)) => {
+                present = true;
+                perms.bundler_sponsorship = Some(RpcBundlerSponsorship {
+                    max_cost: parse_u256_hex(headers::SPONSORSHIP_MAX_COST, mc)?,
+                    valid_until: U64::from(parse_u64(headers::SPONSORSHIP_VALID_UNTIL, vu)?),
+                });
+            }
+            (None, None) => {}
+            (Some(_), None) => {
+                return Err(PermissionsHeaderError {
+                    header: headers::SPONSORSHIP_VALID_UNTIL,
+                    reason: format!(
+                        "must be set together with `{}`",
+                        headers::SPONSORSHIP_MAX_COST
+                    ),
+                });
+            }
+            (None, Some(_)) => {
+                return Err(PermissionsHeaderError {
+                    header: headers::SPONSORSHIP_MAX_COST,
+                    reason: format!(
+                        "must be set together with `{}`",
+                        headers::SPONSORSHIP_VALID_UNTIL
+                    ),
+                });
+            }
+        }
+
+        Ok(present.then_some(perms))
+    }
+}
+
+fn header_str<'a>(
+    headers: &'a http::HeaderMap,
+    name: &'static str,
+) -> Result<Option<&'a str>, PermissionsHeaderError> {
+    match headers.get(name) {
+        None => Ok(None),
+        Some(value) => value
+            .to_str()
+            .map(Some)
+            .map_err(|_| PermissionsHeaderError {
+                header: name,
+                reason: "value is not valid ASCII".to_string(),
+            }),
+    }
+}
+
+fn parse_bool(name: &'static str, s: &str) -> Result<bool, PermissionsHeaderError> {
+    if s.eq_ignore_ascii_case("true") {
+        Ok(true)
+    } else if s.eq_ignore_ascii_case("false") {
+        Ok(false)
+    } else {
+        Err(PermissionsHeaderError {
+            header: name,
+            reason: format!("expected `true` or `false`, got `{s}`"),
+        })
+    }
+}
+
+fn parse_u64(name: &'static str, s: &str) -> Result<u64, PermissionsHeaderError> {
+    s.trim().parse::<u64>().map_err(|e| PermissionsHeaderError {
+        header: name,
+        reason: format!("expected an unsigned integer: {e}"),
+    })
+}
+
+fn parse_u256_hex(name: &'static str, s: &str) -> Result<U256, PermissionsHeaderError> {
+    let stripped = s
+        .strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .ok_or_else(|| PermissionsHeaderError {
+            header: name,
+            reason: "expected a 0x-prefixed hex string".to_string(),
+        })?;
+    U256::from_str_radix(stripped, 16).map_err(|e| PermissionsHeaderError {
+        header: name,
+        reason: format!("invalid hex value: {e}"),
+    })
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -52,9 +219,9 @@ pub(crate) struct RpcBundlerSponsorship {
     pub(crate) valid_until: U64,
 }
 
-impl FromRpcType<RpcUserOperationPermissions> for UserOperationPermissions {
+impl FromRpcType<RpcPermissions> for UserOperationPermissions {
     fn from_rpc_type(
-        rpc: RpcUserOperationPermissions,
+        rpc: RpcPermissions,
         chain_spec: &ChainSpec,
         ep_version: EntryPointVersion,
     ) -> Self {
@@ -81,5 +248,116 @@ impl FromRpcType<RpcBundlerSponsorship> for BundlerSponsorship {
             max_cost: rpc.max_cost,
             valid_until: rpc.valid_until.to(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http::{HeaderMap, HeaderName, HeaderValue};
+
+    use super::*;
+
+    fn headers_from(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (name, value) in pairs {
+            map.insert(
+                HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                HeaderValue::from_str(value).unwrap(),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn no_headers_returns_none() {
+        let parsed = RpcPermissions::from_headers(&HeaderMap::new()).unwrap();
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn parses_all_scalar_headers() {
+        let headers = headers_from(&[
+            (headers::MAX_BLOCK_RANGE, "1000"),
+            (headers::TRUSTED, "true"),
+            (headers::MAX_OPS_IN_POOL_FOR_SENDER, "4"),
+            (headers::UNDERPRICED_ACCEPT_PCT, "10"),
+            (headers::UNDERPRICED_BUNDLE_PCT, "20"),
+            (headers::EIP7702_DISABLED, "false"),
+        ]);
+
+        let perms = RpcPermissions::from_headers(&headers)
+            .unwrap()
+            .expect("at least one header present");
+
+        assert_eq!(perms.max_block_range, Some(U64::from(1000)));
+        assert!(perms.trusted);
+        assert_eq!(perms.max_allowed_in_pool_for_sender, Some(U64::from(4)));
+        assert_eq!(perms.underpriced_accept_pct, Some(U64::from(10)));
+        assert_eq!(perms.underpriced_bundle_pct, Some(U64::from(20)));
+        assert_eq!(perms.eip7702_disabled, Some(false));
+        assert!(perms.bundler_sponsorship.is_none());
+    }
+
+    #[test]
+    fn parses_sponsorship_pair() {
+        let headers = headers_from(&[
+            (headers::SPONSORSHIP_MAX_COST, "0x1bc16d674ec80000"),
+            (headers::SPONSORSHIP_VALID_UNTIL, "1893456000"),
+        ]);
+
+        let perms = RpcPermissions::from_headers(&headers)
+            .unwrap()
+            .expect("sponsorship present");
+        let sponsorship = perms.bundler_sponsorship.expect("sponsorship parsed");
+        assert_eq!(
+            sponsorship.max_cost,
+            U256::from(2_000_000_000_000_000_000u64)
+        );
+        assert_eq!(sponsorship.valid_until, U64::from(1_893_456_000u64));
+    }
+
+    #[test]
+    fn case_insensitive_bool() {
+        let headers = headers_from(&[(headers::TRUSTED, "TRUE")]);
+        let perms = RpcPermissions::from_headers(&headers).unwrap().unwrap();
+        assert!(perms.trusted);
+    }
+
+    #[test]
+    fn malformed_int_is_rejected() {
+        let headers = headers_from(&[(headers::MAX_BLOCK_RANGE, "not-a-number")]);
+        let err = RpcPermissions::from_headers(&headers).unwrap_err();
+        assert_eq!(err.header, headers::MAX_BLOCK_RANGE);
+    }
+
+    #[test]
+    fn malformed_bool_is_rejected() {
+        let headers = headers_from(&[(headers::TRUSTED, "yes")]);
+        let err = RpcPermissions::from_headers(&headers).unwrap_err();
+        assert_eq!(err.header, headers::TRUSTED);
+    }
+
+    #[test]
+    fn max_cost_requires_hex_prefix() {
+        let headers = headers_from(&[
+            (headers::SPONSORSHIP_MAX_COST, "1000"),
+            (headers::SPONSORSHIP_VALID_UNTIL, "10"),
+        ]);
+        let err = RpcPermissions::from_headers(&headers).unwrap_err();
+        assert_eq!(err.header, headers::SPONSORSHIP_MAX_COST);
+    }
+
+    #[test]
+    fn half_set_sponsorship_max_cost_only_is_rejected() {
+        let headers = headers_from(&[(headers::SPONSORSHIP_MAX_COST, "0x10")]);
+        let err = RpcPermissions::from_headers(&headers).unwrap_err();
+        assert_eq!(err.header, headers::SPONSORSHIP_VALID_UNTIL);
+    }
+
+    #[test]
+    fn half_set_sponsorship_valid_until_only_is_rejected() {
+        let headers = headers_from(&[(headers::SPONSORSHIP_VALID_UNTIL, "10")]);
+        let err = RpcPermissions::from_headers(&headers).unwrap_err();
+        assert_eq!(err.header, headers::SPONSORSHIP_MAX_COST);
     }
 }

--- a/crates/rpc/src/types/permissions.rs
+++ b/crates/rpc/src/types/permissions.rs
@@ -41,9 +41,27 @@ pub(crate) struct RpcPermissions {
     /// Disable EIP-7702
     #[serde(default)]
     pub(crate) eip7702_disabled: Option<bool>,
-    /// Override for the maximum block range used when looking up user operation events
-    #[serde(default)]
-    pub(crate) max_block_range: Option<U64>,
+}
+
+/// Per-request override for the maximum block range used when looking up user operation
+/// events, parsed from the [`headers::MAX_BLOCK_RANGE`] header.
+///
+/// Deliberately separate from [`RpcPermissions`]: this is lookup configuration, not a user
+/// operation permission, and its presence must not affect the header-vs-positional
+/// permissions precedence on `eth_sendUserOperation`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MaxBlockRange(pub(crate) u64);
+
+impl MaxBlockRange {
+    /// Parse the max block range override from HTTP headers, if present.
+    pub(crate) fn from_headers(
+        headers: &http::HeaderMap,
+    ) -> Result<Option<Self>, PermissionsHeaderError> {
+        Ok(header_str(headers, headers::MAX_BLOCK_RANGE)?
+            .map(|s| parse_u64(headers::MAX_BLOCK_RANGE, s))
+            .transpose()?
+            .map(MaxBlockRange))
+    }
 }
 
 /// HTTP header names carrying per-request user operation permissions.
@@ -77,11 +95,6 @@ pub(crate) struct PermissionsHeaderError {
 }
 
 impl RpcPermissions {
-    /// The override for the maximum event-lookup block range, if any.
-    pub(crate) fn max_block_range(&self) -> Option<u64> {
-        self.max_block_range.map(|v| v.to())
-    }
-
     /// Parse per-request permissions from HTTP headers.
     ///
     /// Every header is optional; absent headers leave their field at the default. Returns
@@ -94,10 +107,6 @@ impl RpcPermissions {
         let mut present = false;
         let mut perms = RpcPermissions::default();
 
-        if let Some(s) = header_str(headers, headers::MAX_BLOCK_RANGE)? {
-            present = true;
-            perms.max_block_range = Some(U64::from(parse_u64(headers::MAX_BLOCK_RANGE, s)?));
-        }
         if let Some(s) = header_str(headers, headers::TRUSTED)? {
             present = true;
             perms.trusted = parse_bool(headers::TRUSTED, s)?;
@@ -164,16 +173,25 @@ fn header_str<'a>(
     headers: &'a http::HeaderMap,
     name: &'static str,
 ) -> Result<Option<&'a str>, PermissionsHeaderError> {
-    match headers.get(name) {
-        None => Ok(None),
-        Some(value) => value
-            .to_str()
-            .map(Some)
-            .map_err(|_| PermissionsHeaderError {
-                header: name,
-                reason: "value is not valid ASCII".to_string(),
-            }),
+    let mut values = headers.get_all(name).iter();
+    let Some(value) = values.next() else {
+        return Ok(None);
+    };
+    // Fail closed on ambiguity: these headers carry policy, so a smuggled or
+    // proxy-appended duplicate must not be silently first-wins.
+    if values.next().is_some() {
+        return Err(PermissionsHeaderError {
+            header: name,
+            reason: "header supplied more than once".to_string(),
+        });
     }
+    value
+        .to_str()
+        .map(Some)
+        .map_err(|_| PermissionsHeaderError {
+            header: name,
+            reason: "value is not valid ASCII".to_string(),
+        })
 }
 
 fn parse_bool(name: &'static str, s: &str) -> Result<bool, PermissionsHeaderError> {
@@ -277,7 +295,6 @@ mod tests {
     #[test]
     fn parses_all_scalar_headers() {
         let headers = headers_from(&[
-            (headers::MAX_BLOCK_RANGE, "1000"),
             (headers::TRUSTED, "true"),
             (headers::MAX_OPS_IN_POOL_FOR_SENDER, "4"),
             (headers::UNDERPRICED_ACCEPT_PCT, "10"),
@@ -289,13 +306,43 @@ mod tests {
             .unwrap()
             .expect("at least one header present");
 
-        assert_eq!(perms.max_block_range, Some(U64::from(1000)));
         assert!(perms.trusted);
         assert_eq!(perms.max_allowed_in_pool_for_sender, Some(U64::from(4)));
         assert_eq!(perms.underpriced_accept_pct, Some(U64::from(10)));
         assert_eq!(perms.underpriced_bundle_pct, Some(U64::from(20)));
         assert_eq!(perms.eip7702_disabled, Some(false));
         assert!(perms.bundler_sponsorship.is_none());
+    }
+
+    #[test]
+    fn max_block_range_is_independent_of_permissions() {
+        let headers = headers_from(&[(headers::MAX_BLOCK_RANGE, "1000")]);
+
+        let range = MaxBlockRange::from_headers(&headers)
+            .unwrap()
+            .expect("range header present");
+        assert_eq!(range.0, 1000);
+
+        // The lookup-scoped header must not count as "permissions present", otherwise a
+        // gateway attaching it would wipe out positional permissions on sends.
+        assert!(RpcPermissions::from_headers(&headers).unwrap().is_none());
+    }
+
+    #[test]
+    fn malformed_max_block_range_is_rejected() {
+        let headers = headers_from(&[(headers::MAX_BLOCK_RANGE, "not-a-number")]);
+        let err = MaxBlockRange::from_headers(&headers).unwrap_err();
+        assert_eq!(err.header, headers::MAX_BLOCK_RANGE);
+    }
+
+    #[test]
+    fn duplicate_header_is_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.append(headers::TRUSTED, HeaderValue::from_static("true"));
+        headers.append(headers::TRUSTED, HeaderValue::from_static("false"));
+
+        let err = RpcPermissions::from_headers(&headers).unwrap_err();
+        assert_eq!(err.header, headers::TRUSTED);
     }
 
     #[test]
@@ -325,9 +372,9 @@ mod tests {
 
     #[test]
     fn malformed_int_is_rejected() {
-        let headers = headers_from(&[(headers::MAX_BLOCK_RANGE, "not-a-number")]);
+        let headers = headers_from(&[(headers::MAX_OPS_IN_POOL_FOR_SENDER, "not-a-number")]);
         let err = RpcPermissions::from_headers(&headers).unwrap_err();
-        assert_eq!(err.header, headers::MAX_BLOCK_RANGE);
+        assert_eq!(err.header, headers::MAX_OPS_IN_POOL_FOR_SENDER);
     }
 
     #[test]

--- a/docs/architecture/aggregators.md
+++ b/docs/architecture/aggregators.md
@@ -104,4 +104,4 @@ NOTE: This is implemented mostly as a POC of aggregation in Rundler. Due to the 
 
 ### [PBH](../../crates/aggregators/pbh/)
 
-The PBH aggregator has support for the World Chain Priority Blockspace for Humans signature aggregator. More info can be found [here](https://github.com/worldcoin/world-chain/tree/main/contracts).
+The PBH aggregator has support for the World Chain Priority Blockspace for Humans signature aggregator. More info can be found [here](https://github.com/worldcoin/world-chain/tree/main/pkg/contracts).

--- a/docs/architecture/rpc.md
+++ b/docs/architecture/rpc.md
@@ -52,6 +52,33 @@ The parameter is one of:
 
 NOTE: when a block option is supplied, the `--user_operation_event_block_distance_fallback` retry behavior is disabled and the supplied option is used as-is.
 
+#### Per-request permissions (HTTP headers)
+
+When Rundler runs behind a trusted gateway, per-request policy can be supplied via discrete HTTP headers instead of (or in addition to) the legacy positional `permissions` parameter on `eth_sendUserOperation`. The headers are parsed by a transport-level middleware and delivered to the RPC handlers, so they apply across the relevant methods without changing any method's JSON-RPC parameters.
+
+Headers are **only honored when permissions are enabled** (`--rpc.permissions_enabled`) — the same trust assumption as the positional parameter. When permissions are disabled the headers are ignored entirely.
+
+| Header                                 | Type               | Field                            |
+| -------------------------------------- | ------------------ | -------------------------------- |
+| `X-Rundler-Max-Block-Range`            | int                | `maxBlockRange`                  |
+| `X-Rundler-Trusted`                    | `true`/`false`     | `trusted`                        |
+| `X-Rundler-Max-Ops-In-Pool-For-Sender` | int                | `maxAllowedInPoolForSender`      |
+| `X-Rundler-Underpriced-Accept-Pct`     | int (0–100)        | `underpricedAcceptPct`           |
+| `X-Rundler-Underpriced-Bundle-Pct`     | int (0–100)        | `underpricedBundlePct`           |
+| `X-Rundler-Eip7702-Disabled`           | `true`/`false`     | `eip7702Disabled`                |
+| `X-Rundler-Sponsorship-Max-Cost`       | U256, `0x`-hex     | `bundlerSponsorship.maxCost`     |
+| `X-Rundler-Sponsorship-Valid-Until`    | int (unix seconds) | `bundlerSponsorship.validUntil`  |
+
+Parsing rules:
+
+- Every header is optional; an absent header leaves its field at the default.
+- A malformed value fails the request closed with `400 Bad Request` — a bad policy header must never silently fall through to defaults.
+- The sponsorship pair (`X-Rundler-Sponsorship-Max-Cost` and `X-Rundler-Sponsorship-Valid-Until`) is coupled: supply both or neither. Supplying exactly one is rejected with `400`.
+
+`X-Rundler-Max-Block-Range` overrides `--user_operation_event_block_distance` for the event lookup on `eth_getUserOperationByHash`, `eth_getUserOperationReceipt`, and `rundler_getUserOperationStatus`.
+
+On `eth_sendUserOperation`, when both the headers and the positional `permissions` parameter are present, **the headers take precedence**. The positional parameter remains supported for backwards compatibility and is deprecated in favor of the headers.
+
 ### `debug_` Namespace
 
 Method defined by the [ERC-7769 spec](https://eips.ethereum.org/EIPS/eip-7769#rpc-methods-debug-namespace). Used only for debugging/testing and should be disabled on production APIs.

--- a/docs/architecture/rpc.md
+++ b/docs/architecture/rpc.md
@@ -26,6 +26,32 @@ Methods defined by the [ERC-7769 spec](https://eips.ethereum.org/EIPS/eip-7769#r
 | `eth_getUserOperationByHash`   |    ✅     |
 | `eth_getUserOperationReceipt`  |    ✅     |
 
+#### Block Option Parameter
+
+`eth_getUserOperationByHash` and `eth_getUserOperationReceipt` locate user operations by searching for the `UserOperationEvent` log via `eth_getLogs`. By default the search covers the last `--user_operation_event_block_distance` blocks (all blocks if unset). Both methods accept a non-standard optional 2nd positional parameter to scope this search. This is useful when the caller already knows where the operation was mined, or needs to search outside the default window.
+
+The parameter is one of:
+
+- A block range object: `{ fromBlock, toBlock }`, where each field is an optional block number or tag.
+- A block hash: only the given block is searched.
+
+```
+# Request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "eth_getUserOperationByHash",
+  "params": [
+    "0x...", // user operation hash
+    { "fromBlock": "0x64", "toBlock": "0xc8" } // optional, block range or block hash
+  ]
+}
+```
+
+`eth_getUserOperationReceipt` additionally accepts a block tag for this parameter: `"LATEST"` (default) or `"PENDING"`. On networks that support preconfirmations, `"PENDING"` allows the receipt of a preconfirmed user operation to be returned before it lands onchain.
+
+NOTE: when a block option is supplied, the `--user_operation_event_block_distance_fallback` retry behavior is disabled and the supplied option is used as-is.
+
 ### `debug_` Namespace
 
 Method defined by the [ERC-7769 spec](https://eips.ethereum.org/EIPS/eip-7769#rpc-methods-debug-namespace). Used only for debugging/testing and should be disabled on production APIs.
@@ -306,6 +332,8 @@ NOTE: The returned user operation receipt is slightly different than the receipt
 
 Gets the status of a user operation by hash. Intended for use cases where the user wants a single RPC call to retrieve the status of a user operation, as well as its receipt if that user operation is mined.
 
+Accepts an optional 2nd positional parameter to scope the search for the mined user operation event: a block range object or block hash, as described in [Block Option Parameter](#block-option-parameter) (block tags are not supported here).
+
 Possible statuses:
 
 - "unknown": the user operation is not mined or pending in the mempool.
@@ -338,6 +366,7 @@ The `pendingBundle` object contains:
   "method": "rundler_getUserOperationStatus",
   "params": [
     "0x...", // user operation hash
+    { "fromBlock": "0x64", "toBlock": "0xc8" } // optional, block range or block hash
   ]
 }
 

--- a/docs/architecture/rpc.md
+++ b/docs/architecture/rpc.md
@@ -32,8 +32,8 @@ Methods defined by the [ERC-7769 spec](https://eips.ethereum.org/EIPS/eip-7769#r
 
 The parameter is one of:
 
-- A block range object: `{ fromBlock, toBlock }`, where each field is an optional block number or tag. When the node enforces a maximum event block range (`--user_operation_event_block_distance`, or a per-request `X-Rundler-Max-Block-Range` override), both fields are required so the range can be validated, and a range wider than the maximum is rejected with an invalid params error (`-32602`).
-- A block hash: only the given block is searched.
+- A block range object: `{ fromBlock, toBlock }`, where each field is an optional block number or tag. Unknown fields in the object are rejected. When the node enforces a maximum event block range (`--user_operation_event_block_distance`, or a per-request `X-Rundler-Max-Block-Range` override), both fields are required so the range can be validated. A range wider than the maximum, or with `fromBlock` greater than `toBlock`, is rejected with an invalid params error (`-32602`).
+- A block hash (as a string): only the given block is searched.
 
 ```
 # Request
@@ -60,7 +60,7 @@ Headers are **only honored when permissions are enabled** (`--rpc.permissions_en
 
 | Header                                 | Type               | Field                            |
 | -------------------------------------- | ------------------ | -------------------------------- |
-| `X-Rundler-Max-Block-Range`            | int                | `maxBlockRange`                  |
+| `X-Rundler-Max-Block-Range`            | int                | — (header only, see below)       |
 | `X-Rundler-Trusted`                    | `true`/`false`     | `trusted`                        |
 | `X-Rundler-Max-Ops-In-Pool-For-Sender` | int                | `maxAllowedInPoolForSender`      |
 | `X-Rundler-Underpriced-Accept-Pct`     | int (0–100)        | `underpricedAcceptPct`           |
@@ -73,11 +73,12 @@ Parsing rules:
 
 - Every header is optional; an absent header leaves its field at the default.
 - A malformed value fails the request closed with `400 Bad Request` — a bad policy header must never silently fall through to defaults.
+- Supplying the same header more than once is ambiguous and is rejected with `400`.
 - The sponsorship pair (`X-Rundler-Sponsorship-Max-Cost` and `X-Rundler-Sponsorship-Valid-Until`) is coupled: supply both or neither. Supplying exactly one is rejected with `400`.
 
-`X-Rundler-Max-Block-Range` overrides `--user_operation_event_block_distance` for the event lookup on `eth_getUserOperationByHash`, `eth_getUserOperationReceipt`, and `rundler_getUserOperationStatus`.
+`X-Rundler-Max-Block-Range` overrides `--user_operation_event_block_distance` for the event lookup on `eth_getUserOperationByHash`, `eth_getUserOperationReceipt`, and `rundler_getUserOperationStatus`. It is lookup configuration, not a user operation permission: it has no counterpart in the positional `permissions` parameter and never affects `eth_sendUserOperation`.
 
-On `eth_sendUserOperation`, when both the headers and the positional `permissions` parameter are present, **the headers take precedence**. The positional parameter remains supported for backwards compatibility and is deprecated in favor of the headers.
+On `eth_sendUserOperation`, when both the permission headers and the positional `permissions` parameter are present, **the headers take precedence** (`X-Rundler-Max-Block-Range` does not count as a permission header for this purpose). The positional parameter remains supported for backwards compatibility and is deprecated in favor of the headers.
 
 ### `debug_` Namespace
 

--- a/docs/architecture/rpc.md
+++ b/docs/architecture/rpc.md
@@ -50,6 +50,8 @@ The parameter is one of:
 
 `eth_getUserOperationReceipt` additionally accepts a block tag for this parameter: `"LATEST"` (default) or `"PENDING"`, also accepted in lowercase (but not mixed case). On networks that support preconfirmations, `"PENDING"` allows the receipt of a preconfirmed user operation to be returned before it lands onchain.
 
+An empty range object `{}` is treated exactly as if the parameter was omitted. If only one bound is supplied and no maximum block range is enforced, the missing bound is left to the node's `eth_getLogs` default (typically `latest`).
+
 NOTE: when a block option is supplied, the `--user_operation_event_block_distance_fallback` retry behavior is disabled and the supplied option is used as-is.
 
 #### Per-request permissions (HTTP headers)
@@ -76,7 +78,7 @@ Parsing rules:
 - Supplying the same header more than once is ambiguous and is rejected with `400`.
 - The sponsorship pair (`X-Rundler-Sponsorship-Max-Cost` and `X-Rundler-Sponsorship-Valid-Until`) is coupled: supply both or neither. Supplying exactly one is rejected with `400`.
 
-`X-Rundler-Max-Block-Range` overrides `--user_operation_event_block_distance` for the event lookup on `eth_getUserOperationByHash`, `eth_getUserOperationReceipt`, and `rundler_getUserOperationStatus`. It is lookup configuration, not a user operation permission: it has no counterpart in the positional `permissions` parameter and never affects `eth_sendUserOperation`.
+`X-Rundler-Max-Block-Range` overrides `--user_operation_event_block_distance` for the event lookup on `eth_getUserOperationByHash`, `eth_getUserOperationReceipt`, and `rundler_getUserOperationStatus`, and also caps the `--user_operation_event_block_distance_fallback` retry window. It is lookup configuration, not a user operation permission: it has no counterpart in the positional `permissions` parameter and never affects `eth_sendUserOperation`.
 
 On `eth_sendUserOperation`, when both the permission headers and the positional `permissions` parameter are present, **the headers take precedence** (`X-Rundler-Max-Block-Range` does not count as a permission header for this purpose). The positional parameter remains supported for backwards compatibility and is deprecated in favor of the headers.
 

--- a/docs/architecture/rpc.md
+++ b/docs/architecture/rpc.md
@@ -32,7 +32,7 @@ Methods defined by the [ERC-7769 spec](https://eips.ethereum.org/EIPS/eip-7769#r
 
 The parameter is one of:
 
-- A block range object: `{ fromBlock, toBlock }`, where each field is an optional block number or tag. Unknown fields in the object are rejected. When the node enforces a maximum event block range (`--user_operation_event_block_distance`, or a per-request `X-Rundler-Max-Block-Range` override), both fields are required so the range can be validated. A range wider than the maximum, or with `fromBlock` greater than `toBlock`, is rejected with an invalid params error (`-32602`).
+- A block range object: `{ fromBlock, toBlock }`, where each field is an optional string containing either a hex-encoded block number (`0x`-quantity, e.g. `"0x64"` — decimal JSON numbers are rejected) or a block tag (`"latest"`, `"earliest"`, `"pending"`, `"safe"`, `"finalized"`; case-insensitive). Unknown fields in the object are rejected. When the node enforces a maximum event block range (`--user_operation_event_block_distance`, or a per-request `X-Rundler-Max-Block-Range` override), both fields are required so the range can be validated. A range wider than the maximum, or with `fromBlock` greater than `toBlock`, is rejected with an invalid params error (`-32602`).
 - A block hash (as a string): only the given block is searched.
 
 ```
@@ -48,7 +48,7 @@ The parameter is one of:
 }
 ```
 
-`eth_getUserOperationReceipt` additionally accepts a block tag for this parameter: `"LATEST"` (default) or `"PENDING"`. On networks that support preconfirmations, `"PENDING"` allows the receipt of a preconfirmed user operation to be returned before it lands onchain.
+`eth_getUserOperationReceipt` additionally accepts a block tag for this parameter: `"LATEST"` (default) or `"PENDING"`, also accepted in lowercase (but not mixed case). On networks that support preconfirmations, `"PENDING"` allows the receipt of a preconfirmed user operation to be returned before it lands onchain.
 
 NOTE: when a block option is supplied, the `--user_operation_event_block_distance_fallback` retry behavior is disabled and the supplied option is used as-is.
 
@@ -619,6 +619,8 @@ Currently, it simply queries each the `Pool` and the `Builder` servers to check 
 ## User Operation Permissions
 
 Rundler supports a non-standard 3rd positional parameter on `eth_sendUserOperation` to enabled special permissions on a per-user operation basis. If `rpc.permissions_enabled` is set, these permissions will be sent to the mempool. If disabled, the permissions will be ignored.
+
+NOTE: this positional parameter is deprecated in favor of the [per-request permission headers](#per-request-permissions-http-headers), which carry the same fields. When both are supplied, the headers take precedence.
 
 These permissions are meant to be used only by trusted connections. For example, an internal proxy that has a trusted relationship with a sender can tag that user operation as `trusted` and skip complex untrusted simulation.
 

--- a/docs/architecture/rpc.md
+++ b/docs/architecture/rpc.md
@@ -32,7 +32,7 @@ Methods defined by the [ERC-7769 spec](https://eips.ethereum.org/EIPS/eip-7769#r
 
 The parameter is one of:
 
-- A block range object: `{ fromBlock, toBlock }`, where each field is an optional block number or tag.
+- A block range object: `{ fromBlock, toBlock }`, where each field is an optional block number or tag. When the node enforces a maximum event block range (`--user_operation_event_block_distance`, or a per-request `X-Rundler-Max-Block-Range` override), both fields are required so the range can be validated, and a range wider than the maximum is rejected with an invalid params error (`-32602`).
 - A block hash: only the given block is searched.
 
 ```


### PR DESCRIPTION
## Summary

Adds a non-standard optional positional parameter to `eth_getUserOperationByHash`, `eth_getUserOperationReceipt`, and `rundler_getUserOperationStatus` that scopes the `eth_getLogs` search for the `UserOperationEvent` to a caller-supplied block range (`{fromBlock, toBlock}`) or block hash.

This is useful when the caller already knows where the operation was mined (cheaper, targeted `getLogs`) or needs to look up operations older than the configured `user_operation_event_block_distance` window.

## Behavior

- **Omitted**: unchanged — search covers the last `user_operation_event_block_distance` blocks (all blocks if unset), with the existing fallback retry.
- **Supplied**: the block option is used as-is for the `getLogs` filter, and the `user_operation_event_block_distance_fallback` retry is disabled so caller-supplied ranges are never silently rewritten.
- `eth_getUserOperationReceipt` remains backwards compatible with its existing `LATEST`/`PENDING` block tag parameter via an untagged union (`RpcBlockOptionOrTag`).

## Notes

- Wire format uses `rename_all_fields = "camelCase"` so clients send standard `fromBlock`/`toBlock` fields.
- Added a unit test in the existing `api.rs` test module verifying the caller's block option reaches the `getLogs` filter (both range and block-hash variants) and that the latest-block lookup is skipped.
- Documented the new parameter in `docs/architecture/rpc.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Compatibility notes

- Adding a positional parameter means values in that slot are now parsed instead of ignored: a client that previously sent a surplus 2nd positional param to `eth_getUserOperationByHash` or `rundler_getUserOperationStatus` (previously silently dropped by jsonrpsee) will now either get `-32602` for unparseable values, or — if the value happens to parse (e.g. a 32-byte hex string is a valid block hash) — have it interpreted as a block option that scopes the search. This is inherent to adding any trailing parameter and matches the precedent of the existing `permissions`/`state_override` params.
- Everything else is verified unchanged for existing clients: the legacy `eth_getUserOperationReceipt` tag shapes (`"LATEST"`/`"latest"`/`"PENDING"`/`"pending"`/`null`/omitted, positional and named), the positional `permissions` wire format, the default search window and fallback retry, and full header inertness when `--rpc.permissions_enabled` is off.
