### PR TITLE
fix(types): lower user op time range buffer to 20s

### DIFF
--- a/crates/types/src/user_operation/mod.rs
+++ b/crates/types/src/user_operation/mod.rs
@@ -29,7 +29,7 @@ pub mod v0_7;
 use crate::{Entity, aggregator::AggregatorCosts, authorization::Eip7702Auth, chain::ChainSpec};
 
 /// A user op must be valid for at least this long into the future to be included.
-pub const TIME_RANGE_BUFFER: Duration = Duration::from_secs(60);
+pub const TIME_RANGE_BUFFER: Duration = Duration::from_secs(20);
 
 /// Overhead for bytes required for each bundle
 /// 4 bytes for function signature


### PR DESCRIPTION
## Proposed Changes

  - Lower `TIME_RANGE_BUFFER` from 60s to 20s — the minimum remaining validity window a user op must have to be included.
  - Effect: user ops with short-lived expirations (e.g. a 1-minute `validUntil`) are no longer rejected at `eth_sendUserOperation` or skipped during bundle assembly, as long as at least 20s of validity remain.
  - This is enforced against the intersected account + paymaster `validUntil`, so it applies to all user ops, not just bundler-sponsored ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)