### PR TITLE
chore(hooks): avoid cog latest-tag lookup in pre-push hook

### DIFF
--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -2,7 +2,20 @@
 
 echo 'Running pre-push hook...'
 
-if cog check -l; then
+# Resolve the latest tag with git instead of `cog check -l`: cog's libgit2
+# tag lookup mis-detects the working directory in symlinked .git layouts
+# (e.g. `repo` tool workspaces), fails to load cog.toml, and errors with
+# "unable to get any tag". Passing an explicit range avoids the lookup;
+# --ignore-merge-commits is passed explicitly for the same reason.
+latest_tag=$(git describe --tags --abbrev=0 2>/dev/null)
+
+if [ -n "$latest_tag" ]; then
+    set -- --ignore-merge-commits "$latest_tag..HEAD"
+else
+    set -- --from-latest-tag
+fi
+
+if cog check "$@"; then
     exit 0
 fi
 


### PR DESCRIPTION
## Problem

In checkouts where `.git` resolves through symlinks (e.g. Google `repo` tool workspaces, where `rundler/.git` points into `.repo/projects/rundler.git`), the pre-push hook fails on **every** push with:

```
Error: unable to get any tag
Invalid commits were found, force push with '--no-verify'
```

cog uses libgit2, which canonicalizes the git dir path and mis-derives the working directory as the *parent of the real git dir* (`.repo/projects/`). It then can't find `cog.toml`, loses `tag_prefix = "v"`, silently fails to semver-parse every `v*` tag, and `cog check -l` errors out. Plain git handles the layout fine, so only cog's tag lookup breaks. Normal clones are unaffected.

## Fix

Resolve the latest tag with `git describe --tags --abbrev=0` and pass cog an explicit range, sidestepping its tag lookup. `--ignore-merge-commits` is now passed explicitly since that setting also comes from the unloadable `cog.toml`. Falls back to `cog check -l` when no tag is reachable.

## Testing

- Hook passes in a repo-tool checkout (previously always failed)
- Hook passes in a fresh normal clone
- Hook still rejects a non-conventional commit (verified with a dummy commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)