### PR TITLE
fix(provider): filter handled submission errors from metrics

### DIFF
--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -26,7 +26,10 @@ pub(crate) use flashbots::FlashbotsTransactionSender;
 #[cfg(test)]
 use mockall::automock;
 pub(crate) use raw::RawTransactionSender;
-use rundler_provider::{AlloyNetworkConfig, EvmProvider, ProviderError, TransactionRequest};
+use rundler_provider::{
+    AlloyNetworkConfig, EvmProvider, ProviderError, TransactionRequest,
+    transaction::{self, TransactionSubmissionError},
+};
 use rundler_signer::SignerLease;
 use rundler_types::{ExpectedStorage, GasFees};
 use secrecy::SecretString;
@@ -296,64 +299,21 @@ impl From<ProviderError> for TxSenderError {
     }
 }
 
-// Geth: https://github.com/ethereum/go-ethereum/blob/23800122b37695be50565f8221858a16ce1763db/core/txpool/errors.go#L31
-// Reth: https://github.com/paradigmxyz/reth/blob/8e4a917ec1aa70b3779083454ff2d5ecf6b44168/crates/rpc/rpc-eth-types/src/error/mod.rs#L624
-// Erigon: https://github.com/erigontech/erigon/blob/96fabf3fd1a4ddce26b845ffe2b6cfb50d5b4b2d/txnprovider/txpool/txpoolcfg/txpoolcfg.go#L124
 fn parse_known_call_execution_failed(message: &str, code: i64) -> Option<TxSenderError> {
-    // String match on the error message when an error code is not available
-    // DEVELOPER NOTE: ensure to put the most specific matches first
-    let lowercase_message = message.to_lowercase();
-    // geth. Reth & erigon don't have similar
-    if lowercase_message.contains("future transaction tries to replace pending") {
-        return Some(TxSenderError::Rejected);
+    transaction::classify_submission_error(message, code).map(TxSenderError::from)
+}
+
+impl From<TransactionSubmissionError> for TxSenderError {
+    fn from(error: TransactionSubmissionError) -> Self {
+        match error {
+            TransactionSubmissionError::Underpriced => Self::Underpriced,
+            TransactionSubmissionError::ReplacementUnderpriced => Self::ReplacementUnderpriced,
+            TransactionSubmissionError::NonceTooLow => Self::NonceTooLow,
+            TransactionSubmissionError::ConditionNotMet => Self::ConditionNotMet,
+            TransactionSubmissionError::Rejected => Self::Rejected,
+            TransactionSubmissionError::InsufficientFunds => Self::InsufficientFunds,
+        }
     }
-    // geth & reth
-    if lowercase_message.contains("replacement transaction underpriced") {
-        return Some(TxSenderError::ReplacementUnderpriced);
-    }
-    // erigon
-    if lowercase_message.contains("could not replace existing tx") {
-        return Some(TxSenderError::ReplacementUnderpriced);
-    }
-    // monad
-    if lowercase_message.contains("an existing transaction had higher priority") {
-        return Some(TxSenderError::ReplacementUnderpriced);
-    }
-    // geth, erigon, reth
-    if lowercase_message.contains("nonce too low") {
-        return Some(TxSenderError::NonceTooLow);
-    }
-    // Cronos/Cosmos SDK: "invalid nonce; got 1232, expected 1233: invalid sequence"
-    if lowercase_message.contains("invalid nonce; got") {
-        return Some(TxSenderError::NonceTooLow);
-    }
-    // geth
-    if lowercase_message.contains("transaction underpriced") {
-        return Some(TxSenderError::Underpriced);
-    }
-    // reth
-    if lowercase_message.contains("txpool is full") {
-        return Some(TxSenderError::Underpriced);
-    }
-    // erigon
-    if lowercase_message.contains("underpriced") {
-        return Some(TxSenderError::Underpriced);
-    }
-    // geth, erigon, reth
-    if lowercase_message.contains("insufficient funds") {
-        return Some(TxSenderError::InsufficientFunds);
-    }
-    // Aribtrum sequencer
-    if lowercase_message.contains("condition not met") {
-        return Some(TxSenderError::ConditionNotMet);
-    }
-    // Check error codes before checking the message
-    // The error code is -32003 or -32005 when condition is not met: https://eips.ethereum.org/EIPS/eip-7796
-    if code == -32003 || code == -32005 {
-        return Some(TxSenderError::ConditionNotMet);
-    }
-    // No known error matched
-    None
 }
 
 #[cfg(test)]

--- a/crates/provider/src/alloy/metrics.rs
+++ b/crates/provider/src/alloy/metrics.rs
@@ -22,6 +22,8 @@ use rundler_types::task::{
 };
 use tower::{Layer, Service};
 
+use crate::transaction;
+
 /// Alloy provider metric layer.
 #[derive(Default)]
 pub(crate) struct AlloyMetricLayer {}
@@ -95,7 +97,11 @@ where
             match &response {
                 Ok(resp) => {
                     method_logger.record_http(HttpCode::TwoHundreds);
-                    method_logger.record_rpc(get_rpc_status_code(resp));
+                    if resp.as_error().is_none_or(|error| {
+                        should_record_rpc_status(&method_name, &error.message, error.code)
+                    }) {
+                        method_logger.record_rpc(get_rpc_status_code(resp));
+                    }
                     if resp.is_error() {
                         let error = resp.as_error().unwrap();
                         if error.code < 0 {
@@ -115,7 +121,13 @@ where
                     match e {
                         alloy_json_rpc::RpcError::ErrorResp(rpc_error) => {
                             method_logger.record_http(HttpCode::TwoHundreds);
-                            method_logger.record_rpc(get_rpc_status_from_code(rpc_error.code));
+                            if should_record_rpc_status(
+                                &method_name,
+                                &rpc_error.message,
+                                rpc_error.code,
+                            ) {
+                                method_logger.record_rpc(get_rpc_status_from_code(rpc_error.code));
+                            }
                         }
                         alloy_json_rpc::RpcError::Transport(TransportErrorKind::HttpError(
                             HttpError { status, body: _ },
@@ -150,6 +162,19 @@ fn get_method_name(req: &RequestPacket) -> String {
             "batch".to_string()
         }
     }
+}
+
+fn should_record_rpc_status(method_name: &str, message: &str, code: i64) -> bool {
+    if !matches!(
+        method_name,
+        "eth_sendRawTransaction"
+            | "eth_sendRawTransactionConditional"
+            | "eth_sendRawTransactionPrivate"
+    ) {
+        return true;
+    }
+
+    transaction::classify_submission_error(message, code).is_none()
 }
 
 fn get_rpc_status_from_code(code: i64) -> RpcCode {
@@ -189,4 +214,51 @@ fn get_rpc_status_code(response_packet: &ResponsePacket) -> RpcCode {
         alloy_json_rpc::ResponsePayload::Failure(error_payload) => error_payload.code,
     };
     get_rpc_status_from_code(response_code)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn filters_handled_transaction_submission_errors() {
+        let cases = [
+            ("nonce too low", -32000),
+            ("replacement transaction underpriced", -32000),
+            ("transaction underpriced", -32000),
+            ("insufficient funds for gas * price + value", -32000),
+            ("storage slot value condition not met", -32000),
+            ("future transaction tries to replace pending", -32000),
+        ];
+        let methods = [
+            "eth_sendRawTransaction",
+            "eth_sendRawTransactionConditional",
+            "eth_sendRawTransactionPrivate",
+        ];
+
+        for method in methods {
+            for (message, code) in cases {
+                assert!(
+                    !super::should_record_rpc_status(method, message, code),
+                    "method: {method}, message: {message}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn records_unknown_transaction_submission_errors() {
+        assert!(super::should_record_rpc_status(
+            "eth_sendRawTransaction",
+            "internal error",
+            -32000,
+        ));
+    }
+
+    #[test]
+    fn records_known_error_for_other_rpc_methods() {
+        assert!(super::should_record_rpc_status(
+            "eth_call",
+            "nonce too low",
+            -32000,
+        ));
+    }
 }

--- a/crates/provider/src/alloy/metrics.rs
+++ b/crates/provider/src/alloy/metrics.rs
@@ -97,11 +97,7 @@ where
             match &response {
                 Ok(resp) => {
                     method_logger.record_http(HttpCode::TwoHundreds);
-                    if resp.as_error().is_none_or(|error| {
-                        should_record_rpc_status(&method_name, &error.message, error.code)
-                    }) {
-                        method_logger.record_rpc(get_rpc_status_code(resp));
-                    }
+                    method_logger.record_rpc(get_rpc_status_code(&method_name, resp));
                     if resp.is_error() {
                         let error = resp.as_error().unwrap();
                         if error.code < 0 {
@@ -121,13 +117,11 @@ where
                     match e {
                         alloy_json_rpc::RpcError::ErrorResp(rpc_error) => {
                             method_logger.record_http(HttpCode::TwoHundreds);
-                            if should_record_rpc_status(
+                            method_logger.record_rpc(get_rpc_status_from_error(
                                 &method_name,
                                 &rpc_error.message,
                                 rpc_error.code,
-                            ) {
-                                method_logger.record_rpc(get_rpc_status_from_code(rpc_error.code));
-                            }
+                            ));
                         }
                         alloy_json_rpc::RpcError::Transport(TransportErrorKind::HttpError(
                             HttpError { status, body: _ },
@@ -164,17 +158,23 @@ fn get_method_name(req: &RequestPacket) -> String {
     }
 }
 
-fn should_record_rpc_status(method_name: &str, message: &str, code: i64) -> bool {
-    if !matches!(
+/// Maps an RPC error to the status code recorded in metrics.
+///
+/// Known transaction submission errors are handled by Rundler and tracked by dedicated
+/// builder metrics, so they are recorded as success here to keep them out of provider
+/// RPC error alerting.
+fn get_rpc_status_from_error(method_name: &str, message: &str, code: i64) -> RpcCode {
+    let is_submission_method = matches!(
         method_name,
         "eth_sendRawTransaction"
             | "eth_sendRawTransactionConditional"
             | "eth_sendRawTransactionPrivate"
-    ) {
-        return true;
+    );
+    if is_submission_method && transaction::classify_submission_error(message, code).is_some() {
+        RpcCode::Success
+    } else {
+        get_rpc_status_from_code(code)
     }
-
-    transaction::classify_submission_error(message, code).is_none()
 }
 
 fn get_rpc_status_from_code(code: i64) -> RpcCode {
@@ -199,7 +199,7 @@ fn get_http_status_from_code(code: u16) -> HttpCode {
     }
 }
 
-fn get_rpc_status_code(response_packet: &ResponsePacket) -> RpcCode {
+fn get_rpc_status_code(method_name: &str, response_packet: &ResponsePacket) -> RpcCode {
     let response: &alloy_json_rpc::Response = match response_packet {
         ResponsePacket::Batch(resps) => {
             if resps.is_empty() {
@@ -209,17 +209,20 @@ fn get_rpc_status_code(response_packet: &ResponsePacket) -> RpcCode {
         }
         ResponsePacket::Single(resp) => resp,
     };
-    let response_code: i64 = match &response.payload {
-        alloy_json_rpc::ResponsePayload::Success(_) => 0,
-        alloy_json_rpc::ResponsePayload::Failure(error_payload) => error_payload.code,
-    };
-    get_rpc_status_from_code(response_code)
+    match &response.payload {
+        alloy_json_rpc::ResponsePayload::Success(_) => RpcCode::Success,
+        alloy_json_rpc::ResponsePayload::Failure(error_payload) => {
+            get_rpc_status_from_error(method_name, &error_payload.message, error_payload.code)
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::RpcCode;
+
     #[test]
-    fn filters_handled_transaction_submission_errors() {
+    fn maps_handled_transaction_submission_errors_to_success() {
         let cases = [
             ("nonce too low", -32000),
             ("replacement transaction underpriced", -32000),
@@ -237,7 +240,10 @@ mod tests {
         for method in methods {
             for (message, code) in cases {
                 assert!(
-                    !super::should_record_rpc_status(method, message, code),
+                    matches!(
+                        super::get_rpc_status_from_error(method, message, code),
+                        RpcCode::Success
+                    ),
                     "method: {method}, message: {message}"
                 );
             }
@@ -245,20 +251,18 @@ mod tests {
     }
 
     #[test]
-    fn records_unknown_transaction_submission_errors() {
-        assert!(super::should_record_rpc_status(
-            "eth_sendRawTransaction",
-            "internal error",
-            -32000,
+    fn maps_unknown_transaction_submission_errors_to_server_error() {
+        assert!(matches!(
+            super::get_rpc_status_from_error("eth_sendRawTransaction", "internal error", -32000),
+            RpcCode::ServerError
         ));
     }
 
     #[test]
-    fn records_known_error_for_other_rpc_methods() {
-        assert!(super::should_record_rpc_status(
-            "eth_call",
-            "nonce too low",
-            -32000,
+    fn maps_known_error_to_server_error_for_other_rpc_methods() {
+        assert!(matches!(
+            super::get_rpc_status_from_error("eth_call", "nonce too low", -32000),
+            RpcCode::ServerError
         ));
     }
 }

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -48,6 +48,7 @@ pub use alloy_network::{
 pub use alloy_serde::WithOtherFields;
 pub use fees::new_fee_estimator;
 mod traits;
+pub mod transaction;
 // re-export alloy RPC types
 use std::marker::PhantomData;
 

--- a/crates/provider/src/transaction.rs
+++ b/crates/provider/src/transaction.rs
@@ -1,0 +1,202 @@
+// This file is part of Rundler.
+//
+// Rundler is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Rundler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Rundler.
+// If not, see https://www.gnu.org/licenses/.
+
+//! Transaction submission error classification.
+
+/// A transaction submission error that Rundler knows how to handle.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TransactionSubmissionError {
+    /// A transaction was underpriced and dropped.
+    Underpriced,
+    /// A replacement transaction was underpriced.
+    ReplacementUnderpriced,
+    /// A transaction nonce was already used.
+    NonceTooLow,
+    /// A conditional transaction's storage condition was not met.
+    ConditionNotMet,
+    /// A transaction was rejected for a reason that can be solved with a retry.
+    Rejected,
+    /// The sender account has insufficient funds.
+    InsufficientFunds,
+}
+
+/// Classifies a transaction submission RPC error that Rundler knows how to handle.
+///
+/// Client implementations use different error codes for the same condition, so known client
+/// messages are matched before codes.
+pub fn classify_submission_error(message: &str, code: i64) -> Option<TransactionSubmissionError> {
+    // Geth: https://github.com/ethereum/go-ethereum/blob/23800122b37695be50565f8221858a16ce1763db/core/txpool/errors.go#L31
+    // Reth: https://github.com/paradigmxyz/reth/blob/8e4a917ec1aa70b3779083454ff2d5ecf6b44168/crates/rpc/rpc-eth-types/src/error/mod.rs#L624
+    // Erigon: https://github.com/erigontech/erigon/blob/96fabf3fd1a4ddce26b845ffe2b6cfb50d5b4b2d/txnprovider/txpool/txpoolcfg/txpoolcfg.go#L124
+
+    // DEVELOPER NOTE: ensure to put the most specific matches first.
+    let lowercase_message = message.to_lowercase();
+
+    // Geth. Reth and Erigon don't have similar messages.
+    if lowercase_message.contains("future transaction tries to replace pending") {
+        return Some(TransactionSubmissionError::Rejected);
+    }
+    // Geth and Reth.
+    if lowercase_message.contains("replacement transaction underpriced") {
+        return Some(TransactionSubmissionError::ReplacementUnderpriced);
+    }
+    // Erigon.
+    if lowercase_message.contains("could not replace existing tx") {
+        return Some(TransactionSubmissionError::ReplacementUnderpriced);
+    }
+    // Monad.
+    if lowercase_message.contains("an existing transaction had higher priority") {
+        return Some(TransactionSubmissionError::ReplacementUnderpriced);
+    }
+    // Geth, Erigon, and Reth.
+    if lowercase_message.contains("nonce too low") {
+        return Some(TransactionSubmissionError::NonceTooLow);
+    }
+    // Cronos/Cosmos SDK: "invalid nonce; got 1232, expected 1233: invalid sequence".
+    if lowercase_message.contains("invalid nonce; got") {
+        return Some(TransactionSubmissionError::NonceTooLow);
+    }
+    // Geth.
+    if lowercase_message.contains("transaction underpriced") {
+        return Some(TransactionSubmissionError::Underpriced);
+    }
+    // Reth.
+    if lowercase_message.contains("txpool is full") {
+        return Some(TransactionSubmissionError::Underpriced);
+    }
+    // Erigon.
+    if lowercase_message.contains("underpriced") {
+        return Some(TransactionSubmissionError::Underpriced);
+    }
+    // Geth, Erigon, and Reth.
+    if lowercase_message.contains("insufficient funds") {
+        return Some(TransactionSubmissionError::InsufficientFunds);
+    }
+    // Arbitrum sequencer.
+    if lowercase_message.contains("condition not met") {
+        return Some(TransactionSubmissionError::ConditionNotMet);
+    }
+    // EIP-7796 uses -32003 or -32005 when a condition is not met.
+    if code == -32003 || code == -32005 {
+        return Some(TransactionSubmissionError::ConditionNotMet);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TransactionSubmissionError;
+
+    #[test]
+    fn classifies_known_submission_errors() {
+        let cases = [
+            (
+                "future transaction tries to replace pending",
+                -32000,
+                TransactionSubmissionError::Rejected,
+            ),
+            (
+                "replacement transaction underpriced",
+                -32000,
+                TransactionSubmissionError::ReplacementUnderpriced,
+            ),
+            (
+                "could not replace existing tx",
+                -32000,
+                TransactionSubmissionError::ReplacementUnderpriced,
+            ),
+            (
+                "an existing transaction had higher priority",
+                -32000,
+                TransactionSubmissionError::ReplacementUnderpriced,
+            ),
+            (
+                "nonce too low",
+                -32000,
+                TransactionSubmissionError::NonceTooLow,
+            ),
+            (
+                "invalid nonce; got 1232, expected 1233: invalid sequence",
+                -32000,
+                TransactionSubmissionError::NonceTooLow,
+            ),
+            (
+                "transaction underpriced",
+                -32000,
+                TransactionSubmissionError::Underpriced,
+            ),
+            (
+                "txpool is full",
+                -32000,
+                TransactionSubmissionError::Underpriced,
+            ),
+            (
+                "underpriced",
+                -32000,
+                TransactionSubmissionError::Underpriced,
+            ),
+            (
+                "insufficient funds for gas * price + value",
+                -32000,
+                TransactionSubmissionError::InsufficientFunds,
+            ),
+            (
+                "storage slot value condition not met",
+                -32000,
+                TransactionSubmissionError::ConditionNotMet,
+            ),
+            (
+                "transaction rejected",
+                -32003,
+                TransactionSubmissionError::ConditionNotMet,
+            ),
+            (
+                "transaction rejected",
+                -32005,
+                TransactionSubmissionError::ConditionNotMet,
+            ),
+        ];
+
+        for (message, code, expected) in cases {
+            assert_eq!(
+                super::classify_submission_error(message, code),
+                Some(expected),
+                "message: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn classifies_messages_case_insensitively() {
+        assert_eq!(
+            super::classify_submission_error(
+                "Invalid nonce; got 26, expected 27: invalid sequence",
+                -32000,
+            ),
+            Some(TransactionSubmissionError::NonceTooLow)
+        );
+    }
+
+    #[test]
+    fn ignores_unknown_submission_errors() {
+        assert_eq!(
+            super::classify_submission_error("internal error", -32000),
+            None
+        );
+        assert_eq!(
+            super::classify_submission_error("invalid sequence", -32000),
+            None
+        );
+    }
+}


### PR DESCRIPTION
Issue: N/A

## Proposed Changes

- Centralize classification of transaction submission errors that Rundler handles itself.
- Exclude those handled outcomes from the generic Alloy provider RPC response-status metric for raw, conditional, and private transaction submission methods.
- Preserve generic RPC error metrics for unknown submission errors, transport failures, and non-submission methods.

## Root Cause

The provider metrics middleware classified every JSON-RPC error in the `-32000` range as a server error before the builder converted known submission outcomes such as nonce-too-low and replacement-underpriced into retryable or otherwise handled states. This caused expected transaction lifecycle races to contribute to provider RPC alerts.

## Impact

Handled submission outcomes no longer inflate provider RPC error alerts. Request count, latency, HTTP status, warning logs, and the builder's dedicated outcome counters remain unchanged.

## Validation

- `cargo test -p rundler-provider -p rundler-builder` (120 tests passed; 10 existing provider tests ignored)
- Repository pre-commit hooks: workspace Clippy, nightly rustfmt, Buf, and cargo-sort
- `cog check v0.11.0..HEAD`
