### PR TITLE
feat(pool): track poison user operation suspects in the mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5501,6 +5501,7 @@ dependencies = [
  "mockall",
  "parking_lot",
  "prost 0.13.4",
+ "rand 0.8.5",
  "reth-tasks",
  "rundler-contracts",
  "rundler-provider",

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -174,6 +174,49 @@ pub struct PoolArgs {
         env = "POOL_MAX_TIME_IN_POOL_SECS"
     )]
     pub max_time_in_pool_secs: Option<u64>,
+
+    /// Number of non-terminal RPC submission failures before a user operation
+    /// becomes a suspect and is only submitted alone.
+    #[arg(
+        long = "pool.rpc_failures_before_suspect",
+        name = "pool.rpc_failures_before_suspect",
+        env = "POOL_RPC_FAILURES_BEFORE_SUSPECT",
+        default_value = "3"
+    )]
+    pub rpc_failures_before_suspect: u32,
+
+    /// Number of non-terminal RPC submission failures a suspect is allowed
+    /// before it is removed from the pool. 0 disables removal.
+    ///
+    /// The suspect backoff schedule spaces these failures; a provider incident
+    /// outlasting the cumulative backoff can remove healthy operations. Raise
+    /// this threshold to tolerate longer incidents.
+    #[arg(
+        long = "pool.max_suspect_rpc_failures",
+        name = "pool.max_suspect_rpc_failures",
+        env = "POOL_MAX_SUSPECT_RPC_FAILURES",
+        default_value = "3"
+    )]
+    pub max_suspect_rpc_failures: u32,
+
+    /// Initial delay in seconds between suspect isolation attempts, doubling
+    /// with each failure.
+    #[arg(
+        long = "pool.suspect_rpc_backoff_initial_secs",
+        name = "pool.suspect_rpc_backoff_initial_secs",
+        env = "POOL_SUSPECT_RPC_BACKOFF_INITIAL_SECS",
+        default_value = "1"
+    )]
+    pub suspect_rpc_backoff_initial_secs: u64,
+
+    /// Maximum delay in seconds between suspect isolation attempts.
+    #[arg(
+        long = "pool.suspect_rpc_backoff_max_secs",
+        name = "pool.suspect_rpc_backoff_max_secs",
+        env = "POOL_SUSPECT_RPC_BACKOFF_MAX_SECS",
+        default_value = "600"
+    )]
+    pub suspect_rpc_backoff_max_secs: u64,
 }
 
 impl PoolArgs {
@@ -229,6 +272,10 @@ impl PoolArgs {
                 .verification_gas_limit_efficiency_reject_threshold,
             max_time_in_pool: self.max_time_in_pool_secs.map(Duration::from_secs),
             max_expected_storage_slots: common.max_expected_storage_slots.unwrap_or(usize::MAX),
+            rpc_failures_before_suspect: self.rpc_failures_before_suspect,
+            max_suspect_rpc_failures: self.max_suspect_rpc_failures,
+            suspect_rpc_backoff_initial: Duration::from_secs(self.suspect_rpc_backoff_initial_secs),
+            suspect_rpc_backoff_max: Duration::from_secs(self.suspect_rpc_backoff_max_secs),
         };
 
         let mut pool_configs = vec![];

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -175,6 +175,16 @@ pub struct PoolArgs {
     )]
     pub max_time_in_pool_secs: Option<u64>,
 
+    /// Master switch for poison user operation handling (suspect tracking,
+    /// isolation, and removal). Disabled by default.
+    #[arg(
+        long = "pool.suspect_tracking_enabled",
+        name = "pool.suspect_tracking_enabled",
+        env = "POOL_SUSPECT_TRACKING_ENABLED",
+        default_value = "false"
+    )]
+    pub suspect_tracking_enabled: bool,
+
     /// Number of non-terminal RPC submission failures before a user operation
     /// becomes a suspect and is only submitted alone.
     #[arg(
@@ -272,6 +282,7 @@ impl PoolArgs {
                 .verification_gas_limit_efficiency_reject_threshold,
             max_time_in_pool: self.max_time_in_pool_secs.map(Duration::from_secs),
             max_expected_storage_slots: common.max_expected_storage_slots.unwrap_or(usize::MAX),
+            suspect_tracking_enabled: self.suspect_tracking_enabled,
             rpc_failures_before_suspect: self.rpc_failures_before_suspect,
             max_suspect_rpc_failures: self.max_suspect_rpc_failures,
             suspect_rpc_backoff_initial: Duration::from_secs(self.suspect_rpc_backoff_initial_secs),

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -205,7 +205,7 @@ pub struct PoolArgs {
         long = "pool.max_suspect_rpc_failures",
         name = "pool.max_suspect_rpc_failures",
         env = "POOL_MAX_SUSPECT_RPC_FAILURES",
-        default_value = "3"
+        default_value = "8"
     )]
     pub max_suspect_rpc_failures: u32,
 

--- a/crates/builder/src/assigner.rs
+++ b/crates/builder/src/assigner.rs
@@ -204,6 +204,7 @@ impl Assigner {
                 self.pool.get_ops_summaries(
                     ep.address,
                     self.max_pool_ops_per_request,
+                    0, // suspect isolation scheduling is not implemented yet
                     ep.filter_id.clone(),
                 )
             })
@@ -382,6 +383,7 @@ impl Assigner {
             .get_ops_summaries(
                 entry_point,
                 self.max_pool_ops_per_request,
+                0, // suspect isolation scheduling is not implemented yet
                 filter_id.clone(),
             )
             .await?;
@@ -847,7 +849,7 @@ mod tests {
         let ops_cloned = ops.clone();
         mock_pool
             .expect_get_ops_summaries()
-            .returning(move |_, _, _| {
+            .returning(move |_, _, _, _| {
                 Ok(ops_cloned.iter().map(|op| op.into()).collect::<Vec<_>>())
             });
         mock_pool
@@ -867,7 +869,7 @@ mod tests {
         let ep2_ops_clone = ep2_ops.clone();
         mock_pool
             .expect_get_ops_summaries()
-            .returning(move |ep, _, _| {
+            .returning(move |ep, _, _, _| {
                 if ep == TEST_ENTRY_POINT {
                     Ok(ep1_ops_clone.iter().map(|op| op.into()).collect())
                 } else {
@@ -1252,7 +1254,7 @@ mod tests {
         let ep2_ops_clone = ep2_ops.clone();
         mock_pool
             .expect_get_ops_summaries()
-            .returning(move |ep, _, _| {
+            .returning(move |ep, _, _, _| {
                 if ep == TEST_ENTRY_POINT {
                     Ok(ep1_ops_clone.iter().map(|op| op.into()).collect())
                 } else {
@@ -1317,7 +1319,7 @@ mod tests {
         let all_ops_for_summaries = all_ops.clone();
         mock_pool
             .expect_get_ops_summaries()
-            .returning(move |_, _, _| {
+            .returning(move |_, _, _, _| {
                 Ok(all_ops_for_summaries
                     .iter()
                     .map(|op| op.into())
@@ -1416,7 +1418,7 @@ mod tests {
 
         mock_pool
             .expect_get_ops_summaries()
-            .returning(move |ep, _, _| {
+            .returning(move |ep, _, _, _| {
                 let count = call_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 if count < 2 {
                     // First call (assign_work queries both EPs): return ops
@@ -1504,7 +1506,7 @@ mod tests {
         let mut mock_pool = MockPool::new();
         mock_pool
             .expect_get_ops_summaries()
-            .returning(move |_, _, _| {
+            .returning(move |_, _, _, _| {
                 Ok(low_fee_ops.iter().map(|op| op.into()).collect::<Vec<_>>())
             });
 

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -1683,7 +1683,7 @@ mod tests {
         mock_pool
             .expect_get_ops_summaries()
             .times(1)
-            .returning(|_, _, _| {
+            .returning(|_, _, _, _| {
                 Ok(vec![pool_op_summary(
                     ENTRY_POINT_ADDRESS_V0_6,
                     Address::ZERO,
@@ -1731,7 +1731,7 @@ mod tests {
         mock_pool
             .expect_get_ops_summaries()
             .times(1)
-            .returning(|_, _, _| {
+            .returning(|_, _, _, _| {
                 Ok(vec![pool_op_summary(
                     ENTRY_POINT_ADDRESS_V0_6,
                     Address::ZERO,
@@ -1804,15 +1804,17 @@ mod tests {
         // The other EP is never queried since the builder is pinned.
         mock_pool
             .expect_get_ops_summaries()
-            .withf(move |entry_point, _, filter| {
+            .withf(move |entry_point, _, _, filter| {
                 *entry_point == pinned_entry_point
                     && filter.as_deref() == expected_filter.as_deref()
             })
             .times(1)
-            .returning(move |_, _, _| Ok(vec![pool_op_summary(pinned_entry_point, Address::ZERO)]));
+            .returning(move |_, _, _, _| {
+                Ok(vec![pool_op_summary(pinned_entry_point, Address::ZERO)])
+            });
         mock_pool
             .expect_get_ops_summaries()
-            .withf(move |entry_point, _, _| *entry_point == other_entry_point)
+            .withf(move |entry_point, _, _, _| *entry_point == other_entry_point)
             .times(0);
 
         mock_pool
@@ -1883,19 +1885,21 @@ mod tests {
         // along with the other EP.
         mock_pool
             .expect_get_ops_summaries()
-            .withf(move |entry_point, _, filter| {
+            .withf(move |entry_point, _, _, filter| {
                 *entry_point == pinned_entry_point
                     && filter.as_deref() == expected_filter.as_deref()
             })
             .times(2)
-            .returning(move |_, _, _| Ok(vec![pool_op_summary(pinned_entry_point, Address::ZERO)]));
+            .returning(move |_, _, _, _| {
+                Ok(vec![pool_op_summary(pinned_entry_point, Address::ZERO)])
+            });
         mock_pool
             .expect_get_ops_summaries()
-            .withf(move |entry_point, _, filter| {
+            .withf(move |entry_point, _, _, filter| {
                 *entry_point == other_entry_point && filter.is_none()
             })
             .times(1)
-            .returning(move |_, _, _| {
+            .returning(move |_, _, _, _| {
                 Ok(vec![PoolOperationSummary {
                     hash: B256::from([1; 32]),
                     ..pool_op_summary(other_entry_point, Address::from([1; 20]))
@@ -2123,7 +2127,7 @@ mod tests {
         mock_pool
             .expect_get_ops_summaries()
             .times(1)
-            .returning(|_, _, _| {
+            .returning(|_, _, _, _| {
                 Ok(vec![PoolOperationSummary {
                     max_fee_per_gas: 10,
                     max_priority_fee_per_gas: 2,
@@ -2276,7 +2280,7 @@ mod tests {
         mock_pool
             .expect_get_ops_summaries()
             .times(2)
-            .returning(|_, _, _| {
+            .returning(|_, _, _, _| {
                 Ok(vec![pool_op_summary(
                     ENTRY_POINT_ADDRESS_V0_6,
                     Address::from([9; 20]),
@@ -2341,7 +2345,9 @@ mod tests {
         mock_pool
             .expect_get_ops_summaries()
             .times(3)
-            .returning(move |_, _, _| Ok(vec![pool_op_summary(ENTRY_POINT_ADDRESS_V0_6, sender)]));
+            .returning(move |_, _, _, _| {
+                Ok(vec![pool_op_summary(ENTRY_POINT_ADDRESS_V0_6, sender)])
+            });
         mock_pool
             .expect_get_ops_by_hashes()
             .times(1)
@@ -2420,7 +2426,9 @@ mod tests {
 
         mock_pool
             .expect_get_ops_summaries()
-            .returning(move |_, _, _| Ok(vec![pool_op_summary(ENTRY_POINT_ADDRESS_V0_6, sender)]));
+            .returning(move |_, _, _, _| {
+                Ok(vec![pool_op_summary(ENTRY_POINT_ADDRESS_V0_6, sender)])
+            });
         mock_pool
             .expect_get_ops_by_hashes()
             .returning(|_, _| Ok(vec![demo_pool_op()]));
@@ -2536,7 +2544,7 @@ mod tests {
         mock_pool
             .expect_get_ops_summaries()
             .times(1)
-            .returning(|_, _, _| {
+            .returning(|_, _, _, _| {
                 Ok(vec![pool_op_summary(
                     ENTRY_POINT_ADDRESS_V0_6,
                     Address::ZERO,
@@ -2864,6 +2872,7 @@ mod tests {
             max_priority_fee_per_gas: 0,
             gas_limit: 0,
             bundler_sponsorship_max_cost: None,
+            suspect: false,
         }
     }
 

--- a/crates/pool/Cargo.toml
+++ b/crates/pool/Cargo.toml
@@ -24,6 +24,7 @@ metrics.workspace = true
 metrics-derive.workspace = true
 parking_lot.workspace = true
 prost.workspace = true
+rand.workspace = true
 rundler-contracts.workspace = true
 rundler-provider.workspace = true
 rundler-sim.workspace = true

--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -228,6 +228,9 @@ message PoolOperationSummary {
   bytes gas_limit = 7;
   // Maximum WEI the bundler will pay (empty if not sponsored)
   bytes bundler_sponsorship_max_cost = 8;
+  // Whether the operation is suspected of poisoning bundles and must only be
+  // submitted alone
+  bool suspect = 9;
 }
 
 // Data associated with a user operation for DA gas calculations
@@ -318,6 +321,10 @@ service OpPool {
   // Notify the pool about a pending bundle transaction
   rpc NotifyPendingBundle(NotifyPendingBundleRequest) returns (NotifyPendingBundleResponse);
 
+  // Report the final outcome of a bundle submission attempt, for poison
+  // user operation tracking
+  rpc ReportBundleOutcome(ReportBundleOutcomeRequest) returns (ReportBundleOutcomeResponse);
+
   // Get extended status for a user operation
   rpc GetOpStatus(GetOpStatusRequest) returns (GetOpStatusResponse);
 }
@@ -366,13 +373,16 @@ message GetOpsSuccess {
   repeated MempoolOp ops = 1;
 }
 
-message GetOpsSummariesRequest {  
+message GetOpsSummariesRequest {
   // The serialized entry point address
   bytes entry_point = 1;
-  // The maximum number of UserOperations to return
+  // The maximum number of non-suspect UserOperations to return
   uint64 max_ops = 2;
-  // The filter ID to apply to the UserOperations 
+  // The filter ID to apply to the UserOperations
   string filter_id = 3;
+  // The maximum number of due suspect UserOperations to return, in addition
+  // to `max_ops`
+  uint64 max_suspects = 4;
 }
 message GetOpsSummariesResponse {
   oneof result {
@@ -644,6 +654,38 @@ message NotifyPendingBundleResponse {
   }
 }
 message NotifyPendingBundleSuccess {}
+
+// Final outcome of a bundle submission attempt, for poison user operation
+// tracking
+enum BundleOutcome {
+  BUNDLE_OUTCOME_UNSPECIFIED = 0;
+  // The bundle transaction was accepted by the provider
+  BUNDLE_OUTCOME_SUCCESS = 1;
+  // Transport failure, timeout, or ambiguous rejection; acceptance unknown
+  BUNDLE_OUTCOME_NON_TERMINAL_FAILURE = 2;
+  // Final rejection; retrying the identical transaction cannot succeed
+  BUNDLE_OUTCOME_TERMINAL_FAILURE = 3;
+  // Mark every operation in the bundle as suspect
+  BUNDLE_OUTCOME_MARK_SUSPECT = 4;
+}
+
+message ReportBundleOutcomeRequest {
+  // The serialized entry point address
+  bytes entry_point = 1;
+  // The serialized UserOperation hashes in the bundle
+  repeated bytes hashes = 2;
+  // The outcome of the bundle submission attempt
+  BundleOutcome outcome = 3;
+  // Whether a provider health event was active at submission time
+  bool provider_event_active = 4;
+}
+message ReportBundleOutcomeResponse {
+  oneof result {
+    ReportBundleOutcomeSuccess success = 1;
+    MempoolError failure = 2;
+  }
+}
+message ReportBundleOutcomeSuccess {}
 
 message GetOpStatusRequest {
   bytes hash = 1;

--- a/crates/pool/src/emit.rs
+++ b/crates/pool/src/emit.rs
@@ -146,6 +146,12 @@ pub enum OpRemovalReason {
         /// Hash of the new operation that replaced this one
         replaced_by: B256,
     },
+    /// Op was removed because the provider terminally rejected its
+    /// single-operation bundle
+    TerminalRpcError,
+    /// Op was removed because, while isolated as a suspect, it repeatedly
+    /// failed submission with non-terminal RPC errors
+    RepeatedNonTerminalRpcFailure,
 }
 
 impl EntitySummary {

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -108,8 +108,10 @@ pub(crate) trait Mempool: Send + Sync {
     /// Reports the final outcome of a bundle submission attempt for the given
     /// operations, for poison user operation tracking.
     ///
-    /// While `provider_event_active` is true, a non-terminal failure is not
-    /// evidence against its operations and changes no operation state.
+    /// While `provider_event_active` is true, suspect analysis continues but
+    /// removal progress pauses: non-terminal failures still count toward
+    /// suspicion, while suspects only refresh their isolation backoff and
+    /// never advance toward removal.
     fn report_bundle_outcome(
         &self,
         ops: &[B256],

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -108,8 +108,8 @@ pub(crate) trait Mempool: Send + Sync {
     /// Reports the final outcome of a bundle submission attempt for the given
     /// operations, for poison user operation tracking.
     ///
-    /// While `provider_event_active` is true, non-terminal failures do not
-    /// advance the failure counts of non-suspect operations.
+    /// While `provider_event_active` is true, a non-terminal failure is not
+    /// evidence against its operations and changes no operation state.
     fn report_bundle_outcome(
         &self,
         ops: &[B256],

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -38,8 +38,8 @@ use rundler_types::{
     UserOperationVariant,
     chain::ChainSpec,
     pool::{
-        MempoolError, PaymasterMetadata, PoolOperation, PoolOperationStatus, Reputation,
-        ReputationStatus, StakeStatus,
+        BundleOutcome, MempoolError, PaymasterMetadata, PoolOperation, PoolOperationStatus,
+        Reputation, ReputationStatus, StakeStatus,
     },
 };
 use tonic::async_trait;
@@ -92,6 +92,30 @@ pub(crate) trait Mempool: Send + Sync {
         max: usize,
         filter_id: Option<String>,
     ) -> MempoolResult<Vec<Arc<PoolOperation>>>;
+
+    /// Returns suspect operations whose isolation retry delay has elapsed,
+    /// best first, up to `max` operations.
+    ///
+    /// Suspects are excluded from `best_operations` and must only be submitted
+    /// in single-operation bundles. See
+    /// `docs/designs/poison-user-operations.md`.
+    fn due_suspect_operations(
+        &self,
+        max: usize,
+        filter_id: Option<String>,
+    ) -> MempoolResult<Vec<Arc<PoolOperation>>>;
+
+    /// Reports the final outcome of a bundle submission attempt for the given
+    /// operations, for poison user operation tracking.
+    ///
+    /// While `provider_event_active` is true, non-terminal failures do not
+    /// advance the failure counts of non-suspect operations.
+    fn report_bundle_outcome(
+        &self,
+        ops: &[B256],
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+    );
 
     /// Returns the all operations from the pool up to a max size
     fn all_operations(&self, max: usize) -> Vec<Arc<PoolOperation>>;
@@ -192,6 +216,15 @@ pub struct PoolConfig {
     pub max_time_in_pool: Option<Duration>,
     /// The maximum number of storage slots that can be expected to be used by a user operation during validation
     pub max_expected_storage_slots: usize,
+    /// Number of non-terminal RPC submission failures before a user operation becomes a suspect
+    pub rpc_failures_before_suspect: u32,
+    /// Number of non-terminal RPC submission failures a suspect is allowed before removal.
+    /// 0 disables removal.
+    pub max_suspect_rpc_failures: u32,
+    /// Initial backoff delay between suspect isolation attempts
+    pub suspect_rpc_backoff_initial: Duration,
+    /// Maximum backoff delay between suspect isolation attempts
+    pub suspect_rpc_backoff_max: Duration,
 }
 
 /// Origin of an operation.

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -218,6 +218,10 @@ pub struct PoolConfig {
     pub max_time_in_pool: Option<Duration>,
     /// The maximum number of storage slots that can be expected to be used by a user operation during validation
     pub max_expected_storage_slots: usize,
+    /// Master switch for poison user operation handling. When disabled, bundle
+    /// outcomes change no operation state and no operation is ever suspected or
+    /// removed by that flow.
+    pub suspect_tracking_enabled: bool,
     /// Number of non-terminal RPC submission failures before a user operation becomes a suspect
     pub rpc_failures_before_suspect: u32,
     /// Number of non-terminal RPC submission failures a suspect is allowed before removal.

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -286,10 +286,11 @@ where
                     let Some(op) = self.by_hash.get(hash) else {
                         continue;
                     };
-                    // While a provider event is active only suspects accrue
-                    // failures: suspect removal is protected by backoff-spaced
-                    // evidence rather than by outage detection.
-                    if !op.is_suspect(suspect_threshold) && provider_event_active {
+                    // A failure during a provider event is not evidence against
+                    // the op: treat the submission as if it never happened.
+                    // Retry pacing during an event is left to normal submission
+                    // cadence and provider rate limiting.
+                    if provider_event_active {
                         continue;
                     }
                     let failures = op.record_failure(
@@ -2172,8 +2173,11 @@ mod tests {
     }
 
     #[test]
-    fn provider_event_pauses_pre_suspect_counting_only() {
-        let mut pool = pool();
+    fn provider_event_pauses_failure_counting() {
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_rpc_backoff_initial: Duration::from_secs(10),
+            ..conf()
+        });
         let non_suspect = pool
             .add_operation(create_op(Address::random(), 0, 1), 0, 0)
             .unwrap();
@@ -2182,21 +2186,15 @@ mod tests {
             .unwrap();
         pool.by_hash[&suspect].mark_suspect(3);
 
-        pool.apply_bundle_outcome(
-            &[non_suspect],
-            BundleOutcome::NonTerminalFailure,
-            true,
-            Instant::now(),
-        );
-        pool.apply_bundle_outcome(
-            &[suspect],
-            BundleOutcome::NonTerminalFailure,
-            true,
-            Instant::now(),
-        );
+        let now = Instant::now();
+        pool.apply_bundle_outcome(&[non_suspect], BundleOutcome::NonTerminalFailure, true, now);
+        pool.apply_bundle_outcome(&[suspect], BundleOutcome::NonTerminalFailure, true, now);
 
+        // a failure during a provider event changes no UO state
         assert_eq!(pool.by_hash[&non_suspect].failures(), 0);
-        assert_eq!(pool.by_hash[&suspect].failures(), 4);
+        assert_eq!(pool.by_hash[&suspect].failures(), 3);
+        assert!(pool.by_hash[&non_suspect].retry_due(now));
+        assert!(pool.by_hash[&suspect].retry_due(now));
     }
 
     #[test]

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -52,6 +52,7 @@ pub(crate) struct PoolInnerConfig {
     da_gas_tracking_enabled: bool,
     max_time_in_pool: Option<Duration>,
     verification_gas_limit_efficiency_reject_threshold: f64,
+    suspect_tracking_enabled: bool,
     rpc_failures_before_suspect: u32,
     max_suspect_rpc_failures: u32,
     suspect_rpc_backoff_initial: Duration,
@@ -71,6 +72,7 @@ impl From<PoolConfig> for PoolInnerConfig {
             max_time_in_pool: config.max_time_in_pool,
             verification_gas_limit_efficiency_reject_threshold: config
                 .verification_gas_limit_efficiency_reject_threshold,
+            suspect_tracking_enabled: config.suspect_tracking_enabled,
             rpc_failures_before_suspect: config.rpc_failures_before_suspect,
             max_suspect_rpc_failures: config.max_suspect_rpc_failures,
             suspect_rpc_backoff_initial: config.suspect_rpc_backoff_initial,
@@ -270,6 +272,13 @@ where
         provider_event_active: bool,
         now: Instant,
     ) -> Vec<(B256, OpRemovalReason)> {
+        // Master switch for poison UO handling: when disabled, bundle
+        // outcomes change no UO state and no operation is ever suspected
+        // or removed by this flow.
+        if !self.config.suspect_tracking_enabled {
+            return Vec::new();
+        }
+
         let suspect_threshold = self.config.rpc_failures_before_suspect;
         let mut to_remove = Vec::new();
 
@@ -2411,6 +2420,40 @@ mod tests {
     }
 
     #[test]
+    fn disabled_suspect_tracking_ignores_bundle_outcomes() {
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_tracking_enabled: false,
+            suspect_rpc_backoff_initial: Duration::ZERO,
+            ..conf()
+        });
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+
+        for _ in 0..10 {
+            let to_remove = pool.apply_bundle_outcome(
+                &[hash],
+                BundleOutcome::NonTerminalFailure,
+                false,
+                Instant::now(),
+            );
+            assert!(to_remove.is_empty());
+        }
+        let terminal = pool.apply_bundle_outcome(
+            &[hash],
+            BundleOutcome::TerminalFailure,
+            false,
+            Instant::now(),
+        );
+        assert!(terminal.is_empty());
+        pool.apply_bundle_outcome(&[hash], BundleOutcome::MarkSuspect, false, Instant::now());
+
+        assert_eq!(pool.by_hash[&hash].failures(), 0);
+        assert_eq!(pool.best_operations().count(), 1);
+        assert_eq!(pool.due_suspect_operations(Instant::now()).count(), 0);
+    }
+
+    #[test]
     fn bundle_outcome_ignores_unknown_hashes() {
         let pool = pool();
         let to_remove = pool.apply_bundle_outcome(
@@ -2435,6 +2478,7 @@ mod tests {
             da_gas_tracking_enabled: false,
             max_time_in_pool: None,
             verification_gas_limit_efficiency_reject_threshold: 0.5,
+            suspect_tracking_enabled: true,
             rpc_failures_before_suspect: 3,
             max_suspect_rpc_failures: 3,
             suspect_rpc_backoff_initial: Duration::from_secs(1),

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -23,12 +23,16 @@ use anyhow::Context;
 use metrics::{Counter, Gauge, Histogram};
 use metrics_derive::Metrics;
 use parking_lot::RwLock;
+use rand::Rng;
 use rundler_provider::DAGasOracleSync;
 use rundler_types::{
     Entity, EntityType, GasFees, Timestamp, UserOperation, UserOperationId, UserOperationVariant,
     chain::ChainSpec,
     da::DAGasBlockData,
-    pool::{MempoolError, PendingBundleInfo, PoolOperation, PoolOperationStatus, PreconfInfo},
+    pool::{
+        BundleOutcome, MempoolError, PendingBundleInfo, PoolOperation, PoolOperationStatus,
+        PreconfInfo,
+    },
 };
 use rundler_utils::{emit::WithEntryPoint, math};
 use tokio::sync::broadcast;
@@ -48,6 +52,10 @@ pub(crate) struct PoolInnerConfig {
     da_gas_tracking_enabled: bool,
     max_time_in_pool: Option<Duration>,
     verification_gas_limit_efficiency_reject_threshold: f64,
+    rpc_failures_before_suspect: u32,
+    max_suspect_rpc_failures: u32,
+    suspect_rpc_backoff_initial: Duration,
+    suspect_rpc_backoff_max: Duration,
 }
 
 impl From<PoolConfig> for PoolInnerConfig {
@@ -63,6 +71,10 @@ impl From<PoolConfig> for PoolInnerConfig {
             max_time_in_pool: config.max_time_in_pool,
             verification_gas_limit_efficiency_reject_threshold: config
                 .verification_gas_limit_efficiency_reject_threshold,
+            rpc_failures_before_suspect: config.rpc_failures_before_suspect,
+            max_suspect_rpc_failures: config.max_suspect_rpc_failures,
+            suspect_rpc_backoff_initial: config.suspect_rpc_backoff_initial,
+            suspect_rpc_backoff_max: config.suspect_rpc_backoff_max,
         }
     }
 }
@@ -224,7 +236,98 @@ where
     }
 
     pub(crate) fn best_operations(&self) -> impl Iterator<Item = Arc<PoolOperation>> + '_ {
-        self.best.iter().map(|o| o.po.clone())
+        self.best
+            .iter()
+            .filter(|o| !o.is_suspect(self.config.rpc_failures_before_suspect))
+            .map(|o| o.po.clone())
+    }
+
+    /// Returns suspect operations whose isolation retry delay has elapsed,
+    /// best first.
+    pub(crate) fn due_suspect_operations(
+        &self,
+        now: Instant,
+    ) -> impl Iterator<Item = Arc<PoolOperation>> + '_ {
+        self.best
+            .iter()
+            .filter(move |o| {
+                o.is_suspect(self.config.rpc_failures_before_suspect) && o.retry_due(now)
+            })
+            .map(|o| o.po.clone())
+    }
+
+    /// Applies the final outcome of a bundle submission attempt to the given
+    /// operations, per the failure flow in
+    /// `docs/designs/poison-user-operations.md`.
+    ///
+    /// Operations no longer in the pool are skipped. Returns the operations
+    /// that must be removed, with their removal reasons; removal itself is the
+    /// caller's responsibility.
+    pub(crate) fn apply_bundle_outcome(
+        &self,
+        ops: &[B256],
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+        now: Instant,
+    ) -> Vec<(B256, OpRemovalReason)> {
+        let suspect_threshold = self.config.rpc_failures_before_suspect;
+        let mut to_remove = Vec::new();
+
+        match outcome {
+            BundleOutcome::Success => {
+                for hash in ops {
+                    if let Some(op) = self.by_hash.get(hash) {
+                        op.reset_failures();
+                    }
+                }
+            }
+            BundleOutcome::NonTerminalFailure => {
+                for hash in ops {
+                    let Some(op) = self.by_hash.get(hash) else {
+                        continue;
+                    };
+                    // While a provider event is active only suspects accrue
+                    // failures: suspect removal is protected by backoff-spaced
+                    // evidence rather than by outage detection.
+                    if !op.is_suspect(suspect_threshold) && provider_event_active {
+                        continue;
+                    }
+                    let failures = op.record_failure(
+                        now,
+                        suspect_threshold,
+                        self.config.suspect_rpc_backoff_initial,
+                        self.config.suspect_rpc_backoff_max,
+                    );
+                    if self.config.max_suspect_rpc_failures > 0
+                        && failures >= suspect_threshold + self.config.max_suspect_rpc_failures
+                    {
+                        to_remove.push((*hash, OpRemovalReason::RepeatedNonTerminalRpcFailure));
+                    }
+                }
+            }
+            BundleOutcome::TerminalFailure => {
+                if let [hash] = ops {
+                    if self.by_hash.contains_key(hash) {
+                        to_remove.push((*hash, OpRemovalReason::TerminalRpcError));
+                    }
+                } else {
+                    for hash in ops {
+                        if let Some(op) = self.by_hash.get(hash) {
+                            op.mark_suspect(suspect_threshold);
+                        }
+                    }
+                }
+            }
+            BundleOutcome::MarkSuspect => {
+                for hash in ops {
+                    if let Some(op) = self.by_hash.get(hash) {
+                        op.mark_suspect(suspect_threshold);
+                    }
+                }
+            }
+        }
+
+        to_remove
     }
 
     pub(crate) fn all_operations(&self) -> impl Iterator<Item = Arc<PoolOperation>> + '_ {
@@ -828,6 +931,18 @@ where
     }
 }
 
+/// Submission failure tracking for poison user operation handling.
+///
+/// A single counter measured against two thresholds: an operation becomes a
+/// suspect at `rpc_failures_before_suspect` failures and is removed
+/// `max_suspect_rpc_failures` failures later. Any successful submission resets
+/// the counter. See `docs/designs/poison-user-operations.md`.
+#[derive(Debug, Default)]
+struct SuspectState {
+    failures: u32,
+    retry_after: Option<Instant>,
+}
+
 /// Wrapper around PoolOperation that adds a submission ID to implement
 /// a custom ordering for the best operations
 #[derive(Debug)]
@@ -840,6 +955,7 @@ struct OrderedPoolOperation {
     time_to_mine: RwLock<Option<TimeToMineInfo>>,
     /// The block number at which the operation was added to the pool
     added_at_block: u64,
+    suspect_state: RwLock<SuspectState>,
 }
 
 impl OrderedPoolOperation {
@@ -858,6 +974,7 @@ impl OrderedPoolOperation {
             insertion_time: Instant::now(),
             time_to_mine: RwLock::new(Some(TimeToMineInfo::new(current_block_number))),
             added_at_block: current_block_number,
+            suspect_state: RwLock::new(SuspectState::default()),
         }
     }
 
@@ -905,6 +1022,60 @@ impl OrderedPoolOperation {
 
     fn gas_price(&self) -> u128 {
         *self.gas_price.read()
+    }
+
+    fn is_suspect(&self, suspect_threshold: u32) -> bool {
+        self.suspect_state.read().failures >= suspect_threshold
+    }
+
+    /// Records a submission failure, scheduling the next isolation retry with
+    /// exponential backoff once the operation is past the suspect threshold.
+    /// Returns the new failure count.
+    fn record_failure(
+        &self,
+        now: Instant,
+        suspect_threshold: u32,
+        backoff_initial: Duration,
+        backoff_max: Duration,
+    ) -> u32 {
+        let mut state = self.suspect_state.write();
+        state.failures += 1;
+        if state.failures > suspect_threshold {
+            let exponent = state.failures - suspect_threshold - 1;
+            state.retry_after =
+                Some(now + Self::suspect_backoff(backoff_initial, backoff_max, exponent));
+        }
+        state.failures
+    }
+
+    /// Backoff delay doubling from `initial` with ±20% jitter, capped at `max`.
+    fn suspect_backoff(initial: Duration, max: Duration, exponent: u32) -> Duration {
+        let base = initial
+            .saturating_mul(2u32.saturating_pow(exponent))
+            .min(max);
+        base.mul_f64(rand::thread_rng().gen_range(0.8..=1.2))
+            .min(max)
+    }
+
+    fn reset_failures(&self) {
+        *self.suspect_state.write() = SuspectState::default();
+    }
+
+    fn mark_suspect(&self, suspect_threshold: u32) {
+        let mut state = self.suspect_state.write();
+        state.failures = state.failures.max(suspect_threshold);
+    }
+
+    #[cfg(test)]
+    fn failures(&self) -> u32 {
+        self.suspect_state.read().failures
+    }
+
+    fn retry_due(&self, now: Instant) -> bool {
+        self.suspect_state
+            .read()
+            .retry_after
+            .is_none_or(|retry_after| retry_after <= now)
     }
 }
 
@@ -1950,6 +2121,272 @@ mod tests {
         assert!(!pool.pending_bundles_by_uo.contains_key(&hash1));
     }
 
+    #[test]
+    fn success_resets_failures() {
+        let mut pool = pool();
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+
+        pool.apply_bundle_outcome(
+            &[hash],
+            BundleOutcome::NonTerminalFailure,
+            false,
+            Instant::now(),
+        );
+        pool.apply_bundle_outcome(
+            &[hash],
+            BundleOutcome::NonTerminalFailure,
+            false,
+            Instant::now(),
+        );
+        assert_eq!(pool.by_hash[&hash].failures(), 2);
+
+        pool.apply_bundle_outcome(&[hash], BundleOutcome::Success, false, Instant::now());
+        assert_eq!(pool.by_hash[&hash].failures(), 0);
+        assert_eq!(pool.best_operations().count(), 1);
+    }
+
+    #[test]
+    fn non_terminal_failures_promote_to_suspect() {
+        let mut pool = pool();
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+
+        for _ in 0..3 {
+            let to_remove = pool.apply_bundle_outcome(
+                &[hash],
+                BundleOutcome::NonTerminalFailure,
+                false,
+                Instant::now(),
+            );
+            assert!(to_remove.is_empty());
+        }
+
+        // suspect: hidden from best operations, due for isolation immediately
+        assert_eq!(pool.best_operations().count(), 0);
+        let due: Vec<_> = pool.due_suspect_operations(Instant::now()).collect();
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].uo.hash(), hash);
+    }
+
+    #[test]
+    fn provider_event_pauses_pre_suspect_counting_only() {
+        let mut pool = pool();
+        let non_suspect = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+        let suspect = pool
+            .add_operation(create_op(Address::random(), 0, 2), 0, 0)
+            .unwrap();
+        pool.by_hash[&suspect].mark_suspect(3);
+
+        pool.apply_bundle_outcome(
+            &[non_suspect],
+            BundleOutcome::NonTerminalFailure,
+            true,
+            Instant::now(),
+        );
+        pool.apply_bundle_outcome(
+            &[suspect],
+            BundleOutcome::NonTerminalFailure,
+            true,
+            Instant::now(),
+        );
+
+        assert_eq!(pool.by_hash[&non_suspect].failures(), 0);
+        assert_eq!(pool.by_hash[&suspect].failures(), 4);
+    }
+
+    #[test]
+    fn suspect_failure_schedules_backoff() {
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_rpc_backoff_initial: Duration::from_secs(10),
+            suspect_rpc_backoff_max: Duration::from_secs(600),
+            max_suspect_rpc_failures: 0,
+            ..conf()
+        });
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+        pool.by_hash[&hash].mark_suspect(3);
+
+        let now = Instant::now();
+        pool.apply_bundle_outcome(&[hash], BundleOutcome::NonTerminalFailure, false, now);
+
+        // first delay is 10s with ±20% jitter
+        let op = &pool.by_hash[&hash];
+        assert!(!op.retry_due(now + Duration::from_millis(7_900)));
+        assert!(op.retry_due(now + Duration::from_millis(12_100)));
+        assert_eq!(pool.due_suspect_operations(now).count(), 0);
+
+        // second delay doubles to 20s with ±20% jitter
+        pool.apply_bundle_outcome(&[hash], BundleOutcome::NonTerminalFailure, false, now);
+        let op = &pool.by_hash[&hash];
+        assert!(!op.retry_due(now + Duration::from_millis(15_900)));
+        assert!(op.retry_due(now + Duration::from_millis(24_100)));
+    }
+
+    #[test]
+    fn suspect_backoff_caps_at_max() {
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_rpc_backoff_initial: Duration::from_secs(10),
+            suspect_rpc_backoff_max: Duration::from_secs(15),
+            max_suspect_rpc_failures: 0,
+            ..conf()
+        });
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+        pool.by_hash[&hash].mark_suspect(3);
+
+        let now = Instant::now();
+        for _ in 0..8 {
+            pool.apply_bundle_outcome(&[hash], BundleOutcome::NonTerminalFailure, false, now);
+        }
+        assert!(pool.by_hash[&hash].retry_due(now + Duration::from_secs(15)));
+    }
+
+    #[test]
+    fn repeated_suspect_failures_remove_at_threshold() {
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_rpc_backoff_initial: Duration::ZERO,
+            ..conf()
+        });
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+
+        // suspect threshold 3 + removal allowance 3 = removal at the 6th failure
+        for _ in 0..5 {
+            let to_remove = pool.apply_bundle_outcome(
+                &[hash],
+                BundleOutcome::NonTerminalFailure,
+                false,
+                Instant::now(),
+            );
+            assert!(to_remove.is_empty());
+        }
+        let to_remove = pool.apply_bundle_outcome(
+            &[hash],
+            BundleOutcome::NonTerminalFailure,
+            false,
+            Instant::now(),
+        );
+        assert_eq!(to_remove.len(), 1);
+        assert_eq!(to_remove[0].0, hash);
+        assert!(matches!(
+            to_remove[0].1,
+            OpRemovalReason::RepeatedNonTerminalRpcFailure
+        ));
+    }
+
+    #[test]
+    fn zero_max_suspect_failures_disables_removal() {
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            max_suspect_rpc_failures: 0,
+            suspect_rpc_backoff_initial: Duration::ZERO,
+            ..conf()
+        });
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+
+        for _ in 0..20 {
+            let to_remove = pool.apply_bundle_outcome(
+                &[hash],
+                BundleOutcome::NonTerminalFailure,
+                false,
+                Instant::now(),
+            );
+            assert!(to_remove.is_empty());
+        }
+    }
+
+    #[test]
+    fn terminal_failure_single_op_removes() {
+        let mut pool = pool();
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+
+        let to_remove = pool.apply_bundle_outcome(
+            &[hash],
+            BundleOutcome::TerminalFailure,
+            false,
+            Instant::now(),
+        );
+        assert_eq!(to_remove.len(), 1);
+        assert_eq!(to_remove[0].0, hash);
+        assert!(matches!(to_remove[0].1, OpRemovalReason::TerminalRpcError));
+    }
+
+    #[test]
+    fn terminal_failure_multi_op_marks_all_suspect() {
+        let mut pool = pool();
+        let hashes: Vec<B256> = (0..3)
+            .map(|i| {
+                pool.add_operation(create_op(Address::random(), 0, i + 1), 0, 0)
+                    .unwrap()
+            })
+            .collect();
+
+        let to_remove = pool.apply_bundle_outcome(
+            &hashes,
+            BundleOutcome::TerminalFailure,
+            false,
+            Instant::now(),
+        );
+        assert!(to_remove.is_empty());
+        assert_eq!(pool.best_operations().count(), 0);
+        assert_eq!(pool.due_suspect_operations(Instant::now()).count(), 3);
+    }
+
+    #[test]
+    fn mark_suspect_does_not_reset_progress() {
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_rpc_backoff_initial: Duration::ZERO,
+            ..conf()
+        });
+        let fresh = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+        let seasoned = pool
+            .add_operation(create_op(Address::random(), 0, 2), 0, 0)
+            .unwrap();
+        for _ in 0..5 {
+            pool.apply_bundle_outcome(
+                &[seasoned],
+                BundleOutcome::NonTerminalFailure,
+                false,
+                Instant::now(),
+            );
+        }
+
+        pool.apply_bundle_outcome(
+            &[fresh, seasoned],
+            BundleOutcome::MarkSuspect,
+            false,
+            Instant::now(),
+        );
+
+        assert_eq!(pool.by_hash[&fresh].failures(), 3);
+        assert_eq!(pool.by_hash[&seasoned].failures(), 5);
+    }
+
+    #[test]
+    fn bundle_outcome_ignores_unknown_hashes() {
+        let pool = pool();
+        let to_remove = pool.apply_bundle_outcome(
+            &[B256::random()],
+            BundleOutcome::TerminalFailure,
+            false,
+            Instant::now(),
+        );
+        assert!(to_remove.is_empty());
+    }
+
     const MAX_POOL_SIZE_OPS: usize = 20;
 
     fn conf() -> PoolInnerConfig {
@@ -1963,6 +2400,10 @@ mod tests {
             da_gas_tracking_enabled: false,
             max_time_in_pool: None,
             verification_gas_limit_efficiency_reject_threshold: 0.5,
+            rpc_failures_before_suspect: 3,
+            max_suspect_rpc_failures: 3,
+            suspect_rpc_backoff_initial: Duration::from_secs(1),
+            suspect_rpc_backoff_max: Duration::from_secs(600),
         }
     }
 

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -238,9 +238,15 @@ where
     }
 
     pub(crate) fn best_operations(&self) -> impl Iterator<Item = Arc<PoolOperation>> + '_ {
+        // Master switch: when disabled, no operation is ever treated as a
+        // suspect, regardless of `rpc_failures_before_suspect` (a threshold of
+        // 0 would otherwise mark every fresh operation suspect and empty this
+        // iterator).
+        let suspect_tracking_enabled = self.config.suspect_tracking_enabled;
+        let suspect_threshold = self.config.rpc_failures_before_suspect;
         self.best
             .iter()
-            .filter(|o| !o.is_suspect(self.config.rpc_failures_before_suspect))
+            .filter(move |o| !suspect_tracking_enabled || !o.is_suspect(suspect_threshold))
             .map(|o| o.po.clone())
     }
 
@@ -250,10 +256,12 @@ where
         &self,
         now: Instant,
     ) -> impl Iterator<Item = Arc<PoolOperation>> + '_ {
+        let suspect_tracking_enabled = self.config.suspect_tracking_enabled;
+        let suspect_threshold = self.config.rpc_failures_before_suspect;
         self.best
             .iter()
             .filter(move |o| {
-                o.is_suspect(self.config.rpc_failures_before_suspect) && o.retry_due(now)
+                suspect_tracking_enabled && o.is_suspect(suspect_threshold) && o.retry_due(now)
             })
             .map(|o| o.po.clone())
     }
@@ -316,7 +324,9 @@ where
                         self.config.suspect_rpc_backoff_max,
                     );
                     if self.config.max_suspect_rpc_failures > 0
-                        && failures >= suspect_threshold + self.config.max_suspect_rpc_failures
+                        && failures
+                            >= suspect_threshold
+                                .saturating_add(self.config.max_suspect_rpc_failures)
                     {
                         to_remove.push((*hash, OpRemovalReason::RepeatedNonTerminalRpcFailure));
                     }
@@ -1056,7 +1066,7 @@ impl OrderedPoolOperation {
         backoff_max: Duration,
     ) -> u32 {
         let mut state = self.suspect_state.write();
-        state.failures += 1;
+        state.failures = state.failures.saturating_add(1);
         if state.failures > suspect_threshold {
             let exponent = state.failures - suspect_threshold - 1;
             state.retry_after =
@@ -2244,6 +2254,45 @@ mod tests {
     }
 
     #[test]
+    fn provider_event_resumes_removal_progress_after_clearing() {
+        // threshold 3, max_suspect_rpc_failures 3: removal at 6 total failures
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_rpc_backoff_initial: Duration::ZERO,
+            ..conf()
+        });
+        let suspect = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+        pool.by_hash[&suspect].mark_suspect(3);
+
+        let now = Instant::now();
+        for _ in 0..5 {
+            let to_remove =
+                pool.apply_bundle_outcome(&[suspect], BundleOutcome::NonTerminalFailure, true, now);
+            // failures during the event never contribute to a later removal
+            assert!(to_remove.is_empty());
+        }
+        assert_eq!(pool.by_hash[&suspect].failures(), 3);
+
+        // event clears: removal progress resumes from the frozen count, not from 0
+        pool.apply_bundle_outcome(&[suspect], BundleOutcome::NonTerminalFailure, false, now);
+        assert_eq!(pool.by_hash[&suspect].failures(), 4);
+        let to_remove =
+            pool.apply_bundle_outcome(&[suspect], BundleOutcome::NonTerminalFailure, false, now);
+        assert_eq!(pool.by_hash[&suspect].failures(), 5);
+        assert!(to_remove.is_empty());
+
+        let to_remove =
+            pool.apply_bundle_outcome(&[suspect], BundleOutcome::NonTerminalFailure, false, now);
+        assert_eq!(to_remove.len(), 1);
+        assert_eq!(to_remove[0].0, suspect);
+        assert!(matches!(
+            to_remove[0].1,
+            OpRemovalReason::RepeatedNonTerminalRpcFailure
+        ));
+    }
+
+    #[test]
     fn suspect_failure_schedules_backoff() {
         let mut pool = pool_with_conf(PoolInnerConfig {
             suspect_rpc_backoff_initial: Duration::from_secs(10),
@@ -2417,6 +2466,24 @@ mod tests {
 
         assert_eq!(pool.by_hash[&fresh].failures(), 3);
         assert_eq!(pool.by_hash[&seasoned].failures(), 5);
+    }
+
+    #[test]
+    fn disabled_suspect_tracking_ignores_zero_threshold() {
+        // A threshold of 0 would make every fresh op appear suspect
+        // (`failures >= 0`); the master switch must still guarantee that
+        // disabling suspect tracking never removes operations from
+        // `best_operations`.
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_tracking_enabled: false,
+            rpc_failures_before_suspect: 0,
+            ..conf()
+        });
+        pool.add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+
+        assert_eq!(pool.best_operations().count(), 1);
+        assert_eq!(pool.due_suspect_operations(Instant::now()).count(), 0);
     }
 
     #[test]

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -286,11 +286,18 @@ where
                     let Some(op) = self.by_hash.get(hash) else {
                         continue;
                     };
-                    // A failure during a provider event is not evidence against
-                    // the op: treat the submission as if it never happened.
-                    // Retry pacing during an event is left to normal submission
-                    // cadence and provider rate limiting.
-                    if provider_event_active {
+                    // Removal progress pauses during a provider event so that
+                    // provider issues cannot remove operations, but suspect
+                    // analysis continues: gating suspicion too would let a
+                    // poison herd large enough to trip the event keep riding
+                    // in normal bundles for as long as it sustains the event.
+                    if provider_event_active && op.is_suspect(suspect_threshold) {
+                        op.reschedule_retry(
+                            now,
+                            suspect_threshold,
+                            self.config.suspect_rpc_backoff_initial,
+                            self.config.suspect_rpc_backoff_max,
+                        );
                         continue;
                     }
                     let failures = op.record_failure(
@@ -1047,6 +1054,24 @@ impl OrderedPoolOperation {
                 Some(now + Self::suspect_backoff(backoff_initial, backoff_max, exponent));
         }
         state.failures
+    }
+
+    /// Schedules the next isolation retry without recording a failure, for
+    /// suspect failures that are not evidence against the operation (during a
+    /// provider event). No-op unless the operation is a suspect.
+    fn reschedule_retry(
+        &self,
+        now: Instant,
+        suspect_threshold: u32,
+        backoff_initial: Duration,
+        backoff_max: Duration,
+    ) {
+        let mut state = self.suspect_state.write();
+        if state.failures >= suspect_threshold {
+            let exponent = state.failures - suspect_threshold;
+            state.retry_after =
+                Some(now + Self::suspect_backoff(backoff_initial, backoff_max, exponent));
+        }
     }
 
     /// Backoff delay doubling from `initial` with ±20% jitter, capped at `max`.
@@ -2173,7 +2198,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_event_pauses_failure_counting() {
+    fn provider_event_pauses_removal_progress_only() {
         let mut pool = pool_with_conf(PoolInnerConfig {
             suspect_rpc_backoff_initial: Duration::from_secs(10),
             ..conf()
@@ -2187,14 +2212,26 @@ mod tests {
         pool.by_hash[&suspect].mark_suspect(3);
 
         let now = Instant::now();
-        pool.apply_bundle_outcome(&[non_suspect], BundleOutcome::NonTerminalFailure, true, now);
-        pool.apply_bundle_outcome(&[suspect], BundleOutcome::NonTerminalFailure, true, now);
+        for _ in 0..10 {
+            let to_remove = pool.apply_bundle_outcome(
+                &[non_suspect, suspect],
+                BundleOutcome::NonTerminalFailure,
+                true,
+                now,
+            );
+            // no removal ever fires during a provider event
+            assert!(to_remove.is_empty());
+        }
 
-        // a failure during a provider event changes no UO state
-        assert_eq!(pool.by_hash[&non_suspect].failures(), 0);
+        // suspect analysis continues during the event: the non-suspect accrues
+        // failures, is promoted at the threshold, and then freezes
+        assert_eq!(pool.by_hash[&non_suspect].failures(), 3);
+        // an existing suspect makes no removal progress
         assert_eq!(pool.by_hash[&suspect].failures(), 3);
-        assert!(pool.by_hash[&non_suspect].retry_due(now));
-        assert!(pool.by_hash[&suspect].retry_due(now));
+        // but its isolation retries stay spaced: 10s initial with ±20% jitter
+        let suspect_op = &pool.by_hash[&suspect];
+        assert!(!suspect_op.retry_due(now + Duration::from_millis(7_900)));
+        assert!(suspect_op.retry_due(now + Duration::from_millis(12_100)));
     }
 
     #[test]

--- a/crates/pool/src/mempool/uo_pool.rs
+++ b/crates/pool/src/mempool/uo_pool.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, sync::Arc, time::Instant};
 
 use alloy_primitives::{Address, B256, Bytes, U256, utils::format_units};
 use anyhow::Context;
@@ -29,8 +29,8 @@ use rundler_types::{
     Entity, EntityUpdate, EntityUpdateType, EntryPointVersion, GasFees, UserOperation,
     UserOperationId, UserOperationPermissions, UserOperationVariant,
     pool::{
-        MempoolError, PaymasterMetadata, PoolOperation, PoolOperationStatus, Reputation,
-        ReputationStatus, StakeStatus,
+        BundleOutcome, MempoolError, PaymasterMetadata, PoolOperation, PoolOperationStatus,
+        Reputation, ReputationStatus, StakeStatus,
     },
 };
 use rundler_utils::{emit::WithEntryPoint, guard_timer::CustomTimerGuard};
@@ -120,6 +120,29 @@ where
             entry_point: self.config.entry_point,
             event,
         });
+    }
+
+    fn remove_operations_with_reason(&self, hashes: &[B256], reason: OpRemovalReason) {
+        let mut count: u64 = 0;
+        let mut removed_hashes = vec![];
+        {
+            let mut state = self.state.write();
+            for hash in hashes {
+                if let Some(op) = state.pool.remove_operation_by_hash(*hash) {
+                    self.paymaster.remove_operation(&op.uo.id());
+                    count += 1;
+                    removed_hashes.push(*hash);
+                }
+            }
+        }
+
+        for hash in removed_hashes {
+            self.emit(OpPoolEvent::RemovedOp {
+                op_hash: hash,
+                reason: reason.clone(),
+            })
+        }
+        self.ep_specific_metrics.removed_operations.increment(count);
     }
 
     fn throttle_entity(&self, entity: Entity) {
@@ -790,26 +813,7 @@ where
     }
 
     fn remove_operations(&self, hashes: &[B256]) {
-        let mut count: u64 = 0;
-        let mut removed_hashes = vec![];
-        {
-            let mut state = self.state.write();
-            for hash in hashes {
-                if let Some(op) = state.pool.remove_operation_by_hash(*hash) {
-                    self.paymaster.remove_operation(&op.uo.id());
-                    count += 1;
-                    removed_hashes.push(*hash);
-                }
-            }
-        }
-
-        for hash in removed_hashes {
-            self.emit(OpPoolEvent::RemovedOp {
-                op_hash: hash,
-                reason: OpRemovalReason::Requested,
-            })
-        }
-        self.ep_specific_metrics.removed_operations.increment(count);
+        self.remove_operations_with_reason(hashes, OpRemovalReason::Requested);
     }
 
     fn get_op_by_id(&self, id: &UserOperationId) -> Option<Arc<PoolOperation>> {
@@ -899,6 +903,39 @@ where
             .filter(|op| filter_id == op.filter_id)
             .take(max)
             .collect())
+    }
+
+    fn due_suspect_operations(
+        &self,
+        max: usize,
+        filter_id: Option<String>,
+    ) -> MempoolResult<Vec<Arc<PoolOperation>>> {
+        let state = self.state.read();
+
+        Ok(state
+            .pool
+            .due_suspect_operations(Instant::now())
+            .filter(|op| filter_id == op.filter_id)
+            .take(max)
+            .collect())
+    }
+
+    fn report_bundle_outcome(
+        &self,
+        ops: &[B256],
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+    ) {
+        let to_remove = {
+            let state = self.state.read();
+            state
+                .pool
+                .apply_bundle_outcome(ops, outcome, provider_event_active, Instant::now())
+        };
+
+        for (hash, reason) in to_remove {
+            self.remove_operations_with_reason(&[hash], reason);
+        }
     }
 
     fn all_operations(&self, max: usize) -> Vec<Arc<PoolOperation>> {
@@ -1049,7 +1086,7 @@ struct UoPoolMetrics {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, str::FromStr, vec};
+    use std::{collections::HashMap, str::FromStr, time::Duration, vec};
 
     use alloy_primitives::{Address, Bytes, Log as PrimitiveLog, LogData, address, bytes, uint};
     use alloy_rpc_types_eth::TransactionReceipt as AlloyTransactionReceipt;
@@ -1123,6 +1160,58 @@ mod tests {
         check_ops(pool.best_operations(3, None).unwrap(), uos);
         pool.remove_operations(&hashes);
         assert_eq!(pool.best_operations(3, None).unwrap(), vec![]);
+    }
+
+    #[tokio::test]
+    async fn report_bundle_outcome_removes_after_repeated_failures() {
+        let op = create_op(Address::random(), 0, 0, None);
+        let pool = create_pool(vec![op.clone()]);
+        let hash = pool
+            .add_operation(OperationOrigin::Local, op.op, default_perms())
+            .await
+            .unwrap();
+
+        // suspect threshold 3 + removal allowance 3 = removal at the 6th failure
+        for _ in 0..5 {
+            pool.report_bundle_outcome(&[hash], BundleOutcome::NonTerminalFailure, false);
+            assert!(pool.get_user_operation_by_hash(hash).is_some());
+        }
+        pool.report_bundle_outcome(&[hash], BundleOutcome::NonTerminalFailure, false);
+        assert!(pool.get_user_operation_by_hash(hash).is_none());
+    }
+
+    #[tokio::test]
+    async fn report_bundle_outcome_success_clears_suspect() {
+        let op = create_op(Address::random(), 0, 0, None);
+        let uos = vec![op.op.clone()];
+        let pool = create_pool(vec![op.clone()]);
+        let hash = pool
+            .add_operation(OperationOrigin::Local, op.op, default_perms())
+            .await
+            .unwrap();
+
+        for _ in 0..3 {
+            pool.report_bundle_outcome(&[hash], BundleOutcome::NonTerminalFailure, false);
+        }
+        assert_eq!(pool.best_operations(1, None).unwrap(), vec![]);
+        check_ops(pool.due_suspect_operations(1, None).unwrap(), uos.clone());
+
+        pool.report_bundle_outcome(&[hash], BundleOutcome::Success, false);
+        check_ops(pool.best_operations(1, None).unwrap(), uos);
+        assert_eq!(pool.due_suspect_operations(1, None).unwrap(), vec![]);
+    }
+
+    #[tokio::test]
+    async fn report_bundle_outcome_terminal_removes_single() {
+        let op = create_op(Address::random(), 0, 0, None);
+        let pool = create_pool(vec![op.clone()]);
+        let hash = pool
+            .add_operation(OperationOrigin::Local, op.op, default_perms())
+            .await
+            .unwrap();
+
+        pool.report_bundle_outcome(&[hash], BundleOutcome::TerminalFailure, false);
+        assert!(pool.get_user_operation_by_hash(hash).is_none());
     }
 
     #[tokio::test]
@@ -2424,6 +2513,10 @@ mod tests {
             verification_gas_limit_efficiency_reject_threshold: 0.0,
             max_time_in_pool: None,
             max_expected_storage_slots: usize::MAX,
+            rpc_failures_before_suspect: 3,
+            max_suspect_rpc_failures: 3,
+            suspect_rpc_backoff_initial: Duration::from_secs(1),
+            suspect_rpc_backoff_max: Duration::from_secs(600),
         }
     }
 

--- a/crates/pool/src/mempool/uo_pool.rs
+++ b/crates/pool/src/mempool/uo_pool.rs
@@ -2513,6 +2513,7 @@ mod tests {
             verification_gas_limit_efficiency_reject_threshold: 0.0,
             max_time_in_pool: None,
             max_expected_storage_slots: usize::MAX,
+            suspect_tracking_enabled: true,
             rpc_failures_before_suspect: 3,
             max_suspect_rpc_failures: 3,
             suspect_rpc_backoff_initial: Duration::from_secs(1),

--- a/crates/pool/src/server/local.rs
+++ b/crates/pool/src/server/local.rs
@@ -34,7 +34,7 @@ use rundler_types::{
     EntityUpdate, EntryPointAbiVersion, UserOperation, UserOperationId, UserOperationPermissions,
     UserOperationVariant,
     pool::{
-        MempoolError, NewHead, PaymasterMetadata, Pool, PoolError, PoolOperation,
+        BundleOutcome, MempoolError, NewHead, PaymasterMetadata, Pool, PoolError, PoolOperation,
         PoolOperationStatus, PoolOperationSummary, PoolResult, Reputation, ReputationStatus,
         StakeStatus,
     },
@@ -202,11 +202,13 @@ impl Pool for LocalPoolHandle {
         &self,
         entry_point: Address,
         max_ops: u64,
+        max_suspects: u64,
         filter_id: Option<String>,
     ) -> PoolResult<Vec<PoolOperationSummary>> {
         let req = ServerRequestKind::GetOpsSummaries {
             entry_point,
             max_ops,
+            max_suspects,
             filter_id,
         };
         let resp = self.send(req).await?;
@@ -268,6 +270,26 @@ impl Pool for LocalPoolHandle {
         let resp = self.send(req).await?;
         match resp {
             ServerResponse::RemoveOpById { hash } => Ok(hash),
+            _ => Err(PoolError::UnexpectedResponse),
+        }
+    }
+
+    async fn report_bundle_outcome(
+        &self,
+        entry_point: Address,
+        ops: Vec<B256>,
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+    ) -> PoolResult<()> {
+        let req = ServerRequestKind::ReportBundleOutcome {
+            entry_point,
+            ops,
+            outcome,
+            provider_event_active,
+        };
+        let resp = self.send(req).await?;
+        match resp {
+            ServerResponse::ReportBundleOutcome => Ok(()),
             _ => Err(PoolError::UnexpectedResponse),
         }
     }
@@ -522,14 +544,26 @@ impl LocalPoolServerRunner {
         &self,
         entry_point: Address,
         max_ops: u64,
+        max_suspects: u64,
         filter_id: Option<String>,
     ) -> PoolResult<Vec<PoolOperationSummary>> {
         let mempool = self.get_pool(entry_point)?;
-        Ok(mempool
-            .best_operations(max_ops as usize, filter_id)?
+        let mut summaries: Vec<PoolOperationSummary> = mempool
+            .best_operations(max_ops as usize, filter_id.clone())?
             .iter()
             .map(|op| op.as_ref().into())
-            .collect())
+            .collect();
+        summaries.extend(
+            mempool
+                .due_suspect_operations(max_suspects as usize, filter_id)?
+                .iter()
+                .map(|op| {
+                    let mut summary: PoolOperationSummary = op.as_ref().into();
+                    summary.suspect = true;
+                    summary
+                }),
+        );
+        Ok(summaries)
     }
 
     fn get_ops_by_hashes(
@@ -579,6 +613,18 @@ impl LocalPoolServerRunner {
     ) -> PoolResult<Option<B256>> {
         let mempool = self.get_pool(entry_point)?;
         mempool.remove_op_by_id(id).map_err(|e| e.into())
+    }
+
+    fn report_bundle_outcome(
+        &self,
+        entry_point: Address,
+        ops: &[B256],
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+    ) -> PoolResult<()> {
+        let mempool = self.get_pool(entry_point)?;
+        mempool.report_bundle_outcome(ops, outcome, provider_event_active);
+        Ok(())
     }
 
     fn update_entities<'a>(
@@ -801,8 +847,8 @@ impl LocalPoolServerRunner {
                                 Err(e) => Err(e),
                             }
                         },
-                        ServerRequestKind::GetOpsSummaries { entry_point, max_ops, filter_id } => {
-                            match self.get_ops_summaries(entry_point, max_ops, filter_id) {
+                        ServerRequestKind::GetOpsSummaries { entry_point, max_ops, max_suspects, filter_id } => {
+                            match self.get_ops_summaries(entry_point, max_ops, max_suspects, filter_id) {
                                 Ok(summaries) => Ok(ServerResponse::GetOpsSummaries { summaries }),
                                 Err(e) => Err(e),
                             }
@@ -834,6 +880,12 @@ impl LocalPoolServerRunner {
                         ServerRequestKind::RemoveOpById { entry_point, id } => {
                             match self.remove_op_by_id(entry_point, &id) {
                                 Ok(hash) => Ok(ServerResponse::RemoveOpById{ hash }),
+                                Err(e) => Err(e),
+                            }
+                        },
+                        ServerRequestKind::ReportBundleOutcome { entry_point, ops, outcome, provider_event_active } => {
+                            match self.report_bundle_outcome(entry_point, &ops, outcome, provider_event_active) {
+                                Ok(_) => Ok(ServerResponse::ReportBundleOutcome),
                                 Err(e) => Err(e),
                             }
                         },
@@ -935,6 +987,7 @@ enum ServerRequestKind {
     GetOpsSummaries {
         entry_point: Address,
         max_ops: u64,
+        max_suspects: u64,
         filter_id: Option<String>,
     },
     GetOpsByHashes {
@@ -954,6 +1007,12 @@ enum ServerRequestKind {
     RemoveOpById {
         entry_point: Address,
         id: UserOperationId,
+    },
+    ReportBundleOutcome {
+        entry_point: Address,
+        ops: Vec<B256>,
+        outcome: BundleOutcome,
+        provider_event_active: bool,
     },
     UpdateEntities {
         entry_point: Address,
@@ -1033,6 +1092,7 @@ enum ServerResponse {
     RemoveOpById {
         hash: Option<B256>,
     },
+    ReportBundleOutcome,
     UpdateEntities,
     DebugClearState,
     AdminSetTracking,
@@ -1069,8 +1129,8 @@ mod tests {
     use parking_lot::RwLock;
     use reth_tasks::TaskManager;
     use rundler_types::{
-        EntryPointVersion, chain::ChainSpec, v0_6::UserOperation as UserOperationV0_6,
-        v0_7::UserOperation as UserOperationV0_7,
+        EntityInfos, EntryPointVersion, ValidTimeRange, chain::ChainSpec, da::DAGasData,
+        v0_6::UserOperation as UserOperationV0_6, v0_7::UserOperation as UserOperationV0_7,
     };
 
     use super::*;
@@ -1097,6 +1157,37 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(hash0, hash1);
+    }
+
+    #[tokio::test]
+    async fn test_get_ops_summaries_includes_due_suspects() {
+        let mut mock_pool = MockMempool::new();
+        let normal_op = Arc::new(mock_pool_operation());
+        let suspect_op = Arc::new(mock_pool_operation());
+        mock_pool
+            .expect_entry_point_version()
+            .returning(|| EntryPointVersion::V0_6);
+        mock_pool
+            .expect_best_operations()
+            .withf(|max, filter_id| *max == 10 && filter_id.is_none())
+            .returning(move |_, _| Ok(vec![normal_op.clone()]));
+        mock_pool
+            .expect_due_suspect_operations()
+            .withf(|max, filter_id| *max == 5 && filter_id.is_none())
+            .returning(move |_, _| Ok(vec![suspect_op.clone()]));
+
+        let ep = ChainSpec::default().entry_point_address_v0_6;
+        let pool: Arc<dyn Mempool> = Arc::new(mock_pool);
+        let state = setup(HashMap::from([(ep, pool)]));
+
+        let summaries = state
+            .handle
+            .get_ops_summaries(ep, 10, 5, None)
+            .await
+            .unwrap();
+        assert_eq!(summaries.len(), 2);
+        assert!(!summaries[0].suspect);
+        assert!(summaries[1].suspect);
     }
 
     #[tokio::test]
@@ -1225,6 +1316,24 @@ mod tests {
 
     fn mock_op() -> UserOperationVariant {
         UserOperationVariant::V0_6(UserOperationV0_6::default())
+    }
+
+    fn mock_pool_operation() -> PoolOperation {
+        PoolOperation {
+            uo: mock_op(),
+            entry_point: Address::random(),
+            aggregator: None,
+            valid_time_range: ValidTimeRange::default(),
+            expected_code_hash: B256::random(),
+            sim_block_hash: B256::random(),
+            sim_block_number: 0,
+            account_is_staked: false,
+            entity_infos: EntityInfos::default(),
+            da_gas_data: DAGasData::Empty,
+            filter_id: None,
+            perms: UserOperationPermissions::default(),
+            sender_is_7702: false,
+        }
     }
 
     fn mock_op_v0_7() -> UserOperationVariant {

--- a/crates/pool/src/server/remote/client.rs
+++ b/crates/pool/src/server/remote/client.rs
@@ -25,8 +25,9 @@ use rundler_types::{
     EntityUpdate, UserOperationId, UserOperationPermissions, UserOperationVariant,
     chain::ChainSpec,
     pool::{
-        NewHead, PaymasterMetadata, Pool, PoolError, PoolOperation, PoolOperationStatus,
-        PoolOperationSummary, PoolResult, Reputation, ReputationStatus, StakeStatus,
+        BundleOutcome, NewHead, PaymasterMetadata, Pool, PoolError, PoolOperation,
+        PoolOperationStatus, PoolOperationSummary, PoolResult, Reputation, ReputationStatus,
+        StakeStatus,
     },
 };
 use rundler_utils::retry::{self, UnlimitedRetryOpts};
@@ -52,7 +53,8 @@ use super::protos::{
     debug_set_reputation_response, get_op_by_hash_response, get_op_by_id_response,
     get_ops_by_hashes_response, get_ops_response, get_ops_summaries_response,
     get_reputation_status_response, get_stake_status_response, op_pool_client::OpPoolClient,
-    remove_op_by_id_response, remove_ops_response, update_entities_response,
+    remove_op_by_id_response, remove_ops_response, report_bundle_outcome_response,
+    update_entities_response,
 };
 
 /// Remote pool client
@@ -226,6 +228,7 @@ impl Pool for RemotePoolClient {
         &self,
         entry_point: Address,
         max_ops: u64,
+        max_suspects: u64,
         filter_id: Option<String>,
     ) -> PoolResult<Vec<PoolOperationSummary>> {
         let res = self
@@ -234,6 +237,7 @@ impl Pool for RemotePoolClient {
             .get_ops_summaries(protos::GetOpsSummariesRequest {
                 entry_point: entry_point.to_proto_bytes(),
                 max_ops,
+                max_suspects,
                 filter_id: filter_id.unwrap_or_default(),
             })
             .await
@@ -376,6 +380,36 @@ impl Pool for RemotePoolClient {
         match res {
             Some(remove_ops_response::Result::Success(_)) => Ok(()),
             Some(remove_ops_response::Result::Failure(f)) => Err(f.try_into()?),
+            None => Err(PoolError::Other(anyhow::anyhow!(
+                "should have received result from op pool"
+            )))?,
+        }
+    }
+
+    async fn report_bundle_outcome(
+        &self,
+        entry_point: Address,
+        ops: Vec<B256>,
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+    ) -> PoolResult<()> {
+        let res = self
+            .op_pool_client
+            .clone()
+            .report_bundle_outcome(protos::ReportBundleOutcomeRequest {
+                entry_point: entry_point.to_proto_bytes(),
+                hashes: ops.into_iter().map(|h| h.to_proto_bytes()).collect(),
+                outcome: protos::BundleOutcome::from(outcome) as i32,
+                provider_event_active,
+            })
+            .await
+            .map_err(anyhow::Error::from)?
+            .into_inner()
+            .result;
+
+        match res {
+            Some(report_bundle_outcome_response::Result::Success(_)) => Ok(()),
+            Some(report_bundle_outcome_response::Result::Failure(f)) => Err(f.try_into()?),
             None => Err(PoolError::Other(anyhow::anyhow!(
                 "should have received result from op pool"
             )))?,

--- a/crates/pool/src/server/remote/protos.rs
+++ b/crates/pool/src/server/remote/protos.rs
@@ -29,9 +29,10 @@ use rundler_types::{
         NitroDAGasData as RundlerNitroDAGasData,
     },
     pool::{
-        AddressUpdate as PoolAddressUpdate, NewHead as PoolNewHead,
-        PaymasterMetadata as PoolPaymasterMetadata, PendingBundleInfo as RundlerPendingBundleInfo,
-        PoolOperation, PoolOperationStatus as RundlerPoolOperationStatus,
+        AddressUpdate as PoolAddressUpdate, BundleOutcome as RundlerBundleOutcome,
+        NewHead as PoolNewHead, PaymasterMetadata as PoolPaymasterMetadata,
+        PendingBundleInfo as RundlerPendingBundleInfo, PoolOperation,
+        PoolOperationStatus as RundlerPoolOperationStatus,
         PoolOperationSummary as RundlerPoolOperationSummary, PreconfInfo as RundlerPreconfInfo,
         Reputation as PoolReputation, ReputationStatus as PoolReputationStatus,
         StakeStatus as RundlerStakeStatus,
@@ -723,6 +724,7 @@ impl From<RundlerPoolOperationSummary> for PoolOperationSummary {
                 .bundler_sponsorship_max_cost
                 .map(|c| c.to_proto_bytes())
                 .unwrap_or_default(),
+            suspect: summary.suspect,
         }
     }
 }
@@ -745,7 +747,33 @@ impl TryFrom<PoolOperationSummary> for RundlerPoolOperationSummary {
             max_priority_fee_per_gas: from_bytes(&summary.max_priority_fee_per_gas)?,
             gas_limit: from_bytes(&summary.gas_limit)?,
             bundler_sponsorship_max_cost,
+            suspect: summary.suspect,
         })
+    }
+}
+
+impl From<RundlerBundleOutcome> for BundleOutcome {
+    fn from(outcome: RundlerBundleOutcome) -> Self {
+        match outcome {
+            RundlerBundleOutcome::Success => BundleOutcome::Success,
+            RundlerBundleOutcome::NonTerminalFailure => BundleOutcome::NonTerminalFailure,
+            RundlerBundleOutcome::TerminalFailure => BundleOutcome::TerminalFailure,
+            RundlerBundleOutcome::MarkSuspect => BundleOutcome::MarkSuspect,
+        }
+    }
+}
+
+impl TryFrom<BundleOutcome> for RundlerBundleOutcome {
+    type Error = ConversionError;
+
+    fn try_from(outcome: BundleOutcome) -> Result<Self, Self::Error> {
+        match outcome {
+            BundleOutcome::Success => Ok(RundlerBundleOutcome::Success),
+            BundleOutcome::NonTerminalFailure => Ok(RundlerBundleOutcome::NonTerminalFailure),
+            BundleOutcome::TerminalFailure => Ok(RundlerBundleOutcome::TerminalFailure),
+            BundleOutcome::MarkSuspect => Ok(RundlerBundleOutcome::MarkSuspect),
+            BundleOutcome::Unspecified => Err(ConversionError::InvalidEnumValue(outcome as i32)),
+        }
     }
 }
 
@@ -864,6 +892,7 @@ mod tests {
             max_priority_fee_per_gas: 56,
             gas_limit: 100_000,
             bundler_sponsorship_max_cost: Some(U256::from(500_000)),
+            suspect: true,
         };
 
         let proto = PoolOperationSummary::from(summary.clone());
@@ -883,6 +912,7 @@ mod tests {
             converted.bundler_sponsorship_max_cost,
             summary.bundler_sponsorship_max_cost
         );
+        assert_eq!(converted.suspect, summary.suspect);
     }
 
     #[test]
@@ -896,6 +926,7 @@ mod tests {
             max_priority_fee_per_gas: 56,
             gas_limit: 100_000,
             bundler_sponsorship_max_cost: None,
+            suspect: false,
         };
 
         let proto = PoolOperationSummary::from(summary.clone());

--- a/crates/pool/src/server/remote/server.rs
+++ b/crates/pool/src/server/remote/server.rs
@@ -26,7 +26,10 @@ use async_trait::async_trait;
 use futures_util::StreamExt;
 use rundler_task::{
     GracefulShutdown, TaskSpawner,
-    grpc::{grpc_metrics::GrpcMetricsLayer, protos::from_bytes},
+    grpc::{
+        grpc_metrics::GrpcMetricsLayer,
+        protos::{ConversionError, from_bytes},
+    },
 };
 use rundler_types::{
     EntityUpdate, UserOperationId, UserOperationVariant,
@@ -39,7 +42,7 @@ use tonic::{Request, Response, Result, Status, transport::Server};
 
 use super::protos::{
     AddOpRequest, AddOpResponse, AddOpSuccess, AdminSetTrackingRequest, AdminSetTrackingResponse,
-    AdminSetTrackingSuccess, DebugClearStateRequest, DebugClearStateResponse,
+    AdminSetTrackingSuccess, BundleOutcome, DebugClearStateRequest, DebugClearStateResponse,
     DebugClearStateSuccess, DebugDumpMempoolRequest, DebugDumpMempoolResponse,
     DebugDumpMempoolSuccess, DebugDumpPaymasterBalancesRequest, DebugDumpPaymasterBalancesResponse,
     DebugDumpPaymasterBalancesSuccess, DebugDumpReputationRequest, DebugDumpReputationResponse,
@@ -54,16 +57,19 @@ use super::protos::{
     MempoolOp, NotifyPendingBundleRequest, NotifyPendingBundleResponse, NotifyPendingBundleSuccess,
     OP_POOL_FILE_DESCRIPTOR_SET, PoolOperationStatus, PoolOperationSummary, RemoveOpByIdRequest,
     RemoveOpByIdResponse, RemoveOpByIdSuccess, RemoveOpsRequest, RemoveOpsResponse,
-    RemoveOpsSuccess, ReputationStatus, SubscribeNewHeadsRequest, SubscribeNewHeadsResponse,
-    TryUoFromProto, UpdateEntitiesRequest, UpdateEntitiesResponse, UpdateEntitiesSuccess,
-    add_op_response, admin_set_tracking_response, debug_clear_state_response,
-    debug_dump_mempool_response, debug_dump_paymaster_balances_response,
-    debug_dump_reputation_response, debug_set_reputation_response, get_op_by_hash_response,
-    get_op_by_id_response, get_op_status_response, get_ops_by_hashes_response, get_ops_response,
+    RemoveOpsSuccess, ReportBundleOutcomeRequest, ReportBundleOutcomeResponse,
+    ReportBundleOutcomeSuccess, ReputationStatus, SubscribeNewHeadsRequest,
+    SubscribeNewHeadsResponse, TryUoFromProto, UpdateEntitiesRequest, UpdateEntitiesResponse,
+    UpdateEntitiesSuccess, add_op_response, admin_set_tracking_response,
+    debug_clear_state_response, debug_dump_mempool_response,
+    debug_dump_paymaster_balances_response, debug_dump_reputation_response,
+    debug_set_reputation_response, get_op_by_hash_response, get_op_by_id_response,
+    get_op_status_response, get_ops_by_hashes_response, get_ops_response,
     get_ops_summaries_response, get_reputation_status_response, get_stake_status_response,
     notify_pending_bundle_response,
     op_pool_server::{OpPool, OpPoolServer},
-    remove_op_by_id_response, remove_ops_response, update_entities_response,
+    remove_op_by_id_response, remove_ops_response, report_bundle_outcome_response,
+    update_entities_response,
 };
 use crate::server::local::LocalPoolHandle;
 
@@ -229,7 +235,7 @@ impl OpPool for OpPoolImpl {
 
         let resp = match self
             .local_pool
-            .get_ops_summaries(ep, req.max_ops, filter_id)
+            .get_ops_summaries(ep, req.max_ops, req.max_suspects, filter_id)
             .await
         {
             Ok(summaries) => GetOpsSummariesResponse {
@@ -358,6 +364,49 @@ impl OpPool for OpPoolImpl {
             },
             Err(error) => RemoveOpsResponse {
                 result: Some(remove_ops_response::Result::Failure(error.into())),
+            },
+        };
+
+        Ok(Response::new(resp))
+    }
+
+    async fn report_bundle_outcome(
+        &self,
+        request: Request<ReportBundleOutcomeRequest>,
+    ) -> Result<Response<ReportBundleOutcomeResponse>> {
+        let req = request.into_inner();
+        let ep = self.get_entry_point(&req.entry_point)?;
+
+        let hashes: Vec<B256> = req
+            .hashes
+            .into_iter()
+            .map(|h| {
+                if h.len() != 32 {
+                    return Err(Status::invalid_argument("Hash must be 32 bytes long"));
+                }
+                Ok(B256::from_slice(&h))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let outcome = BundleOutcome::try_from(req.outcome)
+            .map_err(|_| Status::invalid_argument("Invalid bundle outcome"))?
+            .try_into()
+            .map_err(|e: ConversionError| Status::invalid_argument(e.to_string()))?;
+
+        let resp = match self
+            .local_pool
+            .report_bundle_outcome(ep, hashes, outcome, req.provider_event_active)
+            .await
+        {
+            Ok(_) => ReportBundleOutcomeResponse {
+                result: Some(report_bundle_outcome_response::Result::Success(
+                    ReportBundleOutcomeSuccess {},
+                )),
+            },
+            Err(error) => ReportBundleOutcomeResponse {
+                result: Some(report_bundle_outcome_response::Result::Failure(
+                    error.into(),
+                )),
             },
         };
 

--- a/crates/types/src/pool/traits.rs
+++ b/crates/types/src/pool/traits.rs
@@ -49,6 +49,27 @@ pub struct PoolOperationSummary {
     pub gas_limit: u128,
     /// Maximum WEI the bundler will pay for this operation (None if not sponsored)
     pub bundler_sponsorship_max_cost: Option<U256>,
+    /// Whether the operation is suspected of poisoning bundles and must only be
+    /// submitted alone. See `docs/designs/poison-user-operations.md`.
+    pub suspect: bool,
+}
+
+/// Final outcome of a bundle submission attempt, reported to the pool for poison
+/// user operation tracking. See `docs/designs/poison-user-operations.md`.
+///
+/// Neutral outcomes (known operational errors with dedicated handling) are not
+/// reported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BundleOutcome {
+    /// The bundle transaction was accepted by the provider.
+    Success,
+    /// Transport failure, timeout, or ambiguous rejection; acceptance unknown.
+    NonTerminalFailure,
+    /// Final rejection; retrying the identical transaction cannot succeed.
+    TerminalFailure,
+    /// Mark every operation in the bundle as suspect, e.g. after an
+    /// unattributed mined revert of a multi-operation bundle.
+    MarkSuspect,
 }
 
 /// Pool server trait
@@ -74,10 +95,15 @@ pub trait Pool: Send + Sync {
     ) -> PoolResult<Vec<PoolOperation>>;
 
     /// Get summaries of operations from the pool
+    ///
+    /// Returns up to `max_ops` non-suspect operations, plus up to `max_suspects`
+    /// suspect operations whose isolation retry delay has elapsed, marked with
+    /// `suspect: true`. Suspects do not count against `max_ops`.
     async fn get_ops_summaries(
         &self,
         entry_point: Address,
         max_ops: u64,
+        max_suspects: u64,
         filter_id: Option<String>,
     ) -> PoolResult<Vec<PoolOperationSummary>>;
 
@@ -105,6 +131,19 @@ pub trait Pool: Send + Sync {
         entry_point: Address,
         id: UserOperationId,
     ) -> PoolResult<Option<B256>>;
+
+    /// Report the final outcome of a bundle submission attempt for the given
+    /// operations, for poison user operation tracking.
+    ///
+    /// `provider_event_active` gates suspect creation: while true, non-terminal
+    /// failures do not advance the failure counts of non-suspect operations.
+    async fn report_bundle_outcome(
+        &self,
+        entry_point: Address,
+        ops: Vec<B256>,
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+    ) -> PoolResult<()>;
 
     /// Get extended status for a user operation
     async fn get_op_status(&self, hash: B256) -> PoolResult<Option<PoolOperationStatus>>;
@@ -197,6 +236,7 @@ impl From<&PoolOperation> for PoolOperationSummary {
             max_priority_fee_per_gas: op.uo.max_priority_fee_per_gas(),
             gas_limit: op.uo.total_gas_limit(),
             bundler_sponsorship_max_cost: op.perms.bundler_sponsorship.as_ref().map(|s| s.max_cost),
+            suspect: false,
         }
     }
 }
@@ -223,6 +263,7 @@ mockall::mock! {
             &self,
             entry_point: Address,
             max_ops: u64,
+            max_suspects: u64,
             filter_id: Option<String>,
         ) -> PoolResult<Vec<PoolOperationSummary>>;
         async fn get_ops_by_hashes(
@@ -238,6 +279,13 @@ mockall::mock! {
             entry_point: Address,
             id: UserOperationId,
         ) -> PoolResult<Option<B256>>;
+        async fn report_bundle_outcome(
+            &self,
+            entry_point: Address,
+            ops: Vec<B256>,
+            outcome: BundleOutcome,
+            provider_event_active: bool,
+        ) -> PoolResult<()>;
         async fn update_entities(
             &self,
             entry_point: Address,

--- a/crates/types/src/pool/traits.rs
+++ b/crates/types/src/pool/traits.rs
@@ -135,8 +135,8 @@ pub trait Pool: Send + Sync {
     /// Report the final outcome of a bundle submission attempt for the given
     /// operations, for poison user operation tracking.
     ///
-    /// `provider_event_active` gates suspect creation: while true, non-terminal
-    /// failures do not advance the failure counts of non-suspect operations.
+    /// While `provider_event_active` is true, a non-terminal failure is not
+    /// evidence against its operations and changes no operation state.
     async fn report_bundle_outcome(
         &self,
         entry_point: Address,

--- a/crates/types/src/pool/traits.rs
+++ b/crates/types/src/pool/traits.rs
@@ -135,8 +135,10 @@ pub trait Pool: Send + Sync {
     /// Report the final outcome of a bundle submission attempt for the given
     /// operations, for poison user operation tracking.
     ///
-    /// While `provider_event_active` is true, a non-terminal failure is not
-    /// evidence against its operations and changes no operation state.
+    /// While `provider_event_active` is true, suspect analysis continues but
+    /// removal progress pauses: non-terminal failures still count toward
+    /// suspicion, while suspects only refresh their isolation backoff and
+    /// never advance toward removal.
     async fn report_bundle_outcome(
         &self,
         entry_point: Address,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -215,7 +215,7 @@ List of command line options for configuring the Pool.
 - `--pool.rpc_failures_before_suspect`: Number of non-terminal RPC submission failures before a UO becomes a suspect and is only submitted alone (default: `3`)
   - env: _POOL_RPC_FAILURES_BEFORE_SUSPECT_
   - See [poison user operations](./designs/poison-user-operations.md) for details. With a single builder signer, the scheduler cannot guarantee progress for both suspect and normal work when both remain continuously eligible.
-- `--pool.max_suspect_rpc_failures`: Number of non-terminal RPC submission failures a suspect is allowed before it is removed from the pool. `0` disables removal. (default: `3`)
+- `--pool.max_suspect_rpc_failures`: Number of non-terminal RPC submission failures a suspect is allowed before it is removed from the pool. `0` disables removal. (default: `8`)
   - env: _POOL_MAX_SUSPECT_RPC_FAILURES_
   - The suspect backoff schedule spaces these failures; a provider incident outlasting the cumulative backoff can remove healthy UOs. Raise this threshold to tolerate longer incidents.
 - `--pool.suspect_rpc_backoff_initial_secs`: Initial delay in seconds between suspect isolation attempts, doubling with each failure (default: `1`)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -209,6 +209,9 @@ List of command line options for configuring the Pool.
   - env: _POOL_DROP_MIN_NUM_BLOCKS_
 - `--pool.max_time_in_pool_secs`: The maximum amount of time a UO is allowed to be in the mempool, in seconds. (default: `None`)
   - env: _POOL_MAX_TIME_IN_POOL_SECS_
+- `--pool.suspect_tracking_enabled`: Master switch for poison user operation handling — suspect tracking, isolation, and removal (default: `false`)
+  - env: _POOL_SUSPECT_TRACKING_ENABLED_
+  - When disabled, bundle outcomes change no UO state and the `pool.*suspect*` options below have no effect.
 - `--pool.rpc_failures_before_suspect`: Number of non-terminal RPC submission failures before a UO becomes a suspect and is only submitted alone (default: `3`)
   - env: _POOL_RPC_FAILURES_BEFORE_SUSPECT_
   - See [poison user operations](./designs/poison-user-operations.md) for details. With a single builder signer, the scheduler cannot guarantee progress for both suspect and normal work when both remain continuously eligible.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -209,6 +209,16 @@ List of command line options for configuring the Pool.
   - env: _POOL_DROP_MIN_NUM_BLOCKS_
 - `--pool.max_time_in_pool_secs`: The maximum amount of time a UO is allowed to be in the mempool, in seconds. (default: `None`)
   - env: _POOL_MAX_TIME_IN_POOL_SECS_
+- `--pool.rpc_failures_before_suspect`: Number of non-terminal RPC submission failures before a UO becomes a suspect and is only submitted alone (default: `3`)
+  - env: _POOL_RPC_FAILURES_BEFORE_SUSPECT_
+  - See [poison user operations](./designs/poison-user-operations.md) for details. With a single builder signer, the scheduler cannot guarantee progress for both suspect and normal work when both remain continuously eligible.
+- `--pool.max_suspect_rpc_failures`: Number of non-terminal RPC submission failures a suspect is allowed before it is removed from the pool. `0` disables removal. (default: `3`)
+  - env: _POOL_MAX_SUSPECT_RPC_FAILURES_
+  - The suspect backoff schedule spaces these failures; a provider incident outlasting the cumulative backoff can remove healthy UOs. Raise this threshold to tolerate longer incidents.
+- `--pool.suspect_rpc_backoff_initial_secs`: Initial delay in seconds between suspect isolation attempts, doubling with each failure (default: `1`)
+  - env: _POOL_SUSPECT_RPC_BACKOFF_INITIAL_SECS_
+- `--pool.suspect_rpc_backoff_max_secs`: Maximum delay in seconds between suspect isolation attempts (default: `600`)
+  - env: _POOL_SUSPECT_RPC_BACKOFF_MAX_SECS_
 
 ## Builder Options
 

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -106,30 +106,39 @@ is entered or exited.
 
 ## Non-terminal RPC evidence
 
+Each UO carries a single failure counter measured against two thresholds. Suspect
+status is derived, not stored: a UO is a suspect once its counter reaches
+`--pool.rpc_failures_before_suspect` (default `3`), and is removed
+`--pool.max_suspect_rpc_failures` (default `3`) failures later.
+
 1. Outside a provider event, a final non-terminal provider failure increments the
-   pre-suspect count of every UO in the failed bundle. During an event, pre-suspect
-   counts do not advance.
-2. A successful submission clears the pre-suspect counts of every UO in that bundle.
-3. At `--pool.rpc_failures_before_suspect` (default `3`), a UO becomes a suspect and its
-   count resets.
-4. A final provider failure from its single-UO attempt schedules an exponentially
-   increasing retry delay with jitter.
-5. The failure also increments the suspect's removal count, regardless of
-   provider-event state.
-6. At `--pool.max_suspect_rpc_failures` (default `3`), the pool removes the UO and logs
-   `RepeatedNonTerminalRpcFailure`.
+   failure counter of every UO in the failed bundle. During an event, only counters
+   already past the suspect threshold advance.
+2. A successful submission resets the failure counter of every UO in that bundle,
+   clearing suspect status.
+3. At the suspect threshold the UO is excluded from normal bundles and becomes
+   eligible for an immediate isolation attempt.
+4. Each failure past the suspect threshold schedules an exponentially increasing
+   retry delay with jitter, and counts toward removal regardless of provider-event
+   state.
+5. At `suspect threshold + max_suspect_rpc_failures` total failures, the pool removes
+   the UO and logs `RepeatedNonTerminalRpcFailure`.
+
+Ambiguous multi-UO terminal failures and unattributed mined reverts force suspicion
+by raising the counter directly to the suspect threshold, never lowering it.
 
 `--pool.max_suspect_rpc_failures=0` disables RPC-based removal. Provider events pause
 pre-suspect counting only; suspect removal counting and backoff continue.
 
-Suspect backoff is configured with `--pool.suspect_rpc_backoff_initial_secs` and
-`--pool.suspect_rpc_backoff_max_secs`. The schedule is load-bearing for the
-false-removal bound: the cumulative delay across `max_suspect_rpc_failures` consecutive
-attempts must exceed the longest provider incident that removal should tolerate, so
-that a single incident contributes at most one removal increment. With doubling from a
-60-second initial, three increments span only about three minutes; tolerating a
-30-minute incident requires a larger initial (for example 600 seconds: 10 m + 20 m
-between increments), a steeper curve, or a higher removal threshold.
+Suspect backoff is configured with `--pool.suspect_rpc_backoff_initial_secs`
+(default `1`) and `--pool.suspect_rpc_backoff_max_secs` (default `600`). The schedule
+bounds false removal: the cumulative delay across `max_suspect_rpc_failures`
+consecutive attempts must exceed the longest provider incident that removal should
+tolerate, so that a single incident contributes at most one removal increment. The
+defaults favor fast poison eviction — the first three increments span only a few
+seconds, so a provider blip can remove a suspect. Tolerating a 30-minute incident
+requires a larger initial (for example 600 seconds: 10 m + 20 m between increments),
+a steeper curve, or a higher removal threshold.
 
 ## Suspect scheduling
 
@@ -152,10 +161,10 @@ state.
 ## State ownership
 
 The submission route owns the provider-event signal; the pool consumes it as a single
-boolean gate on pre-suspect counting. The pool owns pre-suspect counts, suspect status,
-suspect removal counts, and suspect retry times so they are shared across builders and
-cleared with the UO lifecycle. This state is in-memory and does not track transaction
-hashes for deduplication.
+boolean gate on pre-suspect counting. The pool owns each UO's failure counter (from
+which suspect status is derived) and suspect retry time so they are shared across
+builders and cleared with the UO lifecycle. This state is in-memory and does not track
+transaction hashes for deduplication.
 
 ## Tradeoffs
 
@@ -203,25 +212,32 @@ sees it.
 ### PR 2 — Pool-owned suspect state + trait surface
 
 - Add per-UO mutable state to `OrderedPoolOperation`
-  (`crates/pool/src/mempool/pool.rs`), which already uses interior `RwLock`s:
-  `pre_suspect_failures: u32`, `suspect: bool`, `suspect_removal_failures: u32`,
-  `retry_after: Option<Instant>`. State dies with the UO — no separate tracker needed.
+  (`crates/pool/src/mempool/pool.rs`), which already uses interior `RwLock`s: a single
+  `failures: u32` counter plus `retry_after: Option<Instant>`. Suspect status is
+  derived from the counter against the two thresholds; a success resets it. State
+  dies with the UO — no separate tracker needed.
 - Add config to `PoolConfig` (`crates/pool/src/mempool/mod.rs`) and CLI args in
   `bin/rundler/src/cli/pool.rs`: `rpc_failures_before_suspect` (default 3),
   `max_suspect_rpc_failures` (default 3, 0 disables removal),
-  `suspect_rpc_backoff_initial_secs`, `suspect_rpc_backoff_max_secs`.
-- Add one new `Pool` trait method (`crates/types/src/pool/traits.rs`), roughly
-  `report_bundle_outcome(ops, outcome, provider_event_active)`, where outcome is
-  success / non-terminal failure / terminal failure / mark-suspect. The pool applies
-  the failure-flow table internally: clear counts on success, increment pre-suspect
-  counts (unless a provider event is active), promote to suspect at threshold,
-  increment removal counts + compute backoff for isolated suspects, remove at
-  `max_suspect_rpc_failures` with a new
-  `OpRemovalReason::RepeatedNonTerminalRpcFailure` (`crates/pool/src/emit.rs`).
-  Implement in `UoPool`, `LocalPoolHandle`, and the remote protobuf client/server.
-- Exclude suspects from `best_operations` (`crates/pool/src/mempool/uo_pool.rs`) and
-  expose suspects whose `retry_after` has elapsed (a flag on the existing summaries
-  query is simpler than a new method).
+  `suspect_rpc_backoff_initial_secs` (default 1), `suspect_rpc_backoff_max_secs`
+  (default 600).
+- Add one new `Pool` trait method (`crates/types/src/pool/traits.rs`),
+  `report_bundle_outcome(entry_point, ops, outcome, provider_event_active)`, where
+  outcome is success / non-terminal failure / terminal failure / mark-suspect. The
+  pool applies the failure-flow table internally: reset counters on success,
+  increment counters on non-terminal failure (skipping non-suspects while a provider
+  event is active), compute backoff for isolated suspects, remove at the removal
+  threshold with a new `OpRemovalReason::RepeatedNonTerminalRpcFailure`, and remove
+  terminally rejected singletons with `OpRemovalReason::TerminalRpcError`
+  (`crates/pool/src/emit.rs`). Implement in `UoPool`, `LocalPoolHandle`, and the
+  remote protobuf client/server.
+- Exclude suspects from `best_operations` (`crates/pool/src/mempool/pool.rs`). Rather
+  than a new query method, `get_ops_summaries` takes a `max_suspects` cap and appends
+  due suspects (retry delay elapsed) to its response, marked with a `suspect` flag on
+  `PoolOperationSummary`; the assigner passes `max_suspects: 0` until PR 4. Because
+  the flag rides on the summary, this degrades gracefully if PR 3 lands first:
+  requesting no suspects leaves them waiting invisibly, and any nonzero cap without
+  isolation scheduling simply restores today's behavior.
 
 ### PR 3 — Failure flow in the bundle sender
 

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -8,9 +8,11 @@ Status: Draft
    fail, preventing them from blocking bundle submission indefinitely.
 2. **Fairness:** schedule healthy and suspect UOs so neither work class can starve the
    other.
-3. **Provider resilience:** once a provider-health event is detected, stop punishing
-   UOs entirely — no suspicion, no removal progress. Detection is best effort; the
-   suspect backoff schedule spaces evidence to bound damage from undetected incidents.
+3. **Provider resilience:** once a provider-health event is detected, no UO makes
+   progress toward removal, so provider issues cannot remove operations. Suspect
+   analysis continues during events because suspicion is recoverable and isolation is
+   what protects bundling. Detection is best effort; the suspect backoff schedule
+   spaces evidence to bound damage from undetected incidents.
 
 ## How the goals are achieved
 
@@ -39,13 +41,20 @@ both remain continuously eligible.
 
 ### Provider resilience
 
-A failure during a detected provider event is not evidence against a UO. Only final
-outcomes after provider retries and fallbacks affect the provider-event signal, and
-while an event is active, a non-terminal failure changes no UO state — no counter
-advances toward suspicion or removal — so a detected outage can neither mass-convert
-the pool into suspects nor remove UOs. Submissions during an event are treated as if
-they never happened; retry pacing is left to normal submission cadence and provider
-rate limiting, as it is for normal bundles.
+A detected provider event pauses removal, not analysis. While an event is active,
+non-terminal failures still count toward suspicion — quarantine keeps working — but a
+suspect's counter freezes: it makes no progress toward removal, and failures during
+the event never contribute to a later removal. Suspects failing during an event still
+refresh their isolation backoff so retries stay spaced.
+
+Suspicion deliberately stays live during events because gating it is exploitable: a
+herd of poison UOs large enough to trip the provider-event signal with its own
+failures would otherwise keep riding in normal bundles — unsuspectable for exactly as
+long as it sustains the event. With analysis live, such a herd is quarantined into
+isolation even while the event is active; once quarantined, normal bundles recover,
+the event clears, and removal resumes. The cost is that a genuine outage progressively
+suspects the UOs it touches; suspicion is recoverable, so after recovery each false
+suspect clears itself with one successful singleton, at isolation throughput.
 
 Detection requires a rolling sample, so failures observed before the signal activates
 still count; the suspect backoff schedule spaces those increments to bound the damage
@@ -65,7 +74,7 @@ reject the transaction.
 | Terminal RPC error | More than 1 | Mark every UO as suspect immediately. |
 | Non-terminal provider failure while provider is healthy | Any | Increment each non-suspect UO's RPC-failure count; mark it suspect at the configured threshold. |
 | Non-terminal provider failure from an isolated suspect | 1 | Increment its suspect removal count, back off, and remove it at the configured threshold. |
-| Non-terminal provider failure during a provider event | Any | No UO state change. |
+| Non-terminal provider failure during a provider event | Any | Non-suspects accrue toward suspicion as normal; suspects only refresh their isolation backoff, making no removal progress. |
 | Known operational error | Any | Preserve existing behavior. |
 
 Provider retries and configured fallbacks are exhausted before an RPC outcome enters
@@ -98,9 +107,9 @@ Initial parameters:
 Different enter and exit thresholds prevent flapping. The signal does not change bundle
 construction or submission rate; existing provider rate limiting handles request pacing.
 
-The signal has exactly one effect: while a provider event is active, a non-terminal
-failure changes no UO state, so no new suspects are created and no suspects progress
-toward removal. No counter state is cleared when an event is entered or exited.
+The signal has exactly one effect: while a provider event is active, suspects make no
+progress toward removal. Suspect creation and isolation backoff are unaffected. No
+counter state is cleared when an event is entered or exited.
 
 ## Non-terminal RPC evidence
 
@@ -109,9 +118,9 @@ status is derived, not stored: a UO is a suspect once its counter reaches
 `--pool.rpc_failures_before_suspect` (default `3`), and is removed
 `--pool.max_suspect_rpc_failures` (default `3`) failures later.
 
-1. Outside a provider event, a final non-terminal provider failure increments the
-   failure counter of every UO in the failed bundle. During an event, no counters
-   advance.
+1. A final non-terminal provider failure increments the failure counter of every
+   non-suspect UO in the failed bundle. During a provider event, suspects' counters
+   freeze; non-suspects continue to accrue.
 2. A successful submission resets the failure counter of every UO in that bundle,
    clearing suspect status.
 3. At the suspect threshold the UO is excluded from normal bundles and becomes
@@ -125,11 +134,11 @@ Ambiguous multi-UO terminal failures and unattributed mined reverts force suspic
 by raising the counter directly to the suspect threshold, never lowering it.
 
 `--pool.max_suspect_rpc_failures=0` disables RPC-based removal. Provider events pause
-all failure counting; failures during an event change no UO state.
+removal progress only; suspect creation and isolation backoff continue.
 
 Suspect backoff is configured with `--pool.suspect_rpc_backoff_initial_secs`
 (default `1`) and `--pool.suspect_rpc_backoff_max_secs` (default `600`). Detected
-provider events do not count against UOs at all; the backoff schedule bounds false
+provider events pause removal progress entirely; the backoff schedule bounds false
 removal from incidents the signal misses (detection lag, or failure rates below the
 event threshold): the cumulative delay across `max_suspect_rpc_failures` consecutive
 attempts must exceed the longest undetected incident that removal should tolerate.
@@ -159,28 +168,29 @@ state.
 ## State ownership
 
 The submission route owns the provider-event signal; the pool consumes it as a single
-boolean gate on failure counting. The pool owns each UO's failure counter (from
+boolean gate on suspect removal progress. The pool owns each UO's failure counter (from
 which suspect status is derived) and suspect retry time so they are shared across
 builders and cleared with the UO lifecycle. This state is in-memory and does not track
 transaction hashes for deduplication.
 
 ## Tradeoffs
 
-- **Liveness versus false removal:** eventual removal protects bundling, but a
-  poison UO that keeps the provider-event signal active (its own failures feed the
-  window) is never removed while the event lasts, and failures persisting across the
-  backoff span during an undetected incident can still remove a healthy UO. Higher
-  thresholds and longer backoff reduce false removals but extend poison lifetime.
+- **Liveness versus false removal:** eventual removal protects bundling, but
+  failures persisting across the backoff span during an undetected incident can
+  still remove a healthy UO. Higher thresholds and longer backoff reduce false
+  removals but extend poison lifetime. Poison that sustains a provider event is
+  quarantined but not removed until the event clears; bundling is protected by the
+  quarantine, and pool size and age limits bound the accumulation.
 - **Isolation versus throughput:** singleton attempts identify poison UOs without adding
   innocent fillers, but consume more transactions than normal bundles. The dynamic
   isolation limit preserves normal capacity at the cost of slower suspect draining.
-- **Provider protection versus poison detection:** pausing all failure counting during
-  provider events prevents false suspicion and false removal, but a poison UO
-  encountered during an event makes no progress toward identification or removal until
-  the event clears. Detection lag can still create false suspects before the signal
-  activates; each costs one wasted singleton attempt after recovery and then
-  self-clears. An outage that outlasts detection lag may still suspect part of the
-  pool, which drains at singleton throughput after recovery.
+- **Provider protection versus poison detection:** pausing removal during provider
+  events guarantees provider issues cannot remove UOs, at the cost that poison
+  sustaining an event lingers in isolation until the event clears. Keeping suspect
+  analysis live during events closes the herd loophole but means a genuine outage
+  progressively suspects the UOs it touches; each false suspect self-clears with one
+  successful singleton after recovery, so a long outage drains at isolation
+  throughput afterward.
 - **Backoff versus recovery latency:** per-suspect backoff prevents hot loops and resource
   churn, but delays successful retry after a transient failure.
 
@@ -225,9 +235,10 @@ sees it.
   `report_bundle_outcome(entry_point, ops, outcome, provider_event_active)`, where
   outcome is success / non-terminal failure / terminal failure / mark-suspect. The
   pool applies the failure-flow table internally: reset counters on success,
-  increment counters on non-terminal failure (a no-op while a provider event is
-  active), compute backoff for isolated suspects, remove at the removal
-  threshold with a new `OpRemovalReason::RepeatedNonTerminalRpcFailure`, and remove
+  increment counters on non-terminal failure (suspects' counters freeze while a
+  provider event is active), compute backoff for isolated suspects, remove at the
+  removal threshold with a new `OpRemovalReason::RepeatedNonTerminalRpcFailure`, and
+  remove
   terminally rejected singletons with `OpRemovalReason::TerminalRpcError`
   (`crates/pool/src/emit.rs`). Implement in `UoPool`, `LocalPoolHandle`, and the
   remote protobuf client/server.
@@ -286,8 +297,13 @@ exclusion behind PR 4.
   recorder.
 - Expose it as a shared `Arc` boolean checked by the bundle sender when calling
   `report_bundle_outcome` (the `provider_event_active` flag from PR 2). Its only
-  effect: pause all failure counting, so failures during an event change no UO
-  state. No counters are cleared on enter/exit.
+  effect: pause suspect removal progress. Suspect creation and backoff are
+  unaffected, and no counters are cleared on enter/exit.
+- Consider recording only transport-level failures (timeouts, connection failures,
+  sender unavailable) in the window and excluding error responses: a node that
+  evaluates a transaction and answers is not an outage, and rejected-with-a-response
+  is what poison looks like, so this keeps poison herds from tripping the signal at
+  all.
 - Ships last deliberately — without it the system is fully functional, just without
   outage protection (bounded in the interim only by the backoff spacing from PR 2).
 

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -8,9 +8,9 @@ Status: Draft
    fail, preventing them from blocking bundle submission indefinitely.
 2. **Fairness:** schedule healthy and suspect UOs so neither work class can starve the
    other.
-3. **Provider resilience:** prevent provider-health events from converting healthy UOs
-   into suspects (best effort, via detection) or removing them (unconditional, via
-   evidence spacing).
+3. **Provider resilience:** once a provider-health event is detected, stop punishing
+   UOs entirely — no suspicion, no removal progress. Detection is best effort; the
+   suspect backoff schedule spaces evidence to bound damage from undetected incidents.
 
 ## How the goals are achieved
 
@@ -39,19 +39,20 @@ both remain continuously eligible.
 
 ### Provider resilience
 
-Protection is two-tier. Suspect creation is gated by detection: only final outcomes
-after provider retries and fallbacks affect the provider-event signal, and while an
-event is active, non-terminal failures do not advance pre-suspect counts, so an outage
-cannot mass-convert the pool into suspects. Removal is protected independently of
-detection: the suspect backoff schedule spaces removal-counter increments so that a
-single provider incident contributes at most one increment (see "Non-terminal RPC
-evidence").
+A failure during a detected provider event is not evidence against a UO. Only final
+outcomes after provider retries and fallbacks affect the provider-event signal, and
+while an event is active, a non-terminal failure changes no UO state — no counter
+advances toward suspicion or removal — so a detected outage can neither mass-convert
+the pool into suspects nor remove UOs. Submissions during an event are treated as if
+they never happened; retry pacing is left to normal submission cadence and provider
+rate limiting, as it is for normal bundles.
 
 Detection requires a rolling sample, so failures observed before the signal activates
-may still create suspects. Because suspicion is recoverable — a healthy suspect
-succeeds in isolation and clears — detection lag costs wasted singleton attempts, not
-false removals. Terminal RPC errors bypass provider-health gating because they
-definitively reject the transaction.
+still count; the suspect backoff schedule spaces those increments to bound the damage
+from an undetected incident. Because suspicion is recoverable — a healthy suspect
+succeeds in isolation and clears — detection lag mostly costs wasted singleton
+attempts. Terminal RPC errors bypass provider-health gating because they definitively
+reject the transaction.
 
 ## Failure flow
 
@@ -64,7 +65,7 @@ definitively reject the transaction.
 | Terminal RPC error | More than 1 | Mark every UO as suspect immediately. |
 | Non-terminal provider failure while provider is healthy | Any | Increment each non-suspect UO's RPC-failure count; mark it suspect at the configured threshold. |
 | Non-terminal provider failure from an isolated suspect | 1 | Increment its suspect removal count, back off, and remove it at the configured threshold. |
-| Non-terminal provider failure from a normal bundle during a provider event | Any | Do not advance pre-suspect counts; no other UO state change. |
+| Non-terminal provider failure during a provider event | Any | No UO state change. |
 | Known operational error | Any | Preserve existing behavior. |
 
 Provider retries and configured fallbacks are exhausted before an RPC outcome enters
@@ -97,12 +98,9 @@ Initial parameters:
 Different enter and exit thresholds prevent flapping. The signal does not change bundle
 construction or submission rate; existing provider rate limiting handles request pacing.
 
-The signal has exactly one effect: while a provider event is active, non-terminal
-failures do not advance pre-suspect counts, so no new suspects are created. Suspect
-backoff and removal counting are unaffected by the signal; false removal is bounded by
-the backoff schedule's evidence spacing rather than by detection. Because the gate's
-only failure mode is recoverable suspicion, no counter state is cleared when an event
-is entered or exited.
+The signal has exactly one effect: while a provider event is active, a non-terminal
+failure changes no UO state, so no new suspects are created and no suspects progress
+toward removal. No counter state is cleared when an event is entered or exited.
 
 ## Non-terminal RPC evidence
 
@@ -112,15 +110,14 @@ status is derived, not stored: a UO is a suspect once its counter reaches
 `--pool.max_suspect_rpc_failures` (default `3`) failures later.
 
 1. Outside a provider event, a final non-terminal provider failure increments the
-   failure counter of every UO in the failed bundle. During an event, only counters
-   already past the suspect threshold advance.
+   failure counter of every UO in the failed bundle. During an event, no counters
+   advance.
 2. A successful submission resets the failure counter of every UO in that bundle,
    clearing suspect status.
 3. At the suspect threshold the UO is excluded from normal bundles and becomes
    eligible for an immediate isolation attempt.
-4. Each failure past the suspect threshold schedules an exponentially increasing
-   retry delay with jitter, and counts toward removal regardless of provider-event
-   state.
+4. Each counted failure past the suspect threshold schedules an exponentially
+   increasing retry delay with jitter.
 5. At `suspect threshold + max_suspect_rpc_failures` total failures, the pool removes
    the UO and logs `RepeatedNonTerminalRpcFailure`.
 
@@ -128,17 +125,18 @@ Ambiguous multi-UO terminal failures and unattributed mined reverts force suspic
 by raising the counter directly to the suspect threshold, never lowering it.
 
 `--pool.max_suspect_rpc_failures=0` disables RPC-based removal. Provider events pause
-pre-suspect counting only; suspect removal counting and backoff continue.
+all failure counting; failures during an event change no UO state.
 
 Suspect backoff is configured with `--pool.suspect_rpc_backoff_initial_secs`
-(default `1`) and `--pool.suspect_rpc_backoff_max_secs` (default `600`). The schedule
-bounds false removal: the cumulative delay across `max_suspect_rpc_failures`
-consecutive attempts must exceed the longest provider incident that removal should
-tolerate, so that a single incident contributes at most one removal increment. The
-defaults favor fast poison eviction — the first three increments span only a few
-seconds, so a provider blip can remove a suspect. Tolerating a 30-minute incident
-requires a larger initial (for example 600 seconds: 10 m + 20 m between increments),
-a steeper curve, or a higher removal threshold.
+(default `1`) and `--pool.suspect_rpc_backoff_max_secs` (default `600`). Detected
+provider events do not count against UOs at all; the backoff schedule bounds false
+removal from incidents the signal misses (detection lag, or failure rates below the
+event threshold): the cumulative delay across `max_suspect_rpc_failures` consecutive
+attempts must exceed the longest undetected incident that removal should tolerate.
+The defaults favor fast poison eviction — the first three increments span only a few
+seconds — and lean on the provider-event signal for outage protection. Tolerating
+longer undetected incidents requires a larger initial, a steeper curve, or a higher
+removal threshold.
 
 ## Suspect scheduling
 
@@ -161,24 +159,26 @@ state.
 ## State ownership
 
 The submission route owns the provider-event signal; the pool consumes it as a single
-boolean gate on pre-suspect counting. The pool owns each UO's failure counter (from
+boolean gate on failure counting. The pool owns each UO's failure counter (from
 which suspect status is derived) and suspect retry time so they are shared across
 builders and cleared with the UO lifecycle. This state is in-memory and does not track
 transaction hashes for deduplication.
 
 ## Tradeoffs
 
-- **Liveness versus false removal:** eventual removal protects bundling, but failures
-  persisting across the entire backoff span can still remove a healthy UO — for
-  example, a provider incident longer than the cumulative suspect backoff. Higher
+- **Liveness versus false removal:** eventual removal protects bundling, but a
+  poison UO that keeps the provider-event signal active (its own failures feed the
+  window) is never removed while the event lasts, and failures persisting across the
+  backoff span during an undetected incident can still remove a healthy UO. Higher
   thresholds and longer backoff reduce false removals but extend poison lifetime.
 - **Isolation versus throughput:** singleton attempts identify poison UOs without adding
   innocent fillers, but consume more transactions than normal bundles. The dynamic
   isolation limit preserves normal capacity at the cost of slower suspect draining.
-- **Provider protection versus poison detection:** pausing pre-suspect counting during
-  provider events prevents mass false suspicion, but a poison UO encountered during an
-  event takes longer to identify. Detection lag can still create false suspects before
-  the signal activates; each costs one wasted singleton attempt after recovery and then
+- **Provider protection versus poison detection:** pausing all failure counting during
+  provider events prevents false suspicion and false removal, but a poison UO
+  encountered during an event makes no progress toward identification or removal until
+  the event clears. Detection lag can still create false suspects before the signal
+  activates; each costs one wasted singleton attempt after recovery and then
   self-clears. An outage that outlasts detection lag may still suspect part of the
   pool, which drains at singleton throughput after recovery.
 - **Backoff versus recovery latency:** per-suspect backoff prevents hot loops and resource
@@ -225,8 +225,8 @@ sees it.
   `report_bundle_outcome(entry_point, ops, outcome, provider_event_active)`, where
   outcome is success / non-terminal failure / terminal failure / mark-suspect. The
   pool applies the failure-flow table internally: reset counters on success,
-  increment counters on non-terminal failure (skipping non-suspects while a provider
-  event is active), compute backoff for isolated suspects, remove at the removal
+  increment counters on non-terminal failure (a no-op while a provider event is
+  active), compute backoff for isolated suspects, remove at the removal
   threshold with a new `OpRemovalReason::RepeatedNonTerminalRpcFailure`, and remove
   terminally rejected singletons with `OpRemovalReason::TerminalRpcError`
   (`crates/pool/src/emit.rs`). Implement in `UoPool`, `LocalPoolHandle`, and the
@@ -286,11 +286,10 @@ exclusion behind PR 4.
   recorder.
 - Expose it as a shared `Arc` boolean checked by the bundle sender when calling
   `report_bundle_outcome` (the `provider_event_active` flag from PR 2). Its only
-  effect: pause pre-suspect counting. No counters are cleared on enter/exit, and
-  suspect backoff/removal counting are unaffected.
+  effect: pause all failure counting, so failures during an event change no UO
+  state. No counters are cleared on enter/exit.
 - Ships last deliberately — without it the system is fully functional, just without
-  outage protection for suspect creation (removal is already protected by backoff
-  spacing from PR 2).
+  outage protection (bounded in the interim only by the backoff spacing from PR 2).
 
 ## Related work
 

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -77,6 +77,11 @@ reject the transaction.
 | Non-terminal provider failure during a provider event | Any | Non-suspects accrue toward suspicion as normal; suspects only refresh their isolation backoff, making no removal progress. |
 | Known operational error | Any | Preserve existing behavior. |
 
+The entire flow is gated behind `--pool.suspect_tracking_enabled` (default `false`).
+When disabled, bundle outcomes change no UO state: no operation is ever suspected or
+removed by this system. This allows the mechanism to ship dark and be enabled
+deliberately once every stage — including the provider-event signal — is deployed.
+
 Provider retries and configured fallbacks are exhausted before an RPC outcome enters
 this flow. A successful fallback has no effect on UO state.
 
@@ -227,7 +232,8 @@ sees it.
   derived from the counter against the two thresholds; a success resets it. State
   dies with the UO — no separate tracker needed.
 - Add config to `PoolConfig` (`crates/pool/src/mempool/mod.rs`) and CLI args in
-  `bin/rundler/src/cli/pool.rs`: `rpc_failures_before_suspect` (default 3),
+  `bin/rundler/src/cli/pool.rs`: `suspect_tracking_enabled` (default false, the
+  master switch), `rpc_failures_before_suspect` (default 3),
   `max_suspect_rpc_failures` (default 3, 0 disables removal),
   `suspect_rpc_backoff_initial_secs` (default 1), `suspect_rpc_backoff_max_secs`
   (default 600).

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -121,7 +121,7 @@ counter state is cleared when an event is entered or exited.
 Each UO carries a single failure counter measured against two thresholds. Suspect
 status is derived, not stored: a UO is a suspect once its counter reaches
 `--pool.rpc_failures_before_suspect` (default `3`), and is removed
-`--pool.max_suspect_rpc_failures` (default `3`) failures later.
+`--pool.max_suspect_rpc_failures` (default `8`) failures later.
 
 1. A final non-terminal provider failure increments the failure counter of every
    non-suspect UO in the failed bundle. During a provider event, suspects' counters
@@ -147,10 +147,11 @@ provider events pause removal progress entirely; the backoff schedule bounds fal
 removal from incidents the signal misses (detection lag, or failure rates below the
 event threshold): the cumulative delay across `max_suspect_rpc_failures` consecutive
 attempts must exceed the longest undetected incident that removal should tolerate.
-The defaults favor fast poison eviction — the first three increments span only a few
-seconds — and lean on the provider-event signal for outage protection. Tolerating
-longer undetected incidents requires a larger initial, a steeper curve, or a higher
-removal threshold.
+The defaults spend roughly four minutes of cumulative backoff (1+2+4+8+16+32+64+128s
+before jitter) across the 8 allowed failures before removal, giving the
+provider-event signal a real chance to observe a genuine incident and pause removal
+before it fires. Tolerating longer undetected incidents still requires a larger
+initial, a steeper curve, or a higher removal threshold.
 
 ## Suspect scheduling
 
@@ -234,7 +235,7 @@ sees it.
 - Add config to `PoolConfig` (`crates/pool/src/mempool/mod.rs`) and CLI args in
   `bin/rundler/src/cli/pool.rs`: `suspect_tracking_enabled` (default false, the
   master switch), `rpc_failures_before_suspect` (default 3),
-  `max_suspect_rpc_failures` (default 3, 0 disables removal),
+  `max_suspect_rpc_failures` (default 8, 0 disables removal),
   `suspect_rpc_backoff_initial_secs` (default 1), `suspect_rpc_backoff_max_secs`
   (default 600).
 - Add one new `Pool` trait method (`crates/types/src/pool/traits.rs`),


### PR DESCRIPTION
Part of the poison user operation design (PR 2 of 5, see `docs/designs/poison-user-operations.md`). Stacked on #1312.

## Proposed Changes

- Add pool-owned suspect state: each operation carries a single failure counter measured against two thresholds — suspect at `--pool.rpc_failures_before_suspect` (default 3), removed `--pool.max_suspect_rpc_failures` (default 3) failures later. Suspect status is derived from the counter; any successful submission resets it.
- Suspects are excluded from `best_operations` and retried alone, spaced by jittered exponential backoff (`--pool.suspect_rpc_backoff_initial_secs` 1s doubling to `--pool.suspect_rpc_backoff_max_secs` 600s).
- Add `Pool::report_bundle_outcome(entry_point, ops, outcome, provider_event_active)` applying the failure-flow table: reset on success, count non-terminal failures, remove terminal singletons, mark multi-op terminal/mined-revert bundles suspect. New `OpRemovalReason::{TerminalRpcError, RepeatedNonTerminalRpcFailure}`.
- During a provider event, suspect analysis continues but removal progress pauses: non-suspects still accrue toward suspicion (a poison herd cannot shield itself by tripping the signal with its own failures), while suspects' counters freeze and only their isolation backoff refreshes — provider issues can never remove an operation.
- Gate the entire flow behind a master switch, `--pool.suspect_tracking_enabled` (default `false`): when disabled, bundle outcomes change no UO state.
- `get_ops_summaries` gains a `max_suspects` cap and appends due suspects (backoff elapsed) beyond `max_ops`, flagged via a new `suspect` field on `PoolOperationSummary` — no separate query method for the assigner.
- Wire the full surface: local pool server, gRPC proto/client/server, mocks, CLI args, `docs/cli.md`, and align the design doc with the single-counter model.

**Inert by design**: the master switch defaults to off, nothing calls `report_bundle_outcome` in production, and the assigner passes `max_suspects: 0` — no operation can become suspect until PR 3 wires the bundle sender and the flag is deliberately enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
