### PR TITLE
fix(provider): decode handleOps reverts with missing error data

### DIFF
--- a/crates/builder/src/bundle_proposer.rs
+++ b/crates/builder/src/bundle_proposer.rs
@@ -459,7 +459,9 @@ where
             EntryPointAbiVersion::V0_6 => {
                 decode_v0_6_handle_ops_revert(revert_message, &Some(revert_data.clone()))
             }
-            EntryPointAbiVersion::V0_7 => decode_v0_7_handle_ops_revert(&Some(revert_data.clone())),
+            EntryPointAbiVersion::V0_7 => {
+                decode_v0_7_handle_ops_revert(revert_message, &Some(revert_data.clone()))
+            }
         };
         warn!("Onchain revert data for {tx_hash:?}: {revert_data:?}");
         warn!("decoded handle ops out: {handle_ops_out:?}");

--- a/crates/provider/src/alloy/entry_point/v0_6.rs
+++ b/crates/provider/src/alloy/entry_point/v0_6.rs
@@ -680,6 +680,8 @@ pub fn decode_handle_ops_revert(
         // See https://github.com/eth-infinitism/account-abstraction/pull/325 for more details.
         // NOTE: this error message is copied directly from Geth and assumes it will not change.
         Some(HandleOpsOut::PostOpRevert)
+    } else if message.contains("revert") {
+        Some(HandleOpsOut::Revert(Bytes::new()))
     } else {
         None
     }
@@ -774,5 +776,23 @@ mod tests {
             &None,
         );
         assert_eq!(result, Some(HandleOpsOut::PostOpRevert));
+    }
+
+    #[test]
+    fn test_decode_handle_ops_revert_empty_revert_missing_data() {
+        let result = EntryPointProvider::<RootProvider<AnyNetwork>, ZeroDAGasOracle>::decode_handle_ops_revert(
+            "execution reverted",
+            &None,
+        );
+        assert_eq!(result, Some(HandleOpsOut::Revert(Bytes::new())));
+    }
+
+    #[test]
+    fn test_decode_handle_ops_revert_non_revert_error() {
+        let result = EntryPointProvider::<RootProvider<AnyNetwork>, ZeroDAGasOracle>::decode_handle_ops_revert(
+            "out of gas",
+            &None,
+        );
+        assert_eq!(result, None);
     }
 }

--- a/crates/provider/src/alloy/entry_point/v0_7.rs
+++ b/crates/provider/src/alloy/entry_point/v0_7.rs
@@ -381,10 +381,10 @@ where
     }
 
     fn decode_handle_ops_revert(
-        _message: &str,
+        message: &str,
         revert_data: &Option<Bytes>,
     ) -> Option<HandleOpsOut> {
-        decode_handle_ops_revert(revert_data)
+        decode_handle_ops_revert(message, revert_data)
     }
 
     fn decode_ops_from_calldata(
@@ -766,9 +766,14 @@ pub fn decode_ops_from_calldata(
 }
 
 /// Decode the revert data from a call to `handleOps` for v0.7+
-pub fn decode_handle_ops_revert(revert_data: &Option<Bytes>) -> Option<HandleOpsOut> {
+pub fn decode_handle_ops_revert(
+    message: &str,
+    revert_data: &Option<Bytes>,
+) -> Option<HandleOpsOut> {
     let Some(revert_data) = revert_data else {
-        return None;
+        return message
+            .contains("revert")
+            .then(|| HandleOpsOut::Revert(Bytes::new()));
     };
 
     if let Ok(err) = IEntryPointErrors::abi_decode(revert_data) {
@@ -899,5 +904,62 @@ fn add_authorization_tuple(
 ) {
     if let Some(authorization) = authorization {
         authorization_utils::apply_7702_overrides(state_override, sender, authorization.address);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_handle_ops_revert_failed_op() {
+        let err = IEntryPointErrors::FailedOp(FailedOp {
+            opIndex: U256::from(2),
+            reason: "AA25 invalid account nonce".to_string(),
+        });
+        let revert_data = Some(Bytes::from(err.abi_encode()));
+
+        assert_eq!(
+            decode_handle_ops_revert("execution reverted", &revert_data),
+            Some(HandleOpsOut::FailedOp(
+                2,
+                "AA25 invalid account nonce".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_decode_handle_ops_revert_unknown_data() {
+        let revert_data = Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]);
+
+        assert_eq!(
+            decode_handle_ops_revert("execution reverted", &Some(revert_data.clone())),
+            Some(HandleOpsOut::Revert(revert_data))
+        );
+    }
+
+    #[test]
+    fn test_decode_handle_ops_revert_empty_revert_missing_data() {
+        assert_eq!(
+            decode_handle_ops_revert("execution reverted", &None),
+            Some(HandleOpsOut::Revert(Bytes::new()))
+        );
+    }
+
+    #[test]
+    fn test_decode_handle_ops_revert_empty_revert_empty_data() {
+        assert_eq!(
+            decode_handle_ops_revert("execution reverted", &Some(Bytes::new())),
+            Some(HandleOpsOut::Revert(Bytes::new()))
+        );
+    }
+
+    #[test]
+    fn test_decode_handle_ops_revert_non_revert_error() {
+        assert_eq!(decode_handle_ops_revert("out of gas", &None), None);
+        assert_eq!(
+            decode_handle_ops_revert("insufficient funds for gas * price + value", &None),
+            None
+        );
     }
 }


### PR DESCRIPTION
## Proposed Changes

- Handle `eth_call` revert errors whose JSON-RPC error omits the `data` field. Some nodes (e.g. reth) omit `data` entirely when a revert has empty output; `decode_handle_ops_revert` returned `None` for this shape, so `call_handle_ops` surfaced a hard transport error instead of `HandleOpsOut::Revert`.
- This mattered during bundle gas estimation: the hard error bypassed the rejection machinery entirely — no ops were removed from the pool and the builder retried the identical bundle every round, livelocking on a single poison op. Observed in production with an EIP-7702 op whose authorization went stale while pooled (chain stall): the node silently skipped the invalid tuple in the validation `eth_call`, the codeless sender made the v0.7 entry point revert with empty data (uncatchable `validateUserOp` return-decode failure), and the builder spun on `should call handle ops with candidate bundle`.
- Fall back to the error message when `data` is absent: revert-shaped errors (message contains `revert`) now decode to `HandleOpsOut::Revert(0x)` so the existing full-bundle rejection path runs and the pool self-heals. Non-revert errors (out of gas, insufficient funds, rate limits) still propagate as errors.
- Applied to both the v0.6 and v0.7+ decoders; the v0.7 free function now takes the error message, matching the v0.6 signature.
- Added unit tests covering: `FailedOp` decode, unknown revert data passthrough, missing `data` field, empty `data: "0x"`, and non-revert error messages.

Note: this fixes the failure mode (livelock), not the root cause. A follow-up should re-validate EIP-7702 auth nonces at bundle assembly, since they are currently only checked once at mempool entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)