### PR TITLE
fix: allow OP-062 core precompiles.

### DIFF
--- a/crates/sim/tracer/src/validationTracerV0_7.ts
+++ b/crates/sim/tracer/src/validationTracerV0_7.ts
@@ -345,7 +345,7 @@ interface BundlerCollectorTracer extends LogTracer<BundlerTracerResult>, Bundler
         // this.debug.push(`isPrecompiled address=${addrHex} addressInt=${addressInt}`)
 
         // MODIFICATION: allow precompile RIP-7212 through - which is at 256
-        return (addressInt > 0 && addressInt < 10) || addressInt == 256
+        return (addressInt > 0 && addressInt < 18) || addressInt == 256
       }
       // [OP-041]
       if (opcode.match(/^(EXT.*|CALL|CALLCODE|DELEGATECALL|STATICCALL)$/) != null) {


### PR DESCRIPTION
Refs: #1301

[Closes/Fixes] #1301

## Proposed Changes
  - Allow the full set of core precompiles in EIP7562.
