### PR TITLE
fix(builder): re-validate EIP-7702 auth nonces at bundle assembly

### DIFF
--- a/crates/builder/src/bundle_proposer.rs
+++ b/crates/builder/src/bundle_proposer.rs
@@ -47,7 +47,9 @@ use rundler_types::{
     pool::{PoolOperation, SimulationViolation},
     proxy::SubmissionProxy,
 };
-use rundler_utils::{emit::WithEntryPoint, eth, guard_timer::CustomTimerGuard, math};
+use rundler_utils::{
+    authorization_utils, emit::WithEntryPoint, eth, guard_timer::CustomTimerGuard, math,
+};
 use tokio::sync::broadcast;
 use tracing::{debug, error, info, warn};
 
@@ -267,6 +269,12 @@ where
         );
 
         // (3) simulate ops
+        let eip7702_senders = ops
+            .iter()
+            .filter(|op| op.op.uo.authorization_tuple().is_some())
+            .map(|op| op.op.uo.sender())
+            .collect::<HashSet<Address>>();
+
         let simulation_futures = ops
             .into_iter()
             .map(|op| self.simulate_op(op, block_hash))
@@ -275,11 +283,16 @@ where
         let ops_with_simulations_future = future::join_all(simulation_futures);
         let balances_by_paymaster_future =
             self.get_balances_by_paymaster(all_paymaster_addresses, block_hash);
+        let eip7702_sender_states_future = self.get_eip7702_sender_states(eip7702_senders);
 
-        let (ops_with_simulations, balances_by_paymaster) =
-            tokio::join!(ops_with_simulations_future, balances_by_paymaster_future);
+        let (ops_with_simulations, balances_by_paymaster, eip7702_sender_states) = tokio::join!(
+            ops_with_simulations_future,
+            balances_by_paymaster_future,
+            eip7702_sender_states_future
+        );
 
         let balances_by_paymaster = balances_by_paymaster?;
+        let eip7702_sender_states = eip7702_sender_states?;
         let ops_with_simulations = ops_with_simulations
             .into_iter()
             .flatten()
@@ -291,6 +304,7 @@ where
                 bundle_fees.max_fee_per_gas,
                 ops_with_simulations,
                 balances_by_paymaster,
+                eip7702_sender_states,
             )
             .await;
         while !context.is_empty() {
@@ -509,6 +523,8 @@ struct BuilderProposerMetrics {
     op_simulation_ms: Histogram,
     #[metric(describe = "the number of bundle simulation failures.")]
     bundle_simulation_failures: Counter,
+    #[metric(describe = "the number of ops rejected due to a stale EIP-7702 authorization.")]
+    stale_eip7702_auth_rejections: Counter,
     #[metric(describe = "the distribution of bundle simulation time.")]
     bundle_simulation_ms: Histogram,
 }
@@ -763,6 +779,7 @@ where
             Result<SimulationResult, SimulationError>,
         )>,
         mut balances_by_paymaster: HashMap<Address, U256>,
+        eip7702_sender_states: HashMap<Address, Eip7702SenderState>,
     ) -> ProposalContext<EP::UO> {
         if max_bundle_fee == U256::ZERO {
             warn!("Max bundle fee is zero, skipping bundle");
@@ -834,6 +851,28 @@ where
                     context.rejected_ops.push((op.into(), po.op.entity_infos));
                     continue;
                 }
+            }
+
+            // Re-validate the op's EIP-7702 authorization against current chain
+            // state. A tuple whose nonce went stale in the pool is silently
+            // skipped by the node, so unless the sender is already delegated to
+            // the tuple's address the op can never validate on chain — reject it.
+            if let Some(auth) = op.authorization_tuple()
+                && let Some(state) = eip7702_sender_states.get(&op.sender())
+                && auth.nonce != state.transaction_count
+                && state.delegate != Some(auth.address)
+            {
+                self.emit(BuilderEvent::rejected_op(
+                    self.builder_tag.clone(),
+                    op.hash(),
+                    OpRejectionReason::StaleEip7702Auth {
+                        chain_nonce: state.transaction_count,
+                        auth_nonce: auth.nonce,
+                    },
+                ));
+                self.metrics.stale_eip7702_auth_rejections.increment(1);
+                context.rejected_ops.push((op.into(), po.op.entity_infos));
+                continue;
             }
 
             // if the bundle is at or past target, skip op and continue to finish processing any rejections
@@ -1231,6 +1270,34 @@ where
         }
     }
 
+    // Fetch the current transaction count and delegation status of each EIP-7702
+    // sender. Authorization tuple nonces are only checked against chain state at
+    // pool entry, and simulation overrides the sender's code unconditionally, so
+    // this is the builder's only chance to catch a tuple that went stale while
+    // the op sat in the pool.
+    async fn get_eip7702_sender_states(
+        &self,
+        senders: impl IntoIterator<Item = Address>,
+    ) -> BundleProposerResult<HashMap<Address, Eip7702SenderState>> {
+        let futures = senders.into_iter().map(|sender| async move {
+            let (transaction_count, code) = tokio::try_join!(
+                self.ep_providers.evm().get_transaction_count(sender),
+                self.ep_providers.evm().get_code(sender, None)
+            )?;
+            Ok::<_, anyhow::Error>((
+                sender,
+                Eip7702SenderState {
+                    transaction_count,
+                    delegate: authorization_utils::eip7702_delegate_from_code(&code),
+                },
+            ))
+        });
+        let sender_states = future::try_join_all(futures)
+            .await
+            .context("should fetch transaction counts and code for EIP-7702 senders")?;
+        Ok(HashMap::from_iter(sender_states))
+    }
+
     async fn get_balances_by_paymaster(
         &self,
         addresses: impl IntoIterator<Item = Address>,
@@ -1588,6 +1655,14 @@ where
 struct PoolOperationWithSponsoredDAGas {
     op: PoolOperation,
     sponsored_da_gas: u128,
+}
+
+/// Chain state of an EIP-7702 sender at bundle proposal time, used to
+/// re-validate authorization tuples that were only checked at pool entry.
+#[derive(Debug)]
+struct Eip7702SenderState {
+    transaction_count: u64,
+    delegate: Option<Address>,
 }
 
 #[derive(Debug, Clone)]
@@ -4131,6 +4206,7 @@ mod tests {
             None,
             U256::MAX,
             None,
+            vec![],
         )
         .await
         .expect_err("should fail to bundle");
@@ -4170,6 +4246,7 @@ mod tests {
             None,
             U256::MAX,
             None,
+            vec![],
         )
         .await
         .expect_err("should fail to bundle");
@@ -4245,6 +4322,119 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_7702_stale_auth_codeless_sender_rejected() {
+        // Auth tuple nonce (0) is stale (chain nonce 1) and the sender has no
+        // code: the op can never validate on chain, reject it. The innocent op
+        // in the same bundle proceeds.
+        let auth = Eip7702Auth::new_dummy(ChainSpec::default().id, address(7));
+        let poison_op = op_with_sender_and_auth(address(1), auth);
+        let innocent_op = op_with_sender(address(2));
+
+        let bundle = make_bundle_with_7702_states(
+            vec![
+                MockOp {
+                    op: poison_op.clone(),
+                    simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    perms: UserOperationPermissions::default(),
+                },
+                MockOp {
+                    op: innocent_op.clone(),
+                    simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    perms: UserOperationPermissions::default(),
+                },
+            ],
+            vec![(address(1), 1, Bytes::new())],
+        )
+        .await;
+
+        assert_eq!(bundle.rejected_ops, vec![poison_op]);
+        assert_eq!(
+            bundle.ops_per_aggregator,
+            vec![UserOpsPerAggregator {
+                user_ops: vec![innocent_op],
+                ..Default::default()
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_7702_stale_auth_wrong_delegate_rejected() {
+        // Stale tuple and the sender is delegated to a different address than
+        // the tuple's: simulation (which overrode code with the tuple's
+        // delegate) no longer reflects chain state, reject.
+        let auth = Eip7702Auth::new_dummy(ChainSpec::default().id, address(7));
+        let op = op_with_sender_and_auth(address(1), auth);
+
+        let bundle = make_bundle_with_7702_states(
+            vec![MockOp {
+                op: op.clone(),
+                simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                perms: UserOperationPermissions::default(),
+            }],
+            vec![(address(1), 1, eip7702_delegated_code(address(8)))],
+        )
+        .await;
+
+        assert_eq!(bundle.rejected_ops, vec![op]);
+        assert!(bundle.ops_per_aggregator.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_7702_stale_auth_already_delegated_kept() {
+        // Stale tuple but the delegation already landed on chain: the op
+        // validates against the sender's real code, keep it.
+        let delegate = address(7);
+        let auth = Eip7702Auth::new_dummy(ChainSpec::default().id, delegate);
+        let op = op_with_sender_and_auth(address(1), auth);
+
+        let bundle = make_bundle_with_7702_states(
+            vec![MockOp {
+                op: op.clone(),
+                simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                perms: UserOperationPermissions::default(),
+            }],
+            vec![(address(1), 1, eip7702_delegated_code(delegate))],
+        )
+        .await;
+
+        assert_eq!(bundle.rejected_ops, vec![]);
+        assert_eq!(
+            bundle.ops_per_aggregator,
+            vec![UserOpsPerAggregator {
+                user_ops: vec![op],
+                ..Default::default()
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_7702_valid_auth_kept() {
+        // Tuple nonce matches the sender's current transaction count: the
+        // tuple is still valid, keep the op.
+        let auth = Eip7702Auth::new_dummy(ChainSpec::default().id, address(7));
+        let op = op_with_sender_and_auth(address(1), auth);
+
+        let bundle = make_bundle_with_7702_states(
+            vec![MockOp {
+                op: op.clone(),
+                simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                perms: UserOperationPermissions::default(),
+            }],
+            vec![(address(1), 0, Bytes::new())],
+        )
+        .await;
+
+        assert_eq!(bundle.rejected_ops, vec![]);
+        assert_eq!(
+            bundle.ops_per_aggregator,
+            vec![UserOpsPerAggregator {
+                user_ops: vec![op],
+                ..Default::default()
+            }]
+        );
+    }
+
     struct MockOp {
         op: UserOperation,
         simulation_result: Box<dyn Fn() -> Result<SimulationResult, SimulationError> + Send + Sync>,
@@ -4307,6 +4497,33 @@ mod tests {
             proxy,
             max_bundle_fee,
             max_transaction_size_bytes,
+            vec![],
+        )
+        .await
+        .expect("should make a bundle")
+    }
+
+    // Make a bundle with default settings and the given EIP-7702 sender states
+    // (sender, transaction count, code).
+    async fn make_bundle_with_7702_states(
+        mock_ops: Vec<MockOp>,
+        mock_7702_sender_states: Vec<(Address, u64, Bytes)>,
+    ) -> Bundle<UserOperation> {
+        mock_make_bundle_allow_error(
+            mock_ops,
+            vec![],
+            vec![HandleOpsOut::Success],
+            vec![],
+            0,
+            0,
+            false,
+            ExpectedStorage::default(),
+            false,
+            vec![],
+            None,
+            U256::MAX,
+            None,
+            mock_7702_sender_states,
         )
         .await
         .expect("should make a bundle")
@@ -4327,6 +4544,7 @@ mod tests {
         proxy: Option<MockSubmissionProxy>,
         max_bundle_fee: U256,
         max_transaction_size_bytes: Option<usize>,
+        mock_7702_sender_states: Vec<(Address, u64, Bytes)>,
     ) -> BundleProposerResult<Bundle<UserOperation>> {
         let mut chain_spec = ChainSpec {
             da_pre_verification_gas: da_gas_tracking_enabled,
@@ -4405,6 +4623,17 @@ mod tests {
         provider
             .expect_get_latest_block_hash_and_number()
             .returning(move || Ok((current_block_hash, 0)));
+
+        for (sender, transaction_count, code) in mock_7702_sender_states {
+            provider
+                .expect_get_transaction_count()
+                .withf(move |&a| a == sender)
+                .returning(move |_| Ok(transaction_count));
+            provider
+                .expect_get_code()
+                .withf(move |&a, _| a == sender)
+                .returning(move |_, _| Ok(code.clone()));
+        }
 
         let bundle_fees = GasFees {
             max_fee_per_gas: base_fee + max_priority_fee_per_gas,
@@ -4647,6 +4876,25 @@ mod tests {
 
     fn op_from_required(required: UserOperationRequiredFields) -> UserOperation {
         UserOperationBuilder::new(&ChainSpec::default(), required).build()
+    }
+
+    fn op_with_sender_and_auth(sender: Address, auth: Eip7702Auth) -> UserOperation {
+        UserOperationBuilder::new(
+            &ChainSpec::default(),
+            UserOperationRequiredFields {
+                sender,
+                pre_verification_gas: DEFAULT_PVG,
+                ..Default::default()
+            },
+        )
+        .authorization_tuple(auth)
+        .build()
+    }
+
+    fn eip7702_delegated_code(delegate: Address) -> Bytes {
+        [&[0xef, 0x01, 0x00][..], delegate.as_slice()]
+            .concat()
+            .into()
     }
 
     fn mock_signature_aggregator(address: Address, signature: Bytes) -> MockSignatureAggregator {

--- a/crates/builder/src/emit.rs
+++ b/crates/builder/src/emit.rs
@@ -200,6 +200,9 @@ pub enum OpRejectionReason {
     ConditionNotMet(ConditionNotMetReason),
     /// Current time is outside of the operation's valid time range
     InvalidTimeRange { valid_range: ValidTimeRange },
+    /// Operation's EIP-7702 authorization tuple has a stale nonce and its
+    /// sender is not delegated to the tuple's address
+    StaleEip7702Auth { chain_nonce: u64, auth_nonce: u64 },
 }
 
 /// Reason for a condition not being met

--- a/crates/sim/src/precheck.rs
+++ b/crates/sim/src/precheck.rs
@@ -28,7 +28,7 @@ use rundler_types::{
     pool::{MempoolError, PrecheckViolation},
     v0_7::EIP7702_FACTORY_MARKER,
 };
-use rundler_utils::math;
+use rundler_utils::{authorization_utils, math};
 use tracing::instrument;
 
 use crate::{gas, types::ViolationError};
@@ -190,7 +190,8 @@ where
             da_gas_data: async_data.da_gas_data,
             required_pre_verification_gas: async_data.min_pre_verification_gas,
             sender_is_7702: op.authorization_tuple().is_some()
-                || is_7702_bytecode(&async_data.sender_bytecode),
+                || authorization_utils::eip7702_delegate_from_code(&async_data.sender_bytecode)
+                    .is_some(),
         })
     }
 }
@@ -250,7 +251,9 @@ where
                 op.sender(),
             ));
         // EIP-7702 disabled case
-        } else if perms.eip7702_disabled && is_7702_bytecode(sender_bytecode) {
+        } else if perms.eip7702_disabled
+            && authorization_utils::eip7702_delegate_from_code(sender_bytecode).is_some()
+        {
             violations.push(PrecheckViolation::Eip7702Disabled);
         }
 
@@ -624,14 +627,6 @@ where
             pending_transaction_count,
         }))
     }
-}
-
-fn is_7702_bytecode(bytecode: &Bytes) -> bool {
-    if bytecode.len() < 23 {
-        return false;
-    }
-    let prefix = &bytecode[..3];
-    prefix == [0xef, 0x01, 0x00]
 }
 
 #[cfg(test)]

--- a/crates/utils/src/authorization_utils.rs
+++ b/crates/utils/src/authorization_utils.rs
@@ -16,6 +16,9 @@
 use alloy_primitives::{Address, FixedBytes, fixed_bytes};
 use alloy_rpc_types_eth::state::{AccountOverride, StateOverride};
 
+/// EIP-7702 delegation designator prefix
+const DELEGATION_PREFIX: FixedBytes<3> = fixed_bytes!("ef0100");
+
 /// Apply a [7702](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md)
 /// overrides to `StateOverride`.
 pub fn apply_7702_overrides(
@@ -24,12 +27,43 @@ pub fn apply_7702_overrides(
     eip7702_auth_address: Address,
 ) {
     state_override.entry(sender).or_insert({
-        let prefix: FixedBytes<3> = fixed_bytes!("ef0100");
-        let code: FixedBytes<23> = prefix.concat_const(eip7702_auth_address.into());
+        let code: FixedBytes<23> = DELEGATION_PREFIX.concat_const(eip7702_auth_address.into());
 
         AccountOverride {
             code: Some((code).into()),
             ..Default::default()
         }
     });
+}
+
+/// Extract the delegate address from an EIP-7702 delegation designator
+/// (`0xef0100 ‖ address`). Returns `None` for any other code, including empty.
+pub fn eip7702_delegate_from_code(code: &[u8]) -> Option<Address> {
+    let delegate = code.strip_prefix(DELEGATION_PREFIX.as_slice())?;
+    (delegate.len() == Address::len_bytes()).then(|| Address::from_slice(delegate))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::address;
+
+    use super::*;
+
+    #[test]
+    fn test_eip7702_delegate_from_code() {
+        let delegate = address!("0x1234567890123456789012345678901234567890");
+        let code = [DELEGATION_PREFIX.as_slice(), delegate.as_slice()].concat();
+        assert_eq!(eip7702_delegate_from_code(&code), Some(delegate));
+
+        // empty code
+        assert_eq!(eip7702_delegate_from_code(&[]), None);
+        // wrong prefix
+        let code = [&[0xef, 0x01, 0x01][..], delegate.as_slice()].concat();
+        assert_eq!(eip7702_delegate_from_code(&code), None);
+        // truncated delegate
+        assert_eq!(eip7702_delegate_from_code(&code[..22]), None);
+        // trailing bytes
+        let code = [DELEGATION_PREFIX.as_slice(), delegate.as_slice(), &[0x00]].concat();
+        assert_eq!(eip7702_delegate_from_code(&code), None);
+    }
 }


### PR DESCRIPTION
## Proposed Changes

Closes the EIP-7702 staleness window behind the empty-revert bundle livelock incident (fix 2 from the investigation; fix 1, no-data revert handling, landed in #1300).

Auth tuple nonces are only validated at pool entry, and every later simulation bypasses real 7702 semantics via an unconditional code state override — so a tuple that goes stale in the pool reaches the bundle-validation `eth_call`, where the node skips it and the codeless sender reverts the whole `handleOps` with empty, unattributable revert data.

  - At bundle proposal time, batch-fetch the transaction count and delegation status (`eth_getTransactionCount` + `eth_getCode`) of every sender carrying an auth tuple. Runs concurrently with re-simulation and the paymaster balance fetch, so no added latency and no extra RPCs for bundles without 7702 ops.
  - In `assemble_context`, reject an op whose tuple nonce is stale unless the sender is already delegated to the tuple's address. Rejection uses the normal `rejected_ops` path, so only the poison op is removed from the pool — innocent ops in the same bundle proceed.
  - New `OpRejectionReason::StaleEip7702Auth` event variant and `builder_proposer_stale_eip7702_auth_rejections` counter for observability.
  - New `authorization_utils::eip7702_delegate_from_code` helper that strictly parses the `0xef0100 ‖ address` delegation designator.

Verdict table for an op carrying an auth tuple:

| Chain state | Outcome |
|---|---|
| Tuple nonce == sender tx count | Keep (tuple still valid) |
| Stale nonce, sender delegated to tuple's address | Keep (delegation already landed) |
| Stale nonce, sender codeless or delegated elsewhere | Reject just that op |

Tests cover all three verdicts plus the multi-op case (poison op rejected, innocent op still bundled) and designator parsing edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)