### PR TITLE
fix(builder): remove ops after internal RPC error

### DIFF
--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -1019,6 +1019,8 @@ where
                 tx_hash,
             }) => {
                 if Self::is_internal_rpc_error(code, &message) {
+                    // Treat this error shape as terminal. Unlike an onchain bundle revert, do not
+                    // retry the bundle's operations.
                     let uo_hashes: Vec<B256> = ops.iter().map(|(_, hash)| *hash).collect();
                     let uo_count = uo_hashes.len();
                     error!(
@@ -1027,7 +1029,7 @@ where
                         rpc_error_code = code,
                         rpc_error_message = %message,
                         uo_count,
-                        "Bundle transaction failed to land due to internal RPC error; removing all user operations from the pool"
+                        "Bundle submission hit a terminal internal RPC error; removing all user operations from the pool"
                     );
 
                     let rejection_error =
@@ -1038,7 +1040,7 @@ where
                             BuilderEvent::rejected_op(
                                 self.builder_tag.clone(),
                                 *uo_hash,
-                                OpRejectionReason::BundleTransactionFailedToLand {
+                                OpRejectionReason::TerminalBundleSubmissionError {
                                     tx_hash,
                                     error: Arc::clone(&rejection_error),
                                 },
@@ -1890,7 +1892,7 @@ mod tests {
                 event.event.kind,
                 BuilderEventKind::RejectedOp {
                     op_hash,
-                    reason: OpRejectionReason::BundleTransactionFailedToLand {
+                    reason: OpRejectionReason::TerminalBundleSubmissionError {
                         tx_hash: event_tx_hash,
                         error,
                     },

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -41,7 +41,7 @@ use crate::{
     ProposerKey,
     assigner::{Assigner, AssignmentResult},
     bundle_proposer::{BundleData, BundleProposalRequest, BundleProposerError, BundleProposerT},
-    emit::{BuilderEvent, BundleTxDetails},
+    emit::{BuilderEvent, BundleTxDetails, OpRejectionReason},
     transaction_tracker::{
         TrackerState, TrackerUpdate, TransactionTracker, TransactionTrackerError,
     },
@@ -1027,8 +1027,25 @@ where
                         rpc_error_code = code,
                         rpc_error_message = %message,
                         uo_count,
-                        "Bundle transaction failed to land; removing all user operations from the pool"
+                        "Bundle transaction failed to land due to internal RPC error; removing all user operations from the pool"
                     );
+
+                    let rejection_error =
+                        Arc::new(format!("unrecognized RPC error {code}: {message}"));
+                    for uo_hash in &uo_hashes {
+                        self.emit_for_entrypoint(
+                            entry_point,
+                            BuilderEvent::rejected_op(
+                                self.builder_tag.clone(),
+                                *uo_hash,
+                                OpRejectionReason::BundleTransactionFailedToLand {
+                                    tx_hash,
+                                    error: Arc::clone(&rejection_error),
+                                },
+                            ),
+                        );
+                    }
+
                     if let Err(remove_error) = self.pool.remove_ops(entry_point, uo_hashes).await {
                         error!(
                             %tx_hash,
@@ -1664,6 +1681,7 @@ mod tests {
         assigner::{AssignmentResult, EntrypointInfo},
         bundle_proposer::{BundleData, MockBundleProposerT},
         bundle_sender::{BundleSenderImpl, MockTrigger},
+        emit::BuilderEventKind,
         transaction_tracker::MockTransactionTracker,
     };
 
@@ -1845,6 +1863,7 @@ mod tests {
             .returning(|_, _| Ok(()));
 
         let mut sender = new_sender(mock_proposer_t, mock_pool);
+        let mut event_rx = sender.event_sender.subscribe();
         let mut state = SenderMachineState::new(mock_trigger, mock_tracker);
         let result = sender
             .send_bundle_from_data(
@@ -1861,6 +1880,25 @@ mod tests {
 
         let error = result.expect_err("internal RPC error should fail the bundle send");
         assert!(error.to_string().contains(&tx_hash.to_string()));
+
+        for expected_uo_hash in uo_hashes {
+            let event = event_rx
+                .try_recv()
+                .expect("removed UO should emit a rejection event");
+            assert_eq!(event.entry_point, ENTRY_POINT_ADDRESS_V0_6);
+            assert!(matches!(
+                event.event.kind,
+                BuilderEventKind::RejectedOp {
+                    op_hash,
+                    reason: OpRejectionReason::BundleTransactionFailedToLand {
+                        tx_hash: event_tx_hash,
+                        error,
+                    },
+                } if op_hash == expected_uo_hash
+                    && event_tx_hash == tx_hash
+                    && error.as_str() == "unrecognized RPC error -32000: internal error"
+            ));
+        }
     }
 
     #[tokio::test]

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -662,6 +662,21 @@ where
                 self.assigner.release_all(self.sender_eoa);
                 state.reset();
             }
+            Err(TransactionTrackerError::UnrecognizedRpc {
+                code,
+                message,
+                tx_hash,
+            }) => {
+                error!(
+                    %tx_hash,
+                    rpc_error_code = code,
+                    rpc_error_message = %message,
+                    "Failed to cancel transaction, moving back to building state"
+                );
+                self.increment_counter("builder_cancellation_txns_failed", &pinned, 1);
+                self.assigner.release_all(self.sender_eoa);
+                state.reset();
+            }
             Err(TransactionTrackerError::Other(e)) => {
                 error!("Failed to cancel transaction, moving back to building state: {e:#?}");
                 self.increment_counter("builder_cancellation_txns_failed", &pinned, 1);
@@ -998,6 +1013,44 @@ where
                 error!("Bundle attempt insufficient funds");
                 Ok(SendBundleAttemptResult::InsufficientFunds)
             }
+            Err(TransactionTrackerError::UnrecognizedRpc {
+                code,
+                message,
+                tx_hash,
+            }) => {
+                if Self::is_internal_rpc_error(code, &message) {
+                    let uo_hashes: Vec<B256> = ops.iter().map(|(_, hash)| *hash).collect();
+                    let uo_count = uo_hashes.len();
+                    error!(
+                        %tx_hash,
+                        ?entry_point,
+                        rpc_error_code = code,
+                        rpc_error_message = %message,
+                        uo_count,
+                        "Bundle transaction failed to land; removing all user operations from the pool"
+                    );
+                    if let Err(remove_error) = self.pool.remove_ops(entry_point, uo_hashes).await {
+                        error!(
+                            %tx_hash,
+                            ?entry_point,
+                            error = ?remove_error,
+                            "Failed to remove user operations from bundle after internal RPC error"
+                        );
+                    }
+                } else {
+                    error!(
+                        %tx_hash,
+                        ?entry_point,
+                        rpc_error_code = code,
+                        rpc_error_message = %message,
+                        "Failed to send bundle with unrecognized RPC error"
+                    );
+                }
+
+                Err(anyhow::anyhow!(
+                    "unrecognized RPC error {code}: {message}; transaction hash {tx_hash}"
+                ))
+            }
             Err(TransactionTrackerError::Other(e)) => {
                 error!("Failed to send bundle with unexpected error: {e:?}");
                 if Self::is_intrinsic_gas_too_low_error(&e) {
@@ -1012,6 +1065,10 @@ where
                 Err(e)
             }
         }
+    }
+
+    fn is_internal_rpc_error(code: i64, message: &str) -> bool {
+        code == -32000 && message.trim().eq_ignore_ascii_case("internal error")
     }
 
     fn is_intrinsic_gas_too_low_error(error: &anyhow::Error) -> bool {
@@ -1751,6 +1808,98 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[tokio::test]
+    async fn test_internal_rpc_error_removes_all_bundle_ops() {
+        let Mocks {
+            mock_proposer_t,
+            mut mock_tracker,
+            mut mock_trigger,
+            mut mock_pool,
+        } = new_mocks();
+
+        let tx_hash = B256::repeat_byte(0x11);
+        let uo_hashes = vec![B256::repeat_byte(0x22), B256::repeat_byte(0x33)];
+        let expected_uo_hashes = uo_hashes.clone();
+
+        mock_trigger.expect_last_block().return_const(new_head(1));
+        mock_tracker
+            .expect_send_transaction()
+            .once()
+            .returning(move |_, _, _| {
+                Box::pin(async move {
+                    Err(TransactionTrackerError::UnrecognizedRpc {
+                        code: -32000,
+                        message: String::from("internal error"),
+                        tx_hash,
+                    })
+                })
+            });
+        mock_pool
+            .expect_remove_ops()
+            .once()
+            .withf(move |entry_point, hashes| {
+                *entry_point == ENTRY_POINT_ADDRESS_V0_6 && *hashes == expected_uo_hashes
+            })
+            .returning(|_, _| Ok(()));
+
+        let mut sender = new_sender(mock_proposer_t, mock_pool);
+        let mut state = SenderMachineState::new(mock_trigger, mock_tracker);
+        let result = sender
+            .send_bundle_from_data(
+                &mut state,
+                ENTRY_POINT_ADDRESS_V0_6,
+                bundle_data(vec![
+                    (Address::repeat_byte(0x44), uo_hashes[0]),
+                    (Address::repeat_byte(0x55), uo_hashes[1]),
+                ]),
+                0,
+                0,
+            )
+            .await;
+
+        let error = result.expect_err("internal RPC error should fail the bundle send");
+        assert!(error.to_string().contains(&tx_hash.to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_other_unrecognized_rpc_error_keeps_bundle_ops() {
+        let Mocks {
+            mock_proposer_t,
+            mut mock_tracker,
+            mut mock_trigger,
+            mock_pool,
+        } = new_mocks();
+
+        let tx_hash = B256::repeat_byte(0x11);
+        mock_trigger.expect_last_block().return_const(new_head(1));
+        mock_tracker
+            .expect_send_transaction()
+            .once()
+            .returning(move |_, _, _| {
+                Box::pin(async move {
+                    Err(TransactionTrackerError::UnrecognizedRpc {
+                        code: -32001,
+                        message: String::from("server unavailable"),
+                        tx_hash,
+                    })
+                })
+            });
+
+        let mut sender = new_sender(mock_proposer_t, mock_pool);
+        let mut state = SenderMachineState::new(mock_trigger, mock_tracker);
+        let result = sender
+            .send_bundle_from_data(
+                &mut state,
+                ENTRY_POINT_ADDRESS_V0_6,
+                bundle_data(vec![(Address::repeat_byte(0x44), B256::repeat_byte(0x22))]),
+                0,
+                0,
+            )
+            .await;
+
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -1087,7 +1087,14 @@ where
     }
 
     fn is_internal_rpc_error(code: i64, message: &str) -> bool {
-        code == -32000 && message.trim().eq_ignore_ascii_case("internal error")
+        if code != -32000 {
+            return false;
+        }
+        let message = message.trim();
+        // "internal error" is the original message shape; "Transaction rejected by chain
+        // policy" is the newer wording for the same terminal rejection.
+        message.eq_ignore_ascii_case("internal error")
+            || message.eq_ignore_ascii_case("Transaction rejected by chain policy")
     }
 
     fn is_intrinsic_gas_too_low_error(error: &anyhow::Error) -> bool {
@@ -1899,6 +1906,80 @@ mod tests {
                 } if op_hash == expected_uo_hash
                     && event_tx_hash == tx_hash
                     && error.as_str() == "unrecognized RPC error -32000: internal error"
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_chain_policy_rejection_removes_all_bundle_ops() {
+        let Mocks {
+            mock_proposer_t,
+            mut mock_tracker,
+            mut mock_trigger,
+            mut mock_pool,
+        } = new_mocks();
+
+        let tx_hash = B256::repeat_byte(0x11);
+        let uo_hashes = vec![B256::repeat_byte(0x22), B256::repeat_byte(0x33)];
+        let expected_uo_hashes = uo_hashes.clone();
+
+        mock_trigger.expect_last_block().return_const(new_head(1));
+        mock_tracker
+            .expect_send_transaction()
+            .once()
+            .returning(move |_, _, _| {
+                Box::pin(async move {
+                    Err(TransactionTrackerError::UnrecognizedRpc {
+                        code: -32000,
+                        message: String::from("Transaction rejected by chain policy"),
+                        tx_hash,
+                    })
+                })
+            });
+        mock_pool
+            .expect_remove_ops()
+            .once()
+            .withf(move |entry_point, hashes| {
+                *entry_point == ENTRY_POINT_ADDRESS_V0_6 && *hashes == expected_uo_hashes
+            })
+            .returning(|_, _| Ok(()));
+
+        let mut sender = new_sender(mock_proposer_t, mock_pool);
+        let mut event_rx = sender.event_sender.subscribe();
+        let mut state = SenderMachineState::new(mock_trigger, mock_tracker);
+        let result = sender
+            .send_bundle_from_data(
+                &mut state,
+                ENTRY_POINT_ADDRESS_V0_6,
+                bundle_data(vec![
+                    (Address::repeat_byte(0x44), uo_hashes[0]),
+                    (Address::repeat_byte(0x55), uo_hashes[1]),
+                ]),
+                0,
+                0,
+            )
+            .await;
+
+        let error = result.expect_err("chain policy rejection should fail the bundle send");
+        assert!(error.to_string().contains(&tx_hash.to_string()));
+
+        for expected_uo_hash in uo_hashes {
+            let event = event_rx
+                .try_recv()
+                .expect("removed UO should emit a rejection event");
+            assert_eq!(event.entry_point, ENTRY_POINT_ADDRESS_V0_6);
+            assert!(matches!(
+                event.event.kind,
+                BuilderEventKind::RejectedOp {
+                    op_hash,
+                    reason: OpRejectionReason::TerminalBundleSubmissionError {
+                        tx_hash: event_tx_hash,
+                        error,
+                    },
+                } if op_hash == expected_uo_hash
+                    && event_tx_hash == tx_hash
+                    && error.as_str()
+                        == "unrecognized RPC error -32000: Transaction rejected by chain policy"
             ));
         }
     }

--- a/crates/builder/src/emit.rs
+++ b/crates/builder/src/emit.rs
@@ -196,8 +196,9 @@ pub enum OpRejectionReason {
     FailedRevalidation { error: SimulationError },
     /// Operation reverted during bundle formation simulation with message
     FailedInBundle { message: Arc<String> },
-    /// The bundle transaction failed to land after submission.
-    BundleTransactionFailedToLand {
+    /// Bundle submission hit a terminal error. Unlike an onchain bundle revert, it is not
+    /// retried and all associated operations are removed.
+    TerminalBundleSubmissionError {
         /// Hash of the bundle transaction.
         tx_hash: B256,
         /// Submission error returned by the transaction sender.

--- a/crates/builder/src/emit.rs
+++ b/crates/builder/src/emit.rs
@@ -196,6 +196,13 @@ pub enum OpRejectionReason {
     FailedRevalidation { error: SimulationError },
     /// Operation reverted during bundle formation simulation with message
     FailedInBundle { message: Arc<String> },
+    /// The bundle transaction failed to land after submission.
+    BundleTransactionFailedToLand {
+        /// Hash of the bundle transaction.
+        tx_hash: B256,
+        /// Submission error returned by the transaction sender.
+        error: Arc<String>,
+    },
     /// Operation's storage slot condition was not met
     ConditionNotMet(ConditionNotMetReason),
     /// Current time is outside of the operation's valid time range

--- a/crates/builder/src/sender/fallback.rs
+++ b/crates/builder/src/sender/fallback.rs
@@ -39,7 +39,7 @@ struct FallbackSenderMetrics {
     #[metric(describe = "total successful sends via the fallback")]
     fallback_sends: Counter,
     #[metric(
-        describe = "total SenderUnavailable errors from the primary, including those below the failover threshold"
+        describe = "total sender unavailable errors from the primary, including unrecognized RPC errors and those below the failover threshold"
     )]
     primary_unavailable: Counter,
 }
@@ -51,11 +51,12 @@ enum ActiveSender {
 }
 
 /// A transaction sender that transparently fails over to a fallback sender when
-/// the primary returns [`TxSenderError::SenderUnavailable`].
+/// the primary returns [`TxSenderError::SenderUnavailable`] or
+/// [`TxSenderError::UnrecognizedRpc`].
 ///
 /// Recovery is passive: after `recovery_interval` has elapsed the next send
 /// attempt re-tries the primary. On success the primary is reinstated; on
-/// another `SenderUnavailable` the timer resets.
+/// another unavailable error the timer resets.
 ///
 /// Cancellations are always routed to whichever sender originally submitted
 /// the transaction (tracked by tx hash). If the primary is down at cancel time
@@ -73,7 +74,7 @@ pub(crate) struct FallbackTransactionSender {
     /// Tracks whether the most recent transaction was submitted via the fallback,
     /// so cancellations can be routed to the correct sender.
     last_tx_used_fallback: AtomicBool,
-    /// Consecutive SenderUnavailable responses from the primary before we commit to failover.
+    /// Consecutive unavailable responses from the primary before we commit to failover.
     consecutive_failures: AtomicU32,
     /// How many consecutive failures are required before activating the fallback.
     failure_threshold: u32,
@@ -168,7 +169,10 @@ impl TransactionSender for FallbackTransactionSender {
                 self.metrics.primary_sends.increment(1);
                 Ok(hash)
             }
-            Err(TxSenderError::SenderUnavailable(e)) => {
+            Err(
+                error @ (TxSenderError::SenderUnavailable(_)
+                | TxSenderError::UnrecognizedRpc { .. }),
+            ) => {
                 self.metrics.primary_unavailable.increment(1);
                 let failures = self.consecutive_failures.fetch_add(1, Ordering::AcqRel) + 1;
                 if failures >= self.failure_threshold {
@@ -185,10 +189,10 @@ impl TransactionSender for FallbackTransactionSender {
                     tracing::warn!(
                         failures,
                         threshold = self.failure_threshold,
-                        error = %e,
+                        error = %error,
                         "Primary sender unavailable, will activate fallback after threshold"
                     );
-                    Err(TxSenderError::SenderUnavailable(e))
+                    Err(error)
                 }
             }
             Err(e) => Err(e),

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -68,14 +68,41 @@ pub(crate) enum TxSenderError {
     /// Insufficient funds for transaction
     #[error("insufficient funds for transaction")]
     InsufficientFunds,
-    /// Sender is unavailable due to an outage or unrecognized error.
+    /// Sender is unavailable due to an outage or transport error.
     ///
     /// When a fallback sender is configured this triggers failover.
     #[error("sender unavailable: {0}")]
     SenderUnavailable(anyhow::Error),
+    /// The sender returned an unrecognized RPC error after transaction signing.
+    ///
+    /// This is treated as sender unavailability by fallback senders. The transaction
+    /// hash is populated by senders that have access to the signed transaction bytes.
+    #[error("unrecognized RPC error {code}: {message}")]
+    UnrecognizedRpc {
+        /// RPC error code.
+        code: i64,
+        /// RPC error message.
+        message: String,
+        /// Hash of the signed transaction submitted to the sender.
+        tx_hash: Option<B256>,
+    },
     /// All other errors
     #[error(transparent)]
     Other(#[from] anyhow::Error),
+}
+
+impl TxSenderError {
+    /// Attach the signed transaction hash to errors for which it is useful.
+    pub(crate) fn with_tx_hash(self, tx_hash: B256) -> Self {
+        match self {
+            Self::UnrecognizedRpc { code, message, .. } => Self::UnrecognizedRpc {
+                code,
+                message,
+                tx_hash: Some(tx_hash),
+            },
+            error => error,
+        }
+    }
 }
 
 pub(crate) type Result<T> = std::result::Result<T, TxSenderError>;
@@ -278,11 +305,11 @@ impl From<ProviderError> for TxSenderError {
                         rpc_error_message = %e.message,
                         "Unrecognized RPC error from provider, treating as sender unavailable"
                     );
-                    TxSenderError::SenderUnavailable(anyhow::anyhow!(
-                        "unrecognized RPC error {}: {}",
-                        e.code,
-                        e.message
-                    ))
+                    TxSenderError::UnrecognizedRpc {
+                        code: e.code,
+                        message: e.message.to_string(),
+                        tx_hash: None,
+                    }
                 } else {
                     tracing::warn!(
                         error = ?value,
@@ -358,7 +385,29 @@ fn parse_known_call_execution_failed(message: &str, code: i64) -> Option<TxSende
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::B256;
+
     use super::TxSenderError;
+
+    #[test]
+    fn attaches_transaction_hash_to_unrecognized_rpc_error() {
+        let tx_hash = B256::repeat_byte(0x11);
+        let error = TxSenderError::UnrecognizedRpc {
+            code: -32000,
+            message: String::from("internal error"),
+            tx_hash: None,
+        }
+        .with_tx_hash(tx_hash);
+
+        assert!(matches!(
+            error,
+            TxSenderError::UnrecognizedRpc {
+                code: -32000,
+                message,
+                tx_hash: Some(actual_tx_hash),
+            } if message == "internal error" && actual_tx_hash == tx_hash
+        ));
+    }
 
     #[test]
     fn parses_cronos_invalid_sequence_as_nonce_too_low() {

--- a/crates/builder/src/sender/polygon_private.rs
+++ b/crates/builder/src/sender/polygon_private.rs
@@ -63,13 +63,17 @@ where
             .sign_tx_raw(tx)
             .await
             .context("failed to sign transaction")?;
+        let signed_tx_hash = keccak256(&raw_tx);
 
-        let tx_hash = self.submit_provider.send_raw_transaction(raw_tx).await?;
-
-        Ok(CancelTxInfo {
-            tx_hash,
-            soft_cancelled: false,
-        })
+        self.submit_provider
+            .send_raw_transaction(raw_tx)
+            .await
+            .map_err(TxSenderError::from)
+            .map_err(|error| error.with_tx_hash(signed_tx_hash))
+            .map(|tx_hash| CancelTxInfo {
+                tx_hash,
+                soft_cancelled: false,
+            })
     }
 }
 

--- a/crates/builder/src/sender/polygon_private.rs
+++ b/crates/builder/src/sender/polygon_private.rs
@@ -11,14 +11,14 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use alloy_primitives::B256;
+use alloy_primitives::{B256, keccak256};
 use anyhow::Context;
 use async_trait::async_trait;
 use rundler_provider::{EvmProvider, TransactionRequest};
 use rundler_signer::SignerLease;
 use rundler_types::{ExpectedStorage, GasFees};
 
-use super::{CancelTxInfo, Result};
+use super::{CancelTxInfo, Result, TxSenderError};
 use crate::sender::{TransactionSender, create_hard_cancel_tx};
 
 #[derive(Debug)]
@@ -41,13 +41,13 @@ where
             .sign_tx_raw(tx)
             .await
             .context("failed to sign transaction")?;
+        let signed_tx_hash = keccak256(&raw_tx);
 
-        let tx_hash = self
-            .submit_provider
+        self.submit_provider
             .request("eth_sendRawTransactionPrivate", (raw_tx,))
-            .await?;
-
-        Ok(tx_hash)
+            .await
+            .map_err(TxSenderError::from)
+            .map_err(|error| error.with_tx_hash(signed_tx_hash))
     }
 
     async fn cancel_transaction(

--- a/crates/builder/src/sender/raw.rs
+++ b/crates/builder/src/sender/raw.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use alloy_primitives::B256;
+use alloy_primitives::{B256, keccak256};
 use anyhow::Context;
 use async_trait::async_trait;
 use rundler_provider::{EvmProvider, TransactionRequest};
@@ -19,7 +19,7 @@ use rundler_signer::SignerLease;
 use rundler_types::{ExpectedStorage, GasFees};
 use serde_json::json;
 
-use super::{CancelTxInfo, Result};
+use super::{CancelTxInfo, Result, TxSenderError};
 use crate::sender::{TransactionSender, create_hard_cancel_tx};
 
 #[derive(Debug)]
@@ -43,19 +43,24 @@ where
             .sign_tx_raw(tx)
             .await
             .context("failed to sign transaction")?;
+        let signed_tx_hash = keccak256(&raw_tx);
 
-        let tx_hash = if self.use_conditional_rpc {
+        let send_result: Result<B256> = if self.use_conditional_rpc {
             self.submit_provider
                 .request(
                     "eth_sendRawTransactionConditional",
                     (raw_tx, json!({ "knownAccounts": expected_storage })),
                 )
-                .await?
+                .await
+                .map_err(TxSenderError::from)
         } else {
-            self.submit_provider.send_raw_transaction(raw_tx).await?
+            self.submit_provider
+                .send_raw_transaction(raw_tx)
+                .await
+                .map_err(TxSenderError::from)
         };
 
-        Ok(tx_hash)
+        send_result.map_err(|error| error.with_tx_hash(signed_tx_hash))
     }
 
     async fn cancel_transaction(

--- a/crates/builder/src/sender/raw.rs
+++ b/crates/builder/src/sender/raw.rs
@@ -76,13 +76,17 @@ where
             .sign_tx_raw(tx)
             .await
             .context("failed to sign transaction")?;
+        let signed_tx_hash = keccak256(&raw_tx);
 
-        let tx_hash = self.submit_provider.send_raw_transaction(raw_tx).await?;
-
-        Ok(CancelTxInfo {
-            tx_hash,
-            soft_cancelled: false,
-        })
+        self.submit_provider
+            .send_raw_transaction(raw_tx)
+            .await
+            .map_err(TxSenderError::from)
+            .map_err(|error| error.with_tx_hash(signed_tx_hash))
+            .map(|tx_hash| CancelTxInfo {
+                tx_hash,
+                soft_cancelled: false,
+            })
     }
 }
 

--- a/crates/builder/src/transaction_tracker.rs
+++ b/crates/builder/src/transaction_tracker.rs
@@ -117,6 +117,16 @@ pub(crate) enum TransactionTrackerError {
     Rejected,
     #[error("insufficient funds")]
     InsufficientFunds,
+    /// An unrecognized RPC error returned for a signed transaction.
+    #[error("unrecognized RPC error {code}: {message}; transaction hash {tx_hash}")]
+    UnrecognizedRpc {
+        /// RPC error code.
+        code: i64,
+        /// RPC error message.
+        message: String,
+        /// Hash of the signed transaction submitted to the sender.
+        tx_hash: B256,
+    },
     /// All other errors
     #[error(transparent)]
     Other(#[from] anyhow::Error),
@@ -696,6 +706,22 @@ impl From<TxSenderError> for TransactionTrackerError {
             // SenderUnavailable reaching here means no fallback is configured; treat
             // it as a transient error so the bundle sender retries next cycle.
             TxSenderError::SenderUnavailable(e) => TransactionTrackerError::Other(e),
+            TxSenderError::UnrecognizedRpc {
+                code,
+                message,
+                tx_hash: Some(tx_hash),
+            } => TransactionTrackerError::UnrecognizedRpc {
+                code,
+                message,
+                tx_hash,
+            },
+            TxSenderError::UnrecognizedRpc {
+                code,
+                message,
+                tx_hash: None,
+            } => TransactionTrackerError::Other(anyhow::anyhow!(
+                "unrecognized RPC error {code}: {message}"
+            )),
             TxSenderError::Other(e) => TransactionTrackerError::Other(e),
         }
     }
@@ -741,6 +767,25 @@ mod tests {
 
     use super::*;
     use crate::sender::MockTransactionSender;
+
+    #[test]
+    fn preserves_unrecognized_rpc_transaction_hash() {
+        let tx_hash = B256::repeat_byte(0x11);
+        let error = TransactionTrackerError::from(TxSenderError::UnrecognizedRpc {
+            code: -32000,
+            message: String::from("internal error"),
+            tx_hash: Some(tx_hash),
+        });
+
+        assert!(matches!(
+            error,
+            TransactionTrackerError::UnrecognizedRpc {
+                code: -32000,
+                message,
+                tx_hash: actual_tx_hash,
+            } if message == "internal error" && actual_tx_hash == tx_hash
+        ));
+    }
 
     /// Single-signer manager for unit tests.
     struct TestSignerManager {


### PR DESCRIPTION
Issue: N/A

## Proposed Changes

- Preserve unrecognized RPC error details and derive the submitted transaction hash from the signed transaction bytes.
- On a terminal `-32000: internal error`, log the transaction hash and remove every user operation selected for that bundle from the mempool.
- Preserve fallback sender behavior and leave bundle operations untouched for other unrecognized RPC errors.

## Root Cause

Unrecognized provider RPC errors were flattened into a generic error before reaching the bundle sender. That discarded the locally derivable transaction hash and left the bundle sender without a structured signal for cleaning up the affected user operations.

## Impact

Ambiguous internal RPC submission failures no longer leave the same user operations eligible for repeated bundling, and operators can correlate the failure with the exact transaction hash.

## Validation

- `cargo test -p rundler-builder` (100 tests passed)
- `cargo clippy -p rundler-builder --all-features --tests -- -D warnings`
- `cargo +nightly fmt --all --check`
- Repository pre-commit hooks: workspace clippy, rustfmt, buf, and cargo-sort
