### PR TITLE
feat(chain-specs): add GIWA Sepolia (91342) hardcoded chain spec

### DIFF
--- a/bin/rundler/chain_specs/giwa_sepolia.toml
+++ b/bin/rundler/chain_specs/giwa_sepolia.toml
@@ -1,0 +1,12 @@
+name = "GIWA Sepolia"
+id = 91342
+
+da_pre_verification_gas = true
+da_gas_oracle_type = "OPTIMISM_BEDROCK"
+da_gas_oracle_contract_address = "0x420000000000000000000000000000000000000F"
+
+priority_fee_oracle_type = "USAGE_BASED"
+min_max_priority_fee_per_gas = 100000
+block_gas_limit = 60000000
+eip7702_enabled = true
+eip7623_enabled = true

--- a/bin/rundler/src/cli/chain_spec.rs
+++ b/bin/rundler/src/cli/chain_spec.rs
@@ -117,6 +117,7 @@ define_hardcoded_chain_specs!(
     optimism_sepolia,
     base,
     base_sepolia,
+    giwa_sepolia,
     arbitrum,
     arbitrum_sepolia,
     polygon,


### PR DESCRIPTION
## Proposed Changes

- Add a hardcoded chain spec for **GIWA Sepolia** (chain id **91342**), the public testnet of [GIWA](https://giwa.io), an OP Stack L2 built by Upbit/Dunamu
- Register `giwa_sepolia` in `define_hardcoded_chain_specs!`

### Values verified against the live network

Via the public RPC (`https://sepolia-rpc.giwa.io`):

- block gas limit **60,000,000** (`eth_getBlockByNumber`)
- `GasPriceOracle` predeploy (`0x420...000F`) reports **Ecotone/Fjord/Isthmus** active (version 1.6.0) → `eip7702_enabled` / `eip7623_enabled` set to true
- standard OP Bedrock DA gas oracle predeploy → `OPTIMISM_BEDROCK` DA oracle type

### Tested

We operate a self-hosted Rundler (EntryPoint v0.7, single-operator) against GIWA Sepolia. A live UserOperation submitted through a Rundler running **this exact spec file**:

- bundle tx: https://sepolia-explorer.giwa.io/tx/0x26992929b1e32debdbe666c2c75123e1860026b55fb0673f7acf91e2c380882d
- UserOperation: https://sepolia-explorer.giwa.io/op/0xd8bc6e6f45c71e4995fb65809633d352fe24989153427db8361111ddeda7c689

`cargo check -p rundler` passes. Note: GIWA's own fork (giwa-io/rundler) previously upstreamed #1215; no public chain spec for GIWA existed until now.