### PR TITLE
fix(sim): correct [OP-012] GAS opcode matching to exact call opcodes

### DIFF
--- a/crates/sim/tracer/src/validationTracerV0_7.ts
+++ b/crates/sim/tracer/src/validationTracerV0_7.ts
@@ -152,6 +152,7 @@ interface BundlerCollectorTracer extends LogTracer<BundlerTracerResult>, Bundler
  *  slots: accessed slots (on any address)
  */
 ((): BundlerCollectorTracer => {
+  const CALL_OPCODES = new Set(['CALL', 'CALLCODE', 'DELEGATECALL', 'STATICCALL'])
   return {
     callsFromEntryPoint: [],
     currentLevel: null as any,
@@ -362,7 +363,7 @@ interface BundlerCollectorTracer extends LogTracer<BundlerTracerResult>, Bundler
       }
 
       // [OP-012]
-      if (this.lastOp === 'GAS' && !opcode.includes('CALL')) {
+      if (this.lastOp === 'GAS' && !CALL_OPCODES.has(opcode)) {
         // count "GAS" opcode only if not followed by "CALL"
         this.countSlot(this.currentLevel.opcodes, 'GAS')
       }


### PR DESCRIPTION
## Summary

Fixes a correctness bug in the ERC-7562 **[OP-012]** validation rule in the v0.7 validation tracer (`crates/sim/tracer/src/validationTracerV0_7.ts`).

The rule should count a `GAS` opcode **unless** it is immediately followed by an actual call opcode — `CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL`. The previous guard used substring matching:

```js
if (this.lastOp === 'GAS' && !opcode.includes('CALL')) { ... }
```

`opcode.includes('CALL')` also matches `CALLER`, `CALLVALUE`, and `CALLDATALOAD`/`CALLDATASIZE`/`CALLDATACOPY`, so a `GAS` immediately followed by any of those was **wrongly exempted** from the opcode count — an over-permissive validation.

This change matches against an exact `Set` of the four real call opcodes instead. The set is allocated **once per trace** in the IIFE preamble rather than once per opcode in the `step()` hot loop.

## Verification

- `yarn typecheck` (repo tsconfig) — passes
- `yarn build` (swc) — succeeds; minified output confirms the `Set` is hoisted out of `step()`
- Runtime support: the JS tracer engines that consume the embedded script (goja / boa) both support `Set`

🤖 Generated with [Claude Code](https://claude.com/claude-code)