### PR TITLE
feat(pool): order bundler sponsored operations first in the mempool

### DIFF
--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -912,10 +912,15 @@ impl Eq for OrderedPoolOperation {}
 
 impl Ord for OrderedPoolOperation {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Sort by gas price descending then by id ascending
+        // Sort bundler sponsored operations first, then by gas price descending,
+        // then by id ascending
         other
-            .gas_price()
-            .cmp(&self.gas_price())
+            .po
+            .perms
+            .bundler_sponsorship
+            .is_some()
+            .cmp(&self.po.perms.bundler_sponsorship.is_some())
+            .then_with(|| other.gas_price().cmp(&self.gas_price()))
             .then_with(|| self.submission_id.cmp(&other.submission_id))
     }
 }
@@ -1751,6 +1756,27 @@ mod tests {
         pool.do_maintenance(0, Timestamp::from(2), None, GasFees::default(), 0);
         assert!(pool.get_operation_by_hash(hash).is_some());
         assert_eq!(pool.best_operations().collect::<Vec<_>>().len(), 1);
+    }
+
+    #[test]
+    fn test_bundler_sponsorship_ordered_first() {
+        let mut pool = pool();
+
+        let po1 = create_op(Address::random(), 0, 10);
+        let _ = pool.add_operation(po1.clone(), 0, 0).unwrap();
+
+        let mut po2 = create_op_zero_fees(Address::random(), 0);
+        po2.perms.bundler_sponsorship = Some(BundlerSponsorship {
+            max_cost: U256::from(100),
+            valid_until: u64::MAX,
+        });
+        let _ = pool.add_operation(po2.clone(), 0, 0).unwrap();
+
+        // sponsored op sorts first despite zero gas price and later submission
+        assert_eq!(
+            pool.best_operations().collect::<Vec<_>>(),
+            vec![Arc::new(po2), Arc::new(po1)]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bundler sponsored operations are required to have zero fees (`max_fee_per_gas`, `max_priority_fee_per_gas`, and `pre_verification_gas` must all be 0), so they previously sorted at the bottom of the pool's `best` operations set with an effective gas price of 0. That had two undesirable effects:

- They were the **last** operations considered when building bundles, behind every fee-paying op.
- They were the **first** operations evicted when the pool exceeded `max_size_of_pool_bytes`, since `enforce_size` evicts from the bottom of the set.

This PR changes `OrderedPoolOperation`'s ordering to sort bundler sponsored operations ahead of all fee-paying operations. Ordering is now: sponsorship presence, then effective gas price descending, then submission ID ascending. Sponsored ops keep FIFO order among themselves, and ordering among non-sponsored ops is unchanged.

Since the sponsorship permission is immutable for the lifetime of a pool operation, the sorted set stays consistent through the gas price re-sort in `do_maintenance`.

## Testing

- Added `test_bundler_sponsorship_ordered_first`: a zero-fee sponsored op submitted after a fee-paying op is returned first from `best_operations()`.
- `cargo test -p rundler-pool --lib`: 122 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)