### PR TITLE
feat(builder): classify submission errors as terminal, non-terminal, or neutral

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5416,11 +5416,13 @@ version = "0.11.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
+ "alloy-transport",
  "anyhow",
  "async-trait",
  "enum_dispatch",

--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -333,6 +333,7 @@ impl BuilderArgs {
         let raw_args = || RawSenderArgs {
             submit_url: self.submit_url.clone().unwrap_or_else(|| rpc_url.into()),
             use_conditional_rpc: false,
+            internal_rpc_error_is_terminal: chain_spec.internal_rpc_error_is_terminal,
         };
 
         // Wrap `primary` in a FallbackSenderArgs if recovery is configured.
@@ -353,6 +354,7 @@ impl BuilderArgs {
             TransactionSenderKind::Raw => Ok(TransactionSenderArgs::Raw(RawSenderArgs {
                 submit_url: self.submit_url.clone().unwrap_or_else(|| rpc_url.into()),
                 use_conditional_rpc: self.use_conditional_rpc,
+                internal_rpc_error_is_terminal: chain_spec.internal_rpc_error_is_terminal,
             })),
             TransactionSenderKind::PolygonPrivate => {
                 let primary = TransactionSenderArgs::PolygonPrivate(PolygonPrivateArgs {

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -46,7 +46,9 @@ tonic-reflection.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+alloy-json-rpc.workspace = true
 alloy-rpc-types-eth.workspace = true
+alloy-transport.workspace = true
 mockall.workspace = true
 rundler-provider = { workspace = true, features = ["test-utils"] }
 rundler-sim = { workspace = true, features = ["test-utils"] }

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -662,7 +662,11 @@ where
                 self.assigner.release_all(self.sender_eoa);
                 state.reset();
             }
-            Err(TransactionTrackerError::Other(e)) => {
+            Err(
+                e @ (TransactionTrackerError::SenderUnavailable(_)
+                | TransactionTrackerError::UnrecognizedRpc { .. }
+                | TransactionTrackerError::Other(_)),
+            ) => {
                 error!("Failed to cancel transaction, moving back to building state: {e:#?}");
                 self.increment_counter("builder_cancellation_txns_failed", &pinned, 1);
                 self.assigner.release_all(self.sender_eoa);
@@ -998,9 +1002,13 @@ where
                 error!("Bundle attempt insufficient funds");
                 Ok(SendBundleAttemptResult::InsufficientFunds)
             }
-            Err(TransactionTrackerError::Other(e)) => {
-                error!("Failed to send bundle with unexpected error: {e:?}");
-                if Self::is_intrinsic_gas_too_low_error(&e) {
+            Err(TransactionTrackerError::SenderUnavailable(e)) => {
+                error!("Failed to send bundle, sender unavailable: {e:?}");
+                Err(e)
+            }
+            Err(TransactionTrackerError::UnrecognizedRpc { code, message }) => {
+                error!("Failed to send bundle with unrecognized RPC error {code}: {message}");
+                if Self::is_intrinsic_gas_too_low_error(&message) {
                     let tx_bytes = tx.input.input().map_or_else(
                         || String::from("0x"),
                         |data| format!("0x{}", hex::encode(data)),
@@ -1009,15 +1017,17 @@ where
                         "Bundle transaction bytes for intrinsic gas too low: tx_bytes={tx_bytes}"
                     );
                 }
+                Err(anyhow::anyhow!("unrecognized RPC error {code}: {message}"))
+            }
+            Err(TransactionTrackerError::Other(e)) => {
+                error!("Failed to send bundle with unexpected error: {e:?}");
                 Err(e)
             }
         }
     }
 
-    fn is_intrinsic_gas_too_low_error(error: &anyhow::Error) -> bool {
-        format!("{error:#}")
-            .to_lowercase()
-            .contains("intrinsic gas too low")
+    fn is_intrinsic_gas_too_low_error(message: &str) -> bool {
+        message.to_lowercase().contains("intrinsic gas too low")
     }
 
     /// Emits an event for a specific entrypoint (used for shared signer support)

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -664,6 +664,7 @@ where
             }
             Err(
                 e @ (TransactionTrackerError::IntrinsicGasTooLow
+                | TransactionTrackerError::TerminalRpcError { .. }
                 | TransactionTrackerError::SenderUnavailable(_)
                 | TransactionTrackerError::UnrecognizedRpc { .. }
                 | TransactionTrackerError::Other(_)),
@@ -1014,6 +1015,10 @@ where
                 );
                 error!("Bundle transaction intrinsic gas too low: tx_bytes={tx_bytes}");
                 Err(anyhow::anyhow!("intrinsic gas too low"))
+            }
+            Err(TransactionTrackerError::TerminalRpcError { code, message }) => {
+                error!("Failed to send bundle with terminal RPC error {code}: {message}");
+                Err(anyhow::anyhow!("terminal RPC error {code}: {message}"))
             }
             Err(TransactionTrackerError::UnrecognizedRpc { code, message }) => {
                 error!("Failed to send bundle with unrecognized RPC error {code}: {message}");

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -663,7 +663,8 @@ where
                 state.reset();
             }
             Err(
-                e @ (TransactionTrackerError::SenderUnavailable(_)
+                e @ (TransactionTrackerError::IntrinsicGasTooLow
+                | TransactionTrackerError::SenderUnavailable(_)
                 | TransactionTrackerError::UnrecognizedRpc { .. }
                 | TransactionTrackerError::Other(_)),
             ) => {
@@ -1006,17 +1007,16 @@ where
                 error!("Failed to send bundle, sender unavailable: {e:?}");
                 Err(e)
             }
+            Err(TransactionTrackerError::IntrinsicGasTooLow) => {
+                let tx_bytes = tx.input.input().map_or_else(
+                    || String::from("0x"),
+                    |data| format!("0x{}", hex::encode(data)),
+                );
+                error!("Bundle transaction intrinsic gas too low: tx_bytes={tx_bytes}");
+                Err(anyhow::anyhow!("intrinsic gas too low"))
+            }
             Err(TransactionTrackerError::UnrecognizedRpc { code, message }) => {
                 error!("Failed to send bundle with unrecognized RPC error {code}: {message}");
-                if Self::is_intrinsic_gas_too_low_error(&message) {
-                    let tx_bytes = tx.input.input().map_or_else(
-                        || String::from("0x"),
-                        |data| format!("0x{}", hex::encode(data)),
-                    );
-                    error!(
-                        "Bundle transaction bytes for intrinsic gas too low: tx_bytes={tx_bytes}"
-                    );
-                }
                 Err(anyhow::anyhow!("unrecognized RPC error {code}: {message}"))
             }
             Err(TransactionTrackerError::Other(e)) => {
@@ -1024,10 +1024,6 @@ where
                 Err(e)
             }
         }
-    }
-
-    fn is_intrinsic_gas_too_low_error(message: &str) -> bool {
-        message.to_lowercase().contains("intrinsic gas too low")
     }
 
     /// Emits an event for a specific entrypoint (used for shared signer support)

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -42,6 +42,7 @@ use crate::{
     assigner::{Assigner, AssignmentResult},
     bundle_proposer::{BundleData, BundleProposalRequest, BundleProposerError, BundleProposerT},
     emit::{BuilderEvent, BundleTxDetails},
+    sender::TxSenderError,
     transaction_tracker::{
         TrackerState, TrackerUpdate, TransactionTracker, TransactionTrackerError,
     },
@@ -618,9 +619,11 @@ where
                 self.increment_counter("builder_soft_cancellations", &pinned, 1);
                 state.reset();
             }
-            Err(TransactionTrackerError::Rejected)
-            | Err(TransactionTrackerError::Underpriced)
-            | Err(TransactionTrackerError::ReplacementUnderpriced) => {
+            Err(TransactionTrackerError::Sender(
+                TxSenderError::Rejected
+                | TxSenderError::Underpriced
+                | TxSenderError::ReplacementUnderpriced,
+            )) => {
                 info!(
                     "Transaction underpriced/rejected during cancellation, trying again. {cancel_res:?}"
                 );
@@ -642,19 +645,19 @@ where
                     state.update(InnerState::Cancelling(inner.to_self()));
                 }
             }
-            Err(TransactionTrackerError::NonceTooLow) => {
+            Err(TransactionTrackerError::Sender(TxSenderError::NonceTooLow)) => {
                 // reset the transaction tracker and try again
                 info!("Nonce too low during cancellation, starting new bundle attempt");
                 self.assigner.release_all(self.sender_eoa);
                 state.reset();
             }
-            Err(TransactionTrackerError::InsufficientFunds) => {
+            Err(TransactionTrackerError::Sender(TxSenderError::InsufficientFunds)) => {
                 error!("Insufficient funds during cancellation, starting new bundle attempt");
                 self.increment_counter("builder_cancellation_txns_failed", &pinned, 1);
                 self.assigner.release_all(self.sender_eoa);
                 state.reset();
             }
-            Err(TransactionTrackerError::ConditionNotMet) => {
+            Err(TransactionTrackerError::Sender(TxSenderError::ConditionNotMet)) => {
                 error!(
                     "Unexpected condition not met during cancellation, starting new bundle attempt"
                 );
@@ -662,13 +665,7 @@ where
                 self.assigner.release_all(self.sender_eoa);
                 state.reset();
             }
-            Err(
-                e @ (TransactionTrackerError::IntrinsicGasTooLow
-                | TransactionTrackerError::TerminalRpcError { .. }
-                | TransactionTrackerError::SenderUnavailable(_)
-                | TransactionTrackerError::UnrecognizedRpc { .. }
-                | TransactionTrackerError::Other(_)),
-            ) => {
+            Err(e) => {
                 error!("Failed to cancel transaction, moving back to building state: {e:#?}");
                 self.increment_counter("builder_cancellation_txns_failed", &pinned, 1);
                 self.assigner.release_all(self.sender_eoa);
@@ -974,58 +971,68 @@ where
 
                 Ok(SendBundleAttemptResult::Success(ops))
             }
-            Err(TransactionTrackerError::NonceTooLow) => {
-                self.increment_counter_ep("builder_bundle_txn_nonce_too_low", entry_point, 1);
-                warn!("Bundle attempt nonce too low");
-                Ok(SendBundleAttemptResult::NonceTooLow)
-            }
-            Err(TransactionTrackerError::Underpriced) => {
-                self.increment_counter_ep("builder_bundle_txn_underpriced", entry_point, 1);
-                warn!("Bundle attempt underpriced");
-                Ok(SendBundleAttemptResult::Underpriced)
-            }
-            Err(TransactionTrackerError::ReplacementUnderpriced) => {
-                self.increment_counter_ep("builder_bundle_replacement_underpriced", entry_point, 1);
-                warn!("Bundle attempt replacement transaction underpriced");
-                Ok(SendBundleAttemptResult::ReplacementUnderpriced)
-            }
-            Err(TransactionTrackerError::ConditionNotMet) => {
-                self.increment_counter_ep("builder_bundle_txn_condition_not_met", entry_point, 1);
-                warn!("Bundle attempt condition not met");
-                Ok(SendBundleAttemptResult::ConditionNotMet)
-            }
-            Err(TransactionTrackerError::Rejected) => {
-                self.increment_counter_ep("builder_bundle_txn_rejected", entry_point, 1);
-                warn!("Bundle attempt rejected");
-                Ok(SendBundleAttemptResult::Rejected)
-            }
-            Err(TransactionTrackerError::InsufficientFunds) => {
-                self.increment_counter_ep("builder_bundle_txn_insufficient_funds", entry_point, 1);
-                error!("Bundle attempt insufficient funds");
-                Ok(SendBundleAttemptResult::InsufficientFunds)
-            }
-            Err(TransactionTrackerError::SenderUnavailable(e)) => {
-                error!("Failed to send bundle, sender unavailable: {e:?}");
-                Err(e)
-            }
-            Err(TransactionTrackerError::IntrinsicGasTooLow) => {
-                let tx_bytes = tx.input.input().map_or_else(
-                    || String::from("0x"),
-                    |data| format!("0x{}", hex::encode(data)),
-                );
-                error!("Bundle transaction intrinsic gas too low: tx_bytes={tx_bytes}");
-                Err(anyhow::anyhow!("intrinsic gas too low"))
-            }
-            Err(TransactionTrackerError::TerminalRpcError { code, message }) => {
-                error!("Failed to send bundle with terminal RPC error {code}: {message}");
-                Err(anyhow::anyhow!("terminal RPC error {code}: {message}"))
-            }
-            Err(TransactionTrackerError::UnrecognizedRpc { code, message }) => {
-                error!("Failed to send bundle with unrecognized RPC error {code}: {message}");
-                Err(anyhow::anyhow!("unrecognized RPC error {code}: {message}"))
-            }
+            Err(TransactionTrackerError::Sender(error)) => match error {
+                TxSenderError::NonceTooLow => {
+                    self.increment_counter_ep("builder_bundle_txn_nonce_too_low", entry_point, 1);
+                    warn!("Bundle attempt nonce too low");
+                    Ok(SendBundleAttemptResult::NonceTooLow)
+                }
+                TxSenderError::Underpriced => {
+                    self.increment_counter_ep("builder_bundle_txn_underpriced", entry_point, 1);
+                    warn!("Bundle attempt underpriced");
+                    Ok(SendBundleAttemptResult::Underpriced)
+                }
+                TxSenderError::ReplacementUnderpriced => {
+                    self.increment_counter_ep(
+                        "builder_bundle_replacement_underpriced",
+                        entry_point,
+                        1,
+                    );
+                    warn!("Bundle attempt replacement transaction underpriced");
+                    Ok(SendBundleAttemptResult::ReplacementUnderpriced)
+                }
+                TxSenderError::ConditionNotMet => {
+                    self.increment_counter_ep(
+                        "builder_bundle_txn_condition_not_met",
+                        entry_point,
+                        1,
+                    );
+                    warn!("Bundle attempt condition not met");
+                    Ok(SendBundleAttemptResult::ConditionNotMet)
+                }
+                TxSenderError::Rejected => {
+                    self.increment_counter_ep("builder_bundle_txn_rejected", entry_point, 1);
+                    warn!("Bundle attempt rejected");
+                    Ok(SendBundleAttemptResult::Rejected)
+                }
+                TxSenderError::InsufficientFunds => {
+                    self.increment_counter_ep(
+                        "builder_bundle_txn_insufficient_funds",
+                        entry_point,
+                        1,
+                    );
+                    error!("Bundle attempt insufficient funds");
+                    Ok(SendBundleAttemptResult::InsufficientFunds)
+                }
+                TxSenderError::IntrinsicGasTooLow => {
+                    let tx_bytes = tx.input.input().map_or_else(
+                        || String::from("0x"),
+                        |data| format!("0x{}", hex::encode(data)),
+                    );
+                    error!("Bundle transaction intrinsic gas too low: tx_bytes={tx_bytes}");
+                    Err(anyhow::anyhow!("intrinsic gas too low"))
+                }
+                error @ (TxSenderError::TerminalRpcError { .. }
+                | TxSenderError::UnrecognizedRpc { .. }
+                | TxSenderError::SenderUnavailable(_)
+                | TxSenderError::SoftCancelFailed
+                | TxSenderError::Other(_)) => {
+                    error!("Failed to send bundle: {error}");
+                    Err(error.into())
+                }
+            },
             Err(TransactionTrackerError::Other(e)) => {
-                error!("Failed to send bundle with unexpected error: {e:?}");
+                error!("Failed to send bundle with unexpected tracker error: {e:?}");
                 Err(e)
             }
         }
@@ -2543,9 +2550,13 @@ mod tests {
         mock_make_bundle(&mut mock_proposer_t, 1, vec![(Address::ZERO, B256::ZERO)]);
 
         // should send the bundle txn, returns condition not met
-        mock_tracker
-            .expect_send_transaction()
-            .returning(|_, _, _| Box::pin(async { Err(TransactionTrackerError::ConditionNotMet) }));
+        mock_tracker.expect_send_transaction().returning(|_, _, _| {
+            Box::pin(async {
+                Err(TransactionTrackerError::Sender(
+                    TxSenderError::ConditionNotMet,
+                ))
+            })
+        });
 
         // Sender will set condition_not_met flag and pass it to next make_bundle call
         // (tested implicitly via state transition to Building with retry)

--- a/crates/builder/src/sender/fallback.rs
+++ b/crates/builder/src/sender/fallback.rs
@@ -320,6 +320,32 @@ mod tests {
         }
     }
 
+    struct ErrSender {
+        make: fn() -> TxSenderError,
+    }
+
+    #[async_trait::async_trait]
+    impl TransactionSender for ErrSender {
+        async fn send_transaction(
+            &self,
+            _tx: TransactionRequest,
+            _expected_storage: &ExpectedStorage,
+            _signer: &SignerLease,
+        ) -> super::Result<B256> {
+            Err((self.make)())
+        }
+
+        async fn cancel_transaction(
+            &self,
+            _tx_hash: B256,
+            _nonce: u64,
+            _gas_fees: GasFees,
+            _signer: &SignerLease,
+        ) -> super::Result<CancelTxInfo> {
+            unimplemented!()
+        }
+    }
+
     fn make_sender(
         primary: impl TransactionSender + 'static,
         fallback: impl TransactionSender + 'static,
@@ -427,6 +453,64 @@ mod tests {
             .unwrap();
         assert_eq!(hash, fallback_hash);
         assert!(sender.last_tx_used_fallback.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn unrecognized_rpc_activates_fallback_at_threshold() {
+        let fallback_hash = B256::repeat_byte(0x02);
+        let sender = make_sender(
+            ErrSender {
+                make: || TxSenderError::UnrecognizedRpc {
+                    code: -32000,
+                    message: "internal error".to_string(),
+                },
+            },
+            AlwaysOkSender {
+                hash: fallback_hash,
+            },
+            60,
+            1,
+        );
+
+        let hash = sender
+            .send_transaction(
+                TransactionRequest::default(),
+                &ExpectedStorage::default(),
+                &test_signer(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(hash, fallback_hash);
+    }
+
+    #[tokio::test]
+    async fn terminal_error_does_not_activate_fallback() {
+        let sender = make_sender(
+            ErrSender {
+                make: || TxSenderError::TerminalRpcError {
+                    code: -32000,
+                    message: "internal error".to_string(),
+                },
+            },
+            AlwaysOkSender {
+                hash: B256::repeat_byte(0x02),
+            },
+            60,
+            1,
+        );
+
+        let result = sender
+            .send_transaction(
+                TransactionRequest::default(),
+                &ExpectedStorage::default(),
+                &test_signer(),
+            )
+            .await;
+        assert!(matches!(
+            result,
+            Err(TxSenderError::TerminalRpcError { .. })
+        ));
+        assert!(matches!(sender.current_sender(), ActiveSender::Primary));
     }
 
     #[tokio::test]

--- a/crates/builder/src/sender/fallback.rs
+++ b/crates/builder/src/sender/fallback.rs
@@ -39,7 +39,7 @@ struct FallbackSenderMetrics {
     #[metric(describe = "total successful sends via the fallback")]
     fallback_sends: Counter,
     #[metric(
-        describe = "total SenderUnavailable errors from the primary, including those below the failover threshold"
+        describe = "total failover-eligible errors from the primary, including those below the failover threshold"
     )]
     primary_unavailable: Counter,
 }
@@ -51,7 +51,8 @@ enum ActiveSender {
 }
 
 /// A transaction sender that transparently fails over to a fallback sender when
-/// the primary returns [`TxSenderError::SenderUnavailable`].
+/// the primary returns [`TxSenderError::SenderUnavailable`] or
+/// [`TxSenderError::UnrecognizedRpc`].
 ///
 /// Recovery is passive: after `recovery_interval` has elapsed the next send
 /// attempt re-tries the primary. On success the primary is reinstated; on
@@ -168,7 +169,9 @@ impl TransactionSender for FallbackTransactionSender {
                 self.metrics.primary_sends.increment(1);
                 Ok(hash)
             }
-            Err(TxSenderError::SenderUnavailable(e)) => {
+            Err(
+                e @ (TxSenderError::SenderUnavailable(_) | TxSenderError::UnrecognizedRpc { .. }),
+            ) => {
                 self.metrics.primary_unavailable.increment(1);
                 let failures = self.consecutive_failures.fetch_add(1, Ordering::AcqRel) + 1;
                 if failures >= self.failure_threshold {
@@ -188,7 +191,7 @@ impl TransactionSender for FallbackTransactionSender {
                         error = %e,
                         "Primary sender unavailable, will activate fallback after threshold"
                     );
-                    Err(TxSenderError::SenderUnavailable(e))
+                    Err(e)
                 }
             }
             Err(e) => Err(e),

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -71,6 +71,9 @@ pub(crate) enum TxSenderError {
     /// Insufficient funds for transaction
     #[error("insufficient funds for transaction")]
     InsufficientFunds,
+    /// Transaction gas limit is below its intrinsic gas cost
+    #[error("intrinsic gas too low")]
+    IntrinsicGasTooLow,
     /// Sender is unavailable due to an outage or transport error.
     ///
     /// When a fallback sender is configured this triggers failover.
@@ -112,6 +115,7 @@ impl TxSenderError {
     #[allow(dead_code)] // consumed once the bundle sender reports outcomes to the pool
     pub(crate) fn classify(&self) -> RpcOutcomeClass {
         match self {
+            TxSenderError::IntrinsicGasTooLow => RpcOutcomeClass::Terminal,
             TxSenderError::SenderUnavailable(_) | TxSenderError::UnrecognizedRpc { .. } => {
                 RpcOutcomeClass::NonTerminal
             }
@@ -355,6 +359,7 @@ impl From<TransactionSubmissionError> for TxSenderError {
             TransactionSubmissionError::ConditionNotMet => Self::ConditionNotMet,
             TransactionSubmissionError::Rejected => Self::Rejected,
             TransactionSubmissionError::InsufficientFunds => Self::InsufficientFunds,
+            TransactionSubmissionError::IntrinsicGasTooLow => Self::IntrinsicGasTooLow,
         }
     }
 }

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -71,14 +71,60 @@ pub(crate) enum TxSenderError {
     /// Insufficient funds for transaction
     #[error("insufficient funds for transaction")]
     InsufficientFunds,
-    /// Sender is unavailable due to an outage or unrecognized error.
+    /// Sender is unavailable due to an outage or transport error.
     ///
     /// When a fallback sender is configured this triggers failover.
     #[error("sender unavailable: {0}")]
     SenderUnavailable(anyhow::Error),
+    /// The provider returned an RPC error response that Rundler does not recognize.
+    ///
+    /// The node judged the transaction but the meaning is unknown, so acceptance is
+    /// ambiguous. When a fallback sender is configured this triggers failover.
+    #[error("unrecognized RPC error {code}: {message}")]
+    UnrecognizedRpc {
+        /// RPC error code.
+        code: i64,
+        /// RPC error message.
+        message: String,
+    },
     /// All other errors
     #[error(transparent)]
     Other(#[from] anyhow::Error),
+}
+
+/// Classification of a submission failure for poison user operation handling.
+///
+/// See `docs/designs/poison-user-operations.md`.
+#[allow(dead_code)] // consumed once the bundle sender reports outcomes to the pool
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RpcOutcomeClass {
+    /// Final rejection; retrying the identical transaction cannot succeed.
+    Terminal,
+    /// Transport failure, timeout, outage, or ambiguous rejection; acceptance unknown.
+    NonTerminal,
+    /// Known operational error with dedicated handling; evidence of neither user
+    /// operation poison nor provider health.
+    Neutral,
+}
+
+impl TxSenderError {
+    /// Classifies this error for poison user operation handling.
+    #[allow(dead_code)] // consumed once the bundle sender reports outcomes to the pool
+    pub(crate) fn classify(&self) -> RpcOutcomeClass {
+        match self {
+            TxSenderError::SenderUnavailable(_) | TxSenderError::UnrecognizedRpc { .. } => {
+                RpcOutcomeClass::NonTerminal
+            }
+            TxSenderError::Underpriced
+            | TxSenderError::ReplacementUnderpriced
+            | TxSenderError::NonceTooLow
+            | TxSenderError::ConditionNotMet
+            | TxSenderError::Rejected
+            | TxSenderError::SoftCancelFailed
+            | TxSenderError::InsufficientFunds
+            | TxSenderError::Other(_) => RpcOutcomeClass::Neutral,
+        }
+    }
 }
 
 pub(crate) type Result<T> = std::result::Result<T, TxSenderError>;
@@ -274,18 +320,15 @@ impl From<ProviderError> for TxSenderError {
                     if let Some(known) = parse_known_call_execution_failed(&e.message, e.code) {
                         return known;
                     }
-                    // Unrecognized RPC error: -32000s from us should be rare, so treat
-                    // as a provider outage and log for debugging.
                     tracing::warn!(
                         rpc_error_code = e.code,
                         rpc_error_message = %e.message,
-                        "Unrecognized RPC error from provider, treating as sender unavailable"
+                        "Unrecognized RPC error response from provider"
                     );
-                    TxSenderError::SenderUnavailable(anyhow::anyhow!(
-                        "unrecognized RPC error {}: {}",
-                        e.code,
-                        e.message
-                    ))
+                    TxSenderError::UnrecognizedRpc {
+                        code: e.code,
+                        message: e.message.to_string(),
+                    }
                 } else {
                     tracing::warn!(
                         error = ?value,

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -17,6 +17,8 @@ mod flashbots;
 mod polygon_private;
 mod raw;
 
+#[cfg(test)]
+use alloy_json_rpc::{ErrorPayload, RpcError};
 use alloy_primitives::{Address, B256};
 use anyhow::Context;
 pub(crate) use bloxroute::PolygonBloxrouteTransactionSender;
@@ -337,6 +339,16 @@ pub(crate) enum SenderConstructorErrors {
     Other(#[from] anyhow::Error),
 }
 
+/// Builds the `ProviderError` for a JSON-RPC error response, for tests.
+#[cfg(test)]
+pub(crate) fn rpc_error_response(code: i64, message: &str) -> ProviderError {
+    ProviderError::RPC(RpcError::ErrorResp(ErrorPayload {
+        code,
+        message: message.to_string().into(),
+        data: None,
+    }))
+}
+
 fn create_hard_cancel_tx(to: Address, nonce: u64, gas_fees: GasFees) -> TransactionRequest {
     TransactionRequest::default()
         .to(to)
@@ -397,7 +409,100 @@ impl From<TransactionSubmissionError> for TxSenderError {
 
 #[cfg(test)]
 mod tests {
-    use super::TxSenderError;
+    use alloy_transport::TransportErrorKind;
+    use rundler_provider::ProviderError;
+
+    use super::{RpcOutcomeClass, TxSenderError};
+
+    #[test]
+    fn classifies_rpc_outcomes() {
+        let cases = [
+            (TxSenderError::IntrinsicGasTooLow, RpcOutcomeClass::Terminal),
+            (
+                TxSenderError::TerminalRpcError {
+                    code: -32000,
+                    message: "internal error".to_string(),
+                },
+                RpcOutcomeClass::Terminal,
+            ),
+            (
+                TxSenderError::SenderUnavailable(anyhow::anyhow!("connection refused")),
+                RpcOutcomeClass::NonTerminal,
+            ),
+            (
+                TxSenderError::UnrecognizedRpc {
+                    code: -32000,
+                    message: "internal error".to_string(),
+                },
+                RpcOutcomeClass::NonTerminal,
+            ),
+            (TxSenderError::Underpriced, RpcOutcomeClass::Neutral),
+            (TxSenderError::NonceTooLow, RpcOutcomeClass::Neutral),
+            (
+                TxSenderError::Other(anyhow::anyhow!("signing failed")),
+                RpcOutcomeClass::Neutral,
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.classify(), expected, "error: {error}");
+        }
+    }
+
+    #[test]
+    fn maps_unrecognized_rpc_response_to_unrecognized_rpc() {
+        let error = TxSenderError::from(super::rpc_error_response(-32000, "internal error"));
+
+        assert!(matches!(
+            error,
+            TxSenderError::UnrecognizedRpc { code: -32000, ref message } if message == "internal error"
+        ));
+    }
+
+    #[test]
+    fn maps_transport_failure_to_sender_unavailable() {
+        let error = TxSenderError::from(ProviderError::RPC(TransportErrorKind::custom_str(
+            "connection refused",
+        )));
+
+        assert!(matches!(error, TxSenderError::SenderUnavailable(_)));
+    }
+
+    #[test]
+    fn promotes_internal_error_to_terminal() {
+        let error = TxSenderError::UnrecognizedRpc {
+            code: -32000,
+            message: " Internal Error ".to_string(),
+        }
+        .promote_terminal_internal_error();
+
+        assert!(matches!(
+            error,
+            TxSenderError::TerminalRpcError { code: -32000, .. }
+        ));
+    }
+
+    #[test]
+    fn does_not_promote_other_errors() {
+        let cases = [
+            TxSenderError::UnrecognizedRpc {
+                code: -32603,
+                message: "internal error".to_string(),
+            },
+            TxSenderError::UnrecognizedRpc {
+                code: -32000,
+                message: "internal error: tx pool full".to_string(),
+            },
+            TxSenderError::SenderUnavailable(anyhow::anyhow!("internal error")),
+        ];
+
+        for error in cases {
+            assert!(!matches!(
+                error.promote_terminal_internal_error(),
+                TxSenderError::TerminalRpcError { .. }
+            ));
+        }
+    }
 
     #[test]
     fn parses_cronos_invalid_sequence_as_nonce_too_low() {

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -74,6 +74,18 @@ pub(crate) enum TxSenderError {
     /// Transaction gas limit is below its intrinsic gas cost
     #[error("intrinsic gas too low")]
     IntrinsicGasTooLow,
+    /// The provider rejected the transaction with an error response known to be
+    /// terminal for this chain: retrying the identical transaction cannot succeed.
+    ///
+    /// Currently produced for `-32000: internal error` on chains with
+    /// `ChainSpec::internal_rpc_error_is_terminal`.
+    #[error("terminal RPC error {code}: {message}")]
+    TerminalRpcError {
+        /// RPC error code.
+        code: i64,
+        /// RPC error message.
+        message: String,
+    },
     /// Sender is unavailable due to an outage or transport error.
     ///
     /// When a fallback sender is configured this triggers failover.
@@ -115,7 +127,9 @@ impl TxSenderError {
     #[allow(dead_code)] // consumed once the bundle sender reports outcomes to the pool
     pub(crate) fn classify(&self) -> RpcOutcomeClass {
         match self {
-            TxSenderError::IntrinsicGasTooLow => RpcOutcomeClass::Terminal,
+            TxSenderError::IntrinsicGasTooLow | TxSenderError::TerminalRpcError { .. } => {
+                RpcOutcomeClass::Terminal
+            }
             TxSenderError::SenderUnavailable(_) | TxSenderError::UnrecognizedRpc { .. } => {
                 RpcOutcomeClass::NonTerminal
             }
@@ -127,6 +141,20 @@ impl TxSenderError {
             | TxSenderError::SoftCancelFailed
             | TxSenderError::InsufficientFunds
             | TxSenderError::Other(_) => RpcOutcomeClass::Neutral,
+        }
+    }
+
+    /// On chains where the node emits `-32000: internal error` as a terminal
+    /// per-transaction rejection (`ChainSpec::internal_rpc_error_is_terminal`),
+    /// promotes that response from ambiguous to terminal.
+    pub(crate) fn promote_terminal_internal_error(self) -> Self {
+        match self {
+            TxSenderError::UnrecognizedRpc { code, message }
+                if code == -32000 && message.trim().eq_ignore_ascii_case("internal error") =>
+            {
+                TxSenderError::TerminalRpcError { code, message }
+            }
+            other => other,
         }
     }
 }
@@ -199,6 +227,8 @@ pub struct RawSenderArgs {
     pub submit_url: String,
     /// If the sender should use the conditional endpoint
     pub use_conditional_rpc: bool,
+    /// If the chain emits `-32000: internal error` as a terminal rejection
+    pub internal_rpc_error_is_terminal: bool,
 }
 
 /// Bloxroute sender arguments
@@ -260,6 +290,7 @@ impl TransactionSenderArgs {
                 TransactionSenderEnum::Raw(RawTransactionSender::new(
                     submitter,
                     args.use_conditional_rpc,
+                    args.internal_rpc_error_is_terminal,
                 ))
             }
             Self::Flashbots(args) => TransactionSenderEnum::Flashbots(

--- a/crates/builder/src/sender/raw.rs
+++ b/crates/builder/src/sender/raw.rs
@@ -14,18 +14,19 @@
 use alloy_primitives::B256;
 use anyhow::Context;
 use async_trait::async_trait;
-use rundler_provider::{EvmProvider, TransactionRequest};
+use rundler_provider::{EvmProvider, ProviderError, TransactionRequest};
 use rundler_signer::SignerLease;
 use rundler_types::{ExpectedStorage, GasFees};
 use serde_json::json;
 
 use super::{CancelTxInfo, Result};
-use crate::sender::{TransactionSender, create_hard_cancel_tx};
+use crate::sender::{TransactionSender, TxSenderError, create_hard_cancel_tx};
 
 #[derive(Debug)]
 pub(crate) struct RawTransactionSender<P> {
     submit_provider: P,
     use_conditional_rpc: bool,
+    internal_rpc_error_is_terminal: bool,
 }
 
 #[async_trait]
@@ -44,18 +45,18 @@ where
             .await
             .context("failed to sign transaction")?;
 
-        let tx_hash = if self.use_conditional_rpc {
+        let result = if self.use_conditional_rpc {
             self.submit_provider
                 .request(
                     "eth_sendRawTransactionConditional",
                     (raw_tx, json!({ "knownAccounts": expected_storage })),
                 )
-                .await?
+                .await
         } else {
-            self.submit_provider.send_raw_transaction(raw_tx).await?
+            self.submit_provider.send_raw_transaction(raw_tx).await
         };
 
-        Ok(tx_hash)
+        result.map_err(|e| self.map_provider_error(e))
     }
 
     async fn cancel_transaction(
@@ -72,7 +73,11 @@ where
             .await
             .context("failed to sign transaction")?;
 
-        let tx_hash = self.submit_provider.send_raw_transaction(raw_tx).await?;
+        let tx_hash = self
+            .submit_provider
+            .send_raw_transaction(raw_tx)
+            .await
+            .map_err(|e| self.map_provider_error(e))?;
 
         Ok(CancelTxInfo {
             tx_hash,
@@ -82,10 +87,24 @@ where
 }
 
 impl<P> RawTransactionSender<P> {
-    pub(crate) fn new(submit_provider: P, use_conditional_rpc: bool) -> Self {
+    pub(crate) fn new(
+        submit_provider: P,
+        use_conditional_rpc: bool,
+        internal_rpc_error_is_terminal: bool,
+    ) -> Self {
         Self {
             submit_provider,
             use_conditional_rpc,
+            internal_rpc_error_is_terminal,
+        }
+    }
+
+    fn map_provider_error(&self, error: ProviderError) -> TxSenderError {
+        let error = TxSenderError::from(error);
+        if self.internal_rpc_error_is_terminal {
+            error.promote_terminal_internal_error()
+        } else {
+            error
         }
     }
 }

--- a/crates/builder/src/sender/raw.rs
+++ b/crates/builder/src/sender/raw.rs
@@ -108,3 +108,26 @@ impl<P> RawTransactionSender<P> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rundler_provider::MockEvmProvider;
+
+    use super::*;
+    use crate::sender::rpc_error_response;
+
+    #[test]
+    fn promotes_internal_error_only_when_flagged() {
+        let flagged = RawTransactionSender::new(MockEvmProvider::new(), false, true);
+        assert!(matches!(
+            flagged.map_provider_error(rpc_error_response(-32000, "internal error")),
+            TxSenderError::TerminalRpcError { .. }
+        ));
+
+        let unflagged = RawTransactionSender::new(MockEvmProvider::new(), false, false);
+        assert!(matches!(
+            unflagged.map_provider_error(rpc_error_response(-32000, "internal error")),
+            TxSenderError::UnrecognizedRpc { .. }
+        ));
+    }
+}

--- a/crates/builder/src/transaction_tracker.rs
+++ b/crates/builder/src/transaction_tracker.rs
@@ -117,6 +117,9 @@ pub(crate) enum TransactionTrackerError {
     Rejected,
     #[error("insufficient funds")]
     InsufficientFunds,
+    /// The transaction's gas limit is below its intrinsic gas cost.
+    #[error("intrinsic gas too low")]
+    IntrinsicGasTooLow,
     /// The sender is unavailable due to an outage or transport error; acceptance
     /// of the transaction is unknown.
     #[error("sender unavailable: {0}")]
@@ -703,6 +706,7 @@ impl From<TxSenderError> for TransactionTrackerError {
             TxSenderError::ConditionNotMet => TransactionTrackerError::ConditionNotMet,
             TxSenderError::Rejected => TransactionTrackerError::Rejected,
             TxSenderError::InsufficientFunds => TransactionTrackerError::InsufficientFunds,
+            TxSenderError::IntrinsicGasTooLow => TransactionTrackerError::IntrinsicGasTooLow,
             TxSenderError::SoftCancelFailed => {
                 TransactionTrackerError::Other(anyhow::anyhow!("soft cancel failed"))
             }

--- a/crates/builder/src/transaction_tracker.rs
+++ b/crates/builder/src/transaction_tracker.rs
@@ -105,44 +105,10 @@ pub(crate) trait TransactionTracker: Send + Sync {
 /// Errors that can occur while using a `TransactionTracker`.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum TransactionTrackerError {
-    #[error("nonce too low")]
-    NonceTooLow,
-    #[error("transaction underpriced")]
-    Underpriced,
-    #[error("replacement transaction underpriced")]
-    ReplacementUnderpriced,
-    #[error("storage slot value condition not met")]
-    ConditionNotMet,
-    #[error("rejected")]
-    Rejected,
-    #[error("insufficient funds")]
-    InsufficientFunds,
-    /// The transaction's gas limit is below its intrinsic gas cost.
-    #[error("intrinsic gas too low")]
-    IntrinsicGasTooLow,
-    /// The provider rejected the transaction with an error response known to be
-    /// terminal for this chain: retrying the identical transaction cannot succeed.
-    #[error("terminal RPC error {code}: {message}")]
-    TerminalRpcError {
-        /// RPC error code.
-        code: i64,
-        /// RPC error message.
-        message: String,
-    },
-    /// The sender is unavailable due to an outage or transport error; acceptance
-    /// of the transaction is unknown.
-    #[error("sender unavailable: {0}")]
-    SenderUnavailable(anyhow::Error),
-    /// The provider returned an RPC error response that Rundler does not recognize;
-    /// acceptance of the transaction is unknown.
-    #[error("unrecognized RPC error {code}: {message}")]
-    UnrecognizedRpc {
-        /// RPC error code.
-        code: i64,
-        /// RPC error message.
-        message: String,
-    },
-    /// All other errors
+    /// The sender failed to submit or rejected the transaction.
+    #[error(transparent)]
+    Sender(#[from] TxSenderError),
+    /// Tracker-local failures (validation, signer acquisition, chain reads).
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -544,7 +510,9 @@ where
                     });
                 };
 
-                Err(TransactionTrackerError::ReplacementUnderpriced)
+                Err(TransactionTrackerError::Sender(
+                    TxSenderError::ReplacementUnderpriced,
+                ))
             }
             Err(e) => Err(e.into()),
         }
@@ -701,33 +669,6 @@ where
             return true;
         }
         false
-    }
-}
-
-impl From<TxSenderError> for TransactionTrackerError {
-    fn from(value: TxSenderError) -> Self {
-        match value {
-            TxSenderError::NonceTooLow => TransactionTrackerError::NonceTooLow,
-            TxSenderError::Underpriced => TransactionTrackerError::Underpriced,
-            TxSenderError::ReplacementUnderpriced => {
-                TransactionTrackerError::ReplacementUnderpriced
-            }
-            TxSenderError::ConditionNotMet => TransactionTrackerError::ConditionNotMet,
-            TxSenderError::Rejected => TransactionTrackerError::Rejected,
-            TxSenderError::InsufficientFunds => TransactionTrackerError::InsufficientFunds,
-            TxSenderError::IntrinsicGasTooLow => TransactionTrackerError::IntrinsicGasTooLow,
-            TxSenderError::TerminalRpcError { code, message } => {
-                TransactionTrackerError::TerminalRpcError { code, message }
-            }
-            TxSenderError::SoftCancelFailed => {
-                TransactionTrackerError::Other(anyhow::anyhow!("soft cancel failed"))
-            }
-            TxSenderError::SenderUnavailable(e) => TransactionTrackerError::SenderUnavailable(e),
-            TxSenderError::UnrecognizedRpc { code, message } => {
-                TransactionTrackerError::UnrecognizedRpc { code, message }
-            }
-            TxSenderError::Other(e) => TransactionTrackerError::Other(e),
-        }
     }
 }
 
@@ -1093,7 +1034,7 @@ mod tests {
 
         assert!(matches!(
             sent_transaction,
-            Err(TransactionTrackerError::Underpriced)
+            Err(TransactionTrackerError::Sender(TxSenderError::Underpriced))
         ));
         assert_eq!(tracker.num_pending_transactions(), 0);
         assert_eq!(
@@ -1124,7 +1065,9 @@ mod tests {
 
         assert!(matches!(
             sent_transaction,
-            Err(TransactionTrackerError::ReplacementUnderpriced)
+            Err(TransactionTrackerError::Sender(
+                TxSenderError::ReplacementUnderpriced
+            ))
         ));
         assert_eq!(tracker.num_pending_transactions(), 0);
         assert_eq!(

--- a/crates/builder/src/transaction_tracker.rs
+++ b/crates/builder/src/transaction_tracker.rs
@@ -117,6 +117,19 @@ pub(crate) enum TransactionTrackerError {
     Rejected,
     #[error("insufficient funds")]
     InsufficientFunds,
+    /// The sender is unavailable due to an outage or transport error; acceptance
+    /// of the transaction is unknown.
+    #[error("sender unavailable: {0}")]
+    SenderUnavailable(anyhow::Error),
+    /// The provider returned an RPC error response that Rundler does not recognize;
+    /// acceptance of the transaction is unknown.
+    #[error("unrecognized RPC error {code}: {message}")]
+    UnrecognizedRpc {
+        /// RPC error code.
+        code: i64,
+        /// RPC error message.
+        message: String,
+    },
     /// All other errors
     #[error(transparent)]
     Other(#[from] anyhow::Error),
@@ -693,9 +706,10 @@ impl From<TxSenderError> for TransactionTrackerError {
             TxSenderError::SoftCancelFailed => {
                 TransactionTrackerError::Other(anyhow::anyhow!("soft cancel failed"))
             }
-            // SenderUnavailable reaching here means no fallback is configured; treat
-            // it as a transient error so the bundle sender retries next cycle.
-            TxSenderError::SenderUnavailable(e) => TransactionTrackerError::Other(e),
+            TxSenderError::SenderUnavailable(e) => TransactionTrackerError::SenderUnavailable(e),
+            TxSenderError::UnrecognizedRpc { code, message } => {
+                TransactionTrackerError::UnrecognizedRpc { code, message }
+            }
             TxSenderError::Other(e) => TransactionTrackerError::Other(e),
         }
     }

--- a/crates/builder/src/transaction_tracker.rs
+++ b/crates/builder/src/transaction_tracker.rs
@@ -120,6 +120,15 @@ pub(crate) enum TransactionTrackerError {
     /// The transaction's gas limit is below its intrinsic gas cost.
     #[error("intrinsic gas too low")]
     IntrinsicGasTooLow,
+    /// The provider rejected the transaction with an error response known to be
+    /// terminal for this chain: retrying the identical transaction cannot succeed.
+    #[error("terminal RPC error {code}: {message}")]
+    TerminalRpcError {
+        /// RPC error code.
+        code: i64,
+        /// RPC error message.
+        message: String,
+    },
     /// The sender is unavailable due to an outage or transport error; acceptance
     /// of the transaction is unknown.
     #[error("sender unavailable: {0}")]
@@ -707,6 +716,9 @@ impl From<TxSenderError> for TransactionTrackerError {
             TxSenderError::Rejected => TransactionTrackerError::Rejected,
             TxSenderError::InsufficientFunds => TransactionTrackerError::InsufficientFunds,
             TxSenderError::IntrinsicGasTooLow => TransactionTrackerError::IntrinsicGasTooLow,
+            TxSenderError::TerminalRpcError { code, message } => {
+                TransactionTrackerError::TerminalRpcError { code, message }
+            }
             TxSenderError::SoftCancelFailed => {
                 TransactionTrackerError::Other(anyhow::anyhow!("soft cancel failed"))
             }

--- a/crates/provider/src/transaction.rs
+++ b/crates/provider/src/transaction.rs
@@ -28,6 +28,8 @@ pub enum TransactionSubmissionError {
     Rejected,
     /// The sender account has insufficient funds.
     InsufficientFunds,
+    /// A transaction's gas limit is below its intrinsic gas cost.
+    IntrinsicGasTooLow,
 }
 
 /// Classifies a transaction submission RPC error that Rundler knows how to handle.
@@ -81,6 +83,10 @@ pub fn classify_submission_error(message: &str, code: i64) -> Option<Transaction
     // Geth, Erigon, and Reth.
     if lowercase_message.contains("insufficient funds") {
         return Some(TransactionSubmissionError::InsufficientFunds);
+    }
+    // Geth, Erigon, and Reth.
+    if lowercase_message.contains("intrinsic gas too low") {
+        return Some(TransactionSubmissionError::IntrinsicGasTooLow);
     }
     // Arbitrum sequencer.
     if lowercase_message.contains("condition not met") {

--- a/crates/provider/src/transaction.rs
+++ b/crates/provider/src/transaction.rs
@@ -158,6 +158,11 @@ mod tests {
                 TransactionSubmissionError::InsufficientFunds,
             ),
             (
+                "intrinsic gas too low: gas 20000, minimum needed 21000",
+                -32000,
+                TransactionSubmissionError::IntrinsicGasTooLow,
+            ),
+            (
                 "storage slot value condition not met",
                 -32000,
                 TransactionSubmissionError::ConditionNotMet,

--- a/crates/types/src/chain.rs
+++ b/crates/types/src/chain.rs
@@ -142,6 +142,9 @@ pub struct ChainSpec {
     pub flashbots_relay_url: Option<String>,
     /// True if the bloxroute sender is enabled on this chain
     pub bloxroute_enabled: bool,
+    /// True if this chain's node rejects transactions with `-32000: internal error`
+    /// as a terminal, per-transaction rejection rather than a provider outage
+    pub internal_rpc_error_is_terminal: bool,
 
     /*
      * Pool
@@ -215,6 +218,7 @@ impl Default for ChainSpec {
             flashbots_enabled: false,
             flashbots_relay_url: None,
             bloxroute_enabled: false,
+            internal_rpc_error_is_terminal: false,
             chain_history_size: 64,
             signature_aggregators: Arc::new(ContractRegistry::default()),
             submission_proxies: Arc::new(ContractRegistry::default()),


### PR DESCRIPTION
## Proposed Changes

PR 1 of 5 for the poison user operation design (`docs/designs/poison-user-operations.md`). Plumbing only — downstream PRs consume the classification; the intentional behavior changes are called out below.

- Add `TxSenderError::UnrecognizedRpc { code, message }`: unrecognized RPC **error responses** are now distinguishable from transport-level outages, which remain `SenderUnavailable`. This error class is non-terminal-ambiguous and will feed the pre-suspect path rather than removing ops.
- Add `RpcOutcomeClass { Terminal, NonTerminal, Neutral }` and `TxSenderError::classify()`. Known operational errors (underpriced, nonce-too-low, etc.) are `Neutral`: they are evidence of neither UO poison nor provider health and keep their existing dedicated handling.
- Recognize `intrinsic gas too low` (geth/reth/erigon message) in `classify_submission_error` and carry it as a dedicated variant, classified **Terminal** (the first producer): the transaction can never succeed unchanged, and the terminal flow in PR 3 (single-UO remove / multi-UO suspect) lets isolation attribute it instead of letting it poison whole bundles. Its dedicated bundle-sender arm keeps the tx-bytes debug dump, replacing the string sniff on formatted `anyhow` errors.
- Add `TxSenderError::TerminalRpcError { code, message }` (**Terminal**) capturing the `-32000: internal error` class from #1304, gated by a new chain spec flag `internal_rpc_error_is_terminal` (default false; to be enabled only on RH). The raw sender promotes `UnrecognizedRpc` to it below the fallback layer, so it does not count toward failover — it is a per-transaction verdict the fallback node would repeat. On all other chains the error remains ambiguous `UnrecognizedRpc`. Supersedes #1304's unconditional remove-all: the PR 3 terminal path removes a single-UO bundle but only suspects multi-UO bundles, so innocent UOs survive.
- Replace `TransactionTrackerError`'s hand-maintained mirror of sender variants with a transparent `Sender(#[from] TxSenderError)` wrapper (plus `Other` for tracker-local failures), deleting the 12-arm `From` impl. The class survives to the bundle sender losslessly, future sender variants flow through with no tracker changes, and tracker-local errors are now distinguishable from unknown sender errors. All new bundle-sender arms preserve today's `Other` behavior (log → error → lock release → tracker reset).

Behavior changes:
- `UnrecognizedRpc` counts toward fallback failover identically to `SenderUnavailable` (unchanged from today); `IntrinsicGasTooLow` and `TerminalRpcError`, as recognized per-transaction rejections, no longer do.
- `intrinsic gas too low` responses now count as client errors rather than unrecognized in provider RPC metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
