### PR TITLE
feat(builder): wire the poison user operation failure flow, isolation scheduling, and provider-event signal

### DIFF
--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -187,6 +187,10 @@ pub struct PoolArgs {
 
     /// Number of non-terminal RPC submission failures before a user operation
     /// becomes a suspect and is only submitted alone.
+    ///
+    /// With a single builder signer, the scheduler cannot guarantee progress
+    /// for both suspect and normal work when both remain continuously
+    /// eligible.
     #[arg(
         long = "pool.rpc_failures_before_suspect",
         name = "pool.rpc_failures_before_suspect",

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -53,6 +53,7 @@ mockall.workspace = true
 rundler-provider = { workspace = true, features = ["test-utils"] }
 rundler-sim = { workspace = true, features = ["test-utils"] }
 rundler-types = { workspace = true, features = ["test-utils"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/builder/src/assigner.rs
+++ b/crates/builder/src/assigner.rs
@@ -52,6 +52,9 @@ pub(crate) struct WorkAssignment {
     pub filter_id: Option<String>,
     /// The assigned operations
     pub operations: Vec<PoolOperation>,
+    /// Whether this is an isolation bundle for a single suspect operation.
+    /// See `docs/designs/poison-user-operations.md`.
+    pub is_isolation: bool,
 }
 
 /// Detailed result of attempting to assign work.
@@ -96,6 +99,9 @@ struct State {
     entrypoint_last_selected: HashMap<ProposerKey, u64>,
     /// Tracks which entrypoint a builder is pinned to for replacement attempts
     builder_to_pinned_proposer: HashMap<Address, ProposerKey>,
+    /// Builders currently holding an isolation assignment for a suspect
+    /// operation. Bounds isolation capacity while normal work is eligible.
+    isolating_builders: HashSet<Address>,
 }
 
 /// A candidate entrypoint for assignment, used during priority-based selection.
@@ -204,7 +210,7 @@ impl Assigner {
                 self.pool.get_ops_summaries(
                     ep.address,
                     self.max_pool_ops_per_request,
-                    0, // suspect isolation scheduling is not implemented yet
+                    self.num_signers as u64,
                     ep.filter_id.clone(),
                 )
             })
@@ -212,6 +218,7 @@ impl Assigner {
         let query_results = futures_util::future::join_all(query_futures).await;
 
         let mut candidates = Vec::new();
+        let mut suspect_candidates = Vec::new();
         let mut fee_filtered_candidate_exists = false;
         for (entrypoint_idx, (ep, result)) in self
             .entrypoints
@@ -219,7 +226,10 @@ impl Assigner {
             .zip(query_results.into_iter())
             .enumerate()
         {
-            let ops = result?;
+            let (suspects, ops): (Vec<_>, Vec<_>) = result?.into_iter().partition(|op| op.suspect);
+            if !suspects.is_empty() {
+                suspect_candidates.push((ep.clone(), suspects));
+            }
             let (assignable_count, eligible_count) =
                 self.count_ops(&ops, builder_address, max_sim_block_number, &required_fees);
             let ep_metrics = ep_metrics_for(ep);
@@ -233,6 +243,32 @@ impl Assigner {
                 });
             } else if assignable_count > 0 {
                 fee_filtered_candidate_exists = true;
+            }
+        }
+
+        // Isolation is filled before normal work: while normal work is
+        // eligible, at most `max(1, num_signers / 2)` builders isolate so
+        // suspects cannot starve normal bundles; once normal work is
+        // exhausted, any idle builder may drain suspects. Recomputed on every
+        // assignment.
+        if !suspect_candidates.is_empty() {
+            let isolation_limit = if candidates.is_empty() {
+                self.num_signers
+            } else {
+                (self.num_signers / 2).max(1)
+            };
+            let isolating_count = self.state.lock().unwrap().isolating_builders.len();
+            if isolating_count < isolation_limit
+                && let Some(assignment) = self
+                    .assign_isolation_work(
+                        builder_address,
+                        suspect_candidates,
+                        max_sim_block_number,
+                        &required_fees,
+                    )
+                    .await?
+            {
+                return Ok(AssignmentResult::Assigned(assignment));
             }
         }
 
@@ -361,10 +397,62 @@ impl Assigner {
                 entry_point: candidate.ep.address,
                 filter_id: candidate.ep.filter_id,
                 operations: assigned_ops,
+                is_isolation: false,
             }));
         }
 
         Ok(AssignmentResult::NoOperations)
+    }
+
+    /// Attempts to assign a single-operation isolation bundle for one due
+    /// suspect. Returns `None` if no suspect is claimable by this builder.
+    async fn assign_isolation_work(
+        &self,
+        builder_address: Address,
+        suspect_candidates: Vec<(EntrypointInfo, Vec<PoolOperationSummary>)>,
+        max_sim_block_number: u64,
+        required_fees: &GasFees,
+    ) -> anyhow::Result<Option<WorkAssignment>> {
+        for (ep, suspects) in suspect_candidates {
+            for suspect in suspects {
+                let hash = suspect.hash;
+                let assigned_ops = self
+                    .assign_ops_internal(
+                        builder_address,
+                        &ep,
+                        vec![suspect],
+                        max_sim_block_number,
+                        required_fees,
+                    )
+                    .await?;
+                if assigned_ops.is_empty() {
+                    continue;
+                }
+
+                tracing::info!(
+                    "Builder Assigner: isolation assignment of suspect op {hash:?} to builder {builder_address:?}"
+                );
+                {
+                    let mut state = self.state.lock().unwrap();
+                    state.isolating_builders.insert(builder_address);
+                    // Pin so revert processing can find the proposer; suspects
+                    // do not refresh starvation tracking for normal work.
+                    state
+                        .builder_to_pinned_proposer
+                        .insert(builder_address, ep.key());
+                }
+                ep_metrics_for(&ep).ep_isolation_assignments.increment(1);
+
+                return Ok(Some(WorkAssignment {
+                    entry_point: ep.address,
+                    filter_id: ep.filter_id,
+                    operations: assigned_ops,
+                    is_isolation: true,
+                }));
+            }
+        }
+
+        Ok(None)
     }
 
     /// Assigns work for a specific entrypoint configuration.
@@ -383,7 +471,10 @@ impl Assigner {
             .get_ops_summaries(
                 entry_point,
                 self.max_pool_ops_per_request,
-                0, // suspect isolation scheduling is not implemented yet
+                // Replacement attempts never start new isolation work: an
+                // in-flight accepted bundle has already cleared its ops'
+                // suspect status, so suspects are not requested here.
+                0,
                 filter_id.clone(),
             )
             .await?;
@@ -446,6 +537,7 @@ impl Assigner {
             entry_point,
             filter_id,
             operations: assigned_ops,
+            is_isolation: false,
         };
         tracing::info!("Builder Assigner: assignment: {assignment:?}");
 
@@ -697,6 +789,7 @@ impl Assigner {
                 self.metrics.active_builders.decrement(1);
                 state.builder_to_uo_senders.remove(&builder_address);
                 state.builder_to_pinned_proposer.remove(&builder_address);
+                state.isolating_builders.remove(&builder_address);
             }
         }
 
@@ -722,6 +815,7 @@ impl Assigner {
             .get(&builder_address)
             .map(ep_metrics_for_key);
         state.builder_to_pinned_proposer.remove(&builder_address);
+        state.isolating_builders.remove(&builder_address);
         let Some(builder_senders) = state.builder_to_uo_senders.remove(&builder_address) else {
             return;
         };
@@ -810,6 +904,8 @@ struct PerEntrypointMetrics {
     ep_starvation_wakeups: Counter,
     #[metric(describe = "the last-seen eligible op count for this entrypoint.")]
     ep_eligible_ops: Gauge,
+    #[metric(describe = "the total number of suspect isolation assignments from this entrypoint.")]
+    ep_isolation_assignments: Counter,
 }
 
 fn ep_metrics_for(ep: &EntrypointInfo) -> PerEntrypointMetrics {
@@ -1075,6 +1171,148 @@ mod tests {
             err.to_string().contains("lock contract broken"),
             "unexpected error: {err:#}"
         );
+    }
+
+    fn mock_pool_with_suspects(ops: Vec<PoolOperation>, suspect_senders: Vec<Address>) -> MockPool {
+        let mut mock_pool = MockPool::new();
+        let ops_cloned = ops.clone();
+        mock_pool
+            .expect_get_ops_summaries()
+            .returning(move |_, _, max_suspects, _| {
+                Ok(ops_cloned
+                    .iter()
+                    .map(|op| {
+                        let mut summary: PoolOperationSummary = op.into();
+                        summary.suspect = suspect_senders.contains(&op.uo.sender());
+                        summary
+                    })
+                    .filter(|summary| !summary.suspect || max_suspects > 0)
+                    .collect::<Vec<_>>())
+            });
+        mock_pool
+            .expect_get_ops_by_hashes()
+            .returning(move |_, hashes| {
+                Ok(ops
+                    .iter()
+                    .filter(|op| hashes.contains(&op.uo.hash()))
+                    .cloned()
+                    .collect::<Vec<_>>())
+            });
+        mock_pool
+    }
+
+    #[tokio::test]
+    async fn test_suspect_isolated_alone() {
+        // 1 suspect + 2 normal ops with 4 signers: isolation limit is 2
+        let ops = create_test_ops(&[address(1), address(2), address(3)]);
+        let mock_pool = mock_pool_with_suspects(ops, vec![address(3)]);
+        let assigner = Assigner::new(Box::new(mock_pool), test_entrypoints(), 4, 10, 10, 0.50);
+
+        // the first builder isolates the suspect
+        let isolation = assign_expect_default(&assigner, address(10)).await;
+        assert!(isolation.is_isolation);
+        assert_eq!(isolation.operations.len(), 1);
+        assert_eq!(isolation.operations[0].uo.sender(), address(3));
+
+        // the suspect is locked, so the second builder receives the normal work
+        let normal = assign_expect_default(&assigner, address(11)).await;
+        assert!(!normal.is_isolation);
+        assert_eq!(normal.operations.len(), 2);
+        assert!(
+            normal
+                .operations
+                .iter()
+                .all(|op| op.uo.sender() != address(3))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_isolation_capped_while_normal_work_eligible() {
+        // 2 suspects + 1 normal op with 2 signers: isolation limit is 1
+        let ops = create_test_ops(&[address(1), address(2), address(3)]);
+        let mock_pool = mock_pool_with_suspects(ops, vec![address(2), address(3)]);
+        let assigner = Assigner::new(Box::new(mock_pool), test_entrypoints(), 2, 10, 10, 0.50);
+
+        let first = assign_expect_default(&assigner, address(10)).await;
+        assert!(first.is_isolation);
+
+        // isolation capacity is used up: the second builder gets normal work
+        // even though a second suspect is due
+        let second = assign_expect_default(&assigner, address(11)).await;
+        assert!(!second.is_isolation);
+        assert_eq!(second.operations.len(), 1);
+        assert_eq!(second.operations[0].uo.sender(), address(1));
+    }
+
+    #[tokio::test]
+    async fn test_isolation_expands_when_no_normal_work() {
+        // only suspects with 2 signers: every builder may isolate
+        let ops = create_test_ops(&[address(1), address(2)]);
+        let mock_pool = mock_pool_with_suspects(ops, vec![address(1), address(2)]);
+        let assigner = Assigner::new(Box::new(mock_pool), test_entrypoints(), 2, 10, 10, 0.50);
+
+        let first = assign_expect_default(&assigner, address(10)).await;
+        assert!(first.is_isolation);
+        assert_eq!(first.operations.len(), 1);
+
+        let second = assign_expect_default(&assigner, address(11)).await;
+        assert!(second.is_isolation);
+        assert_eq!(second.operations.len(), 1);
+        assert_ne!(
+            first.operations[0].uo.sender(),
+            second.operations[0].uo.sender()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_isolation_slot_freed_after_release() {
+        let ops = create_test_ops(&[address(1), address(2), address(3)]);
+        let mock_pool = mock_pool_with_suspects(ops, vec![address(2), address(3)]);
+        let assigner = Assigner::new(Box::new(mock_pool), test_entrypoints(), 2, 10, 10, 0.50);
+
+        let first = assign_expect_default(&assigner, address(10)).await;
+        assert!(first.is_isolation);
+
+        // the isolation limit is recomputed per assignment: releasing the
+        // isolating builder frees its slot for the next assignment
+        assigner.release_all(address(10));
+
+        let second = assign_expect_default(&assigner, address(11)).await;
+        assert!(second.is_isolation);
+    }
+
+    #[tokio::test]
+    async fn test_locked_suspect_not_reassigned() {
+        let ops = create_test_ops(&[address(1)]);
+        let mock_pool = mock_pool_with_suspects(ops, vec![address(1)]);
+        let assigner = Assigner::new(Box::new(mock_pool), test_entrypoints(), 4, 10, 10, 0.50);
+
+        let first = assign_expect_default(&assigner, address(10)).await;
+        assert!(first.is_isolation);
+
+        let second = assign_default(&assigner, address(11)).await;
+        assert!(matches!(second, AssignmentResult::NoOperations));
+    }
+
+    #[tokio::test]
+    async fn test_suspect_respects_fee_filter() {
+        // the suspect op has zero fees and doesn't meet the fee requirement
+        let ops = create_test_ops(&[address(1)]);
+        let mock_pool = mock_pool_with_suspects(ops, vec![address(1)]);
+        let assigner = Assigner::new(Box::new(mock_pool), test_entrypoints(), 4, 10, 10, 0.50);
+
+        let result = assigner
+            .assign_work(
+                address(10),
+                u64::MAX,
+                GasFees {
+                    max_fee_per_gas: 1,
+                    max_priority_fee_per_gas: 1,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(matches!(result, AssignmentResult::NoOperations));
     }
 
     fn address(i: u64) -> Address {

--- a/crates/builder/src/assigner.rs
+++ b/crates/builder/src/assigner.rs
@@ -257,18 +257,43 @@ impl Assigner {
             } else {
                 (self.num_signers / 2).max(1)
             };
-            let isolating_count = self.state.lock().unwrap().isolating_builders.len();
-            if isolating_count < isolation_limit
-                && let Some(assignment) = self
+            // Reserve the isolation slot under the same lock as the capacity
+            // check: concurrent builders calling assign_work must not both
+            // read a count below the limit and then both insert, exceeding
+            // isolation_limit. Released below if no suspect ends up
+            // claimable, so a failed attempt doesn't waste the slot.
+            let reserved = {
+                let mut state = self.state.lock().unwrap();
+                state.isolating_builders.len() < isolation_limit
+                    && state.isolating_builders.insert(builder_address)
+            };
+            if reserved {
+                match self
                     .assign_isolation_work(
                         builder_address,
                         suspect_candidates,
                         max_sim_block_number,
                         &required_fees,
                     )
-                    .await?
-            {
-                return Ok(AssignmentResult::Assigned(assignment));
+                    .await
+                {
+                    Ok(Some(assignment)) => return Ok(AssignmentResult::Assigned(assignment)),
+                    Ok(None) => {
+                        self.state
+                            .lock()
+                            .unwrap()
+                            .isolating_builders
+                            .remove(&builder_address);
+                    }
+                    Err(e) => {
+                        self.state
+                            .lock()
+                            .unwrap()
+                            .isolating_builders
+                            .remove(&builder_address);
+                        return Err(e);
+                    }
+                }
             }
         }
 
@@ -406,6 +431,10 @@ impl Assigner {
 
     /// Attempts to assign a single-operation isolation bundle for one due
     /// suspect. Returns `None` if no suspect is claimable by this builder.
+    ///
+    /// The caller must have already reserved `builder_address`'s isolation
+    /// slot in `isolating_builders` before calling this, and releases it if
+    /// `None` or an error is returned.
     async fn assign_isolation_work(
         &self,
         builder_address: Address,
@@ -434,7 +463,7 @@ impl Assigner {
                 );
                 {
                     let mut state = self.state.lock().unwrap();
-                    state.isolating_builders.insert(builder_address);
+                    // isolating_builders was already reserved by the caller.
                     // Pin so revert processing can find the proposer; suspects
                     // do not refresh starvation tracking for normal work.
                     state
@@ -925,6 +954,8 @@ fn ep_metrics_for_key(key: &ProposerKey) -> PerEntrypointMetrics {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use alloy_primitives::B256;
     use rundler_types::{
         EntityInfos, UserOperation, UserOperationPermissions, ValidTimeRange,
@@ -1279,6 +1310,77 @@ mod tests {
 
         let second = assign_expect_default(&assigner, address(11)).await;
         assert!(second.is_isolation);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_isolation_reservation_atomic_under_concurrency() {
+        // 2 suspects + 1 normal op with 2 signers: isolation limit is 1.
+        // Two builders race to isolate concurrently; the capacity check and
+        // the isolating_builders reservation must happen under the same lock
+        // so at most 1 can claim the single slot, even when both requests
+        // are genuinely running in parallel (not just interleaved awaits).
+        let ops = create_test_ops(&[address(1), address(2), address(3)]);
+        let suspect_senders = [address(2), address(3)];
+        let ops_for_summaries = ops.clone();
+        let mut mock_pool = MockPool::new();
+        mock_pool
+            .expect_get_ops_summaries()
+            .returning(move |_, _, max_suspects, _| {
+                Ok(ops_for_summaries
+                    .iter()
+                    .map(|op| {
+                        let mut summary: PoolOperationSummary = op.into();
+                        summary.suspect = suspect_senders.contains(&op.uo.sender());
+                        summary
+                    })
+                    .filter(|summary| !summary.suspect || max_suspects > 0)
+                    .collect::<Vec<_>>())
+            });
+        let ops_for_hashes = ops.clone();
+        mock_pool
+            .expect_get_ops_by_hashes()
+            .returning(move |_, hashes| {
+                // Widen the race window so both concurrent callers are
+                // inside assign_isolation_work at the same time.
+                std::thread::sleep(std::time::Duration::from_millis(20));
+                Ok(ops_for_hashes
+                    .iter()
+                    .filter(|op| hashes.contains(&op.uo.hash()))
+                    .cloned()
+                    .collect::<Vec<_>>())
+            });
+
+        let assigner = Arc::new(Assigner::new(
+            Box::new(mock_pool),
+            test_entrypoints(),
+            2,
+            10,
+            10,
+            0.50,
+        ));
+
+        let a1 = assigner.clone();
+        let a2 = assigner.clone();
+        let h1 = tokio::spawn(async move {
+            a1.assign_work(address(10), u64::MAX, GasFees::default())
+                .await
+        });
+        let h2 = tokio::spawn(async move {
+            a2.assign_work(address(11), u64::MAX, GasFees::default())
+                .await
+        });
+
+        let r1 = h1.await.unwrap().unwrap();
+        let r2 = h2.await.unwrap().unwrap();
+
+        let isolating_count = [&r1, &r2]
+            .into_iter()
+            .filter(|r| matches!(r, AssignmentResult::Assigned(a) if a.is_isolation))
+            .count();
+        assert_eq!(
+            isolating_count, 1,
+            "exactly one concurrent request should claim the single isolation slot"
+        );
     }
 
     #[tokio::test]

--- a/crates/builder/src/bundle_proposer.rs
+++ b/crates/builder/src/bundle_proposer.rs
@@ -129,6 +129,40 @@ impl BundleData {
     }
 }
 
+/// Result of processing a reverted bundle transaction, per the failure flow in
+/// `docs/designs/poison-user-operations.md`.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct RevertOutcome {
+    /// Op hashes to remove from the pool.
+    pub(crate) to_remove: Vec<B256>,
+    /// Op hashes to mark suspect in the pool.
+    pub(crate) to_mark_suspect: Vec<B256>,
+}
+
+impl RevertOutcome {
+    /// Outcome that removes the given operations.
+    fn remove(to_remove: Vec<B256>) -> Self {
+        Self {
+            to_remove,
+            ..Self::default()
+        }
+    }
+
+    /// Outcome for a revert attributable to no single operation: a sole
+    /// operation is removed, while every operation of a larger bundle is
+    /// marked suspect.
+    fn unattributed(hashes: Vec<B256>) -> Self {
+        if hashes.len() > 1 {
+            Self {
+                to_mark_suspect: hashes,
+                ..Self::default()
+            }
+        } else {
+            Self::remove(hashes)
+        }
+    }
+}
+
 /// Request parameters for building a bundle.
 #[derive(Debug)]
 pub(crate) struct BundleProposalRequest {
@@ -164,9 +198,10 @@ pub(crate) trait BundleProposerT: Send + Sync {
     async fn make_bundle(&self, request: BundleProposalRequest)
     -> BundleProposerResult<BundleData>;
 
-    /// Process a reverted bundle transaction and return op hashes to remove from pool.
+    /// Process a reverted bundle transaction and return op hashes to remove from
+    /// pool or mark suspect.
     /// Fetches the trace and transaction internally, then decodes and processes the revert.
-    async fn process_revert(&self, tx_hash: B256) -> anyhow::Result<Vec<B256>>;
+    async fn process_revert(&self, tx_hash: B256) -> anyhow::Result<RevertOutcome>;
 }
 
 pub(crate) struct BundleProposerImpl<EP, BP> {
@@ -402,7 +437,7 @@ where
         })
     }
 
-    async fn process_revert(&self, tx_hash: B256) -> anyhow::Result<Vec<B256>> {
+    async fn process_revert(&self, tx_hash: B256) -> anyhow::Result<RevertOutcome> {
         let address = *self.ep_providers.entry_point().address();
         let chain_spec = &self.settings.chain_spec;
 
@@ -452,19 +487,22 @@ where
                 }
             };
 
+        let all_op_hashes: Vec<B256> = ops
+            .iter()
+            .flat_map(|ops| ops.user_ops.iter().map(|op| op.hash()))
+            .collect();
+
         let Some(revert_data) = revert_data else {
-            // No revert data - remove all ops
-            return Ok(ops
-                .iter()
-                .flat_map(|ops| ops.user_ops.iter().map(|op| op.hash()))
-                .collect());
+            // No revert data attributes the revert to no single op
+            warn!("no revert data for reverted bundle, treating as unattributed");
+            return Ok(RevertOutcome::unattributed(all_op_hashes));
         };
 
         // If we have a submission proxy, use it to process the revert first
         if let Some(proxy) = &self.settings.submission_proxy {
             let to_remove = proxy.process_revert(revert_data, &ops).await;
             if !to_remove.is_empty() {
-                return Ok(to_remove);
+                return Ok(RevertOutcome::remove(to_remove));
             }
         }
 
@@ -486,29 +524,31 @@ where
             }
             Some(HandleOpsOut::FailedOp(index, _)) => {
                 warn!("removing op from pool for reverted bundle op index {index:?}");
-                Ok(ops
-                    .iter()
-                    .flat_map(|ops| ops.user_ops.iter())
-                    .nth(index)
-                    .map(|op| vec![op.hash()])
-                    .unwrap_or_default())
+                Ok(RevertOutcome::remove(
+                    ops.iter()
+                        .flat_map(|ops| ops.user_ops.iter())
+                        .nth(index)
+                        .map(|op| vec![op.hash()])
+                        .unwrap_or_default(),
+                ))
             }
             Some(HandleOpsOut::SignatureValidationFailed(aggregator)) => {
                 warn!(
                     "removing all ops from pool for reverted bundle for aggregator {aggregator:?}"
                 );
-                Ok(ops
-                    .iter()
-                    .find(|op| op.aggregator == aggregator)
-                    .map(|ops| ops.user_ops.iter().map(|op| op.hash()).collect())
-                    .unwrap_or_default())
+                Ok(RevertOutcome::remove(
+                    ops.iter()
+                        .find(|op| op.aggregator == aggregator)
+                        .map(|ops| ops.user_ops.iter().map(|op| op.hash()).collect())
+                        .unwrap_or_default(),
+                ))
             }
             None | Some(HandleOpsOut::Revert(_)) | Some(HandleOpsOut::PostOpRevert) => {
-                warn!("removing all ops from pool for reverted bundle");
-                Ok(ops
-                    .iter()
-                    .flat_map(|ops| ops.user_ops.iter().map(|op| op.hash()))
-                    .collect())
+                warn!(
+                    "unattributed revert for bundle of {} ops",
+                    all_op_hashes.len()
+                );
+                Ok(RevertOutcome::unattributed(all_op_hashes))
             }
         }
     }
@@ -4904,5 +4944,37 @@ mod tests {
         agg.expect_aggregate_signatures()
             .returning(move |_| Ok(signature.clone()));
         agg
+    }
+
+    #[test]
+    fn test_unattributed_revert_of_sole_op_removes() {
+        let hash = B256::repeat_byte(1);
+        assert_eq!(
+            RevertOutcome::unattributed(vec![hash]),
+            RevertOutcome {
+                to_remove: vec![hash],
+                to_mark_suspect: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_unattributed_revert_of_multiple_ops_marks_suspect() {
+        let hashes = vec![B256::repeat_byte(1), B256::repeat_byte(2)];
+        assert_eq!(
+            RevertOutcome::unattributed(hashes.clone()),
+            RevertOutcome {
+                to_remove: vec![],
+                to_mark_suspect: hashes,
+            }
+        );
+    }
+
+    #[test]
+    fn test_unattributed_revert_of_no_ops_is_empty() {
+        assert_eq!(
+            RevertOutcome::unattributed(vec![]),
+            RevertOutcome::default()
+        );
     }
 }

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -43,7 +43,7 @@ use crate::{
     assigner::{Assigner, AssignmentResult},
     bundle_proposer::{BundleData, BundleProposalRequest, BundleProposerError, BundleProposerT},
     emit::{BuilderEvent, BundleTxDetails},
-    sender::{RpcOutcomeClass, TxSenderError},
+    sender::{ProviderEventSignal, RpcOutcomeClass, TxSenderError},
     transaction_tracker::{
         TrackerState, TrackerUpdate, TransactionTracker, TransactionTrackerError,
     },
@@ -81,6 +81,10 @@ pub(crate) struct BundleSenderImpl<T, C> {
     pool: C,
     settings: Settings,
     event_sender: broadcast::Sender<WithEntryPoint<BuilderEvent>>,
+    /// Provider-health signal for the submission route, shared with the other
+    /// builders on the route. Final submission outcomes are recorded here and
+    /// its state gates poison user operation evidence in the pool.
+    provider_event_signal: Arc<ProviderEventSignal>,
 }
 
 pub enum BundleSenderAction {
@@ -230,6 +234,7 @@ where
         pool: C,
         settings: Settings,
         event_sender: broadcast::Sender<WithEntryPoint<BuilderEvent>>,
+        provider_event_signal: Arc<ProviderEventSignal>,
     ) -> Self {
         Self {
             builder_tag,
@@ -244,6 +249,7 @@ where
             pool,
             settings,
             event_sender,
+            provider_event_signal,
         }
     }
 
@@ -946,6 +952,8 @@ where
             Ok(tx_hash) => {
                 let ops = Arc::new(ops);
 
+                self.provider_event_signal.record_success();
+
                 self.emit_for_entrypoint(
                     entry_point,
                     BuilderEvent::formed_bundle(
@@ -983,6 +991,8 @@ where
             }
             Err(TransactionTrackerError::Sender(error)) => {
                 match error.classify() {
+                    // Terminal errors definitively reject the transaction and
+                    // are excluded from the provider-health window.
                     RpcOutcomeClass::Terminal => {
                         self.report_bundle_outcome(
                             entry_point,
@@ -992,6 +1002,10 @@ where
                         .await;
                     }
                     RpcOutcomeClass::NonTerminal => {
+                        // Record before reporting so the report is gated by
+                        // the freshest signal state, including an event this
+                        // failure itself triggers.
+                        self.provider_event_signal.record_failure();
                         self.report_bundle_outcome(
                             entry_point,
                             uo_hashes,
@@ -1095,9 +1109,6 @@ where
 
     /// Reports the final outcome of a bundle submission attempt to the pool for
     /// poison user operation tracking. Best effort: failures are logged.
-    ///
-    /// Provider-event detection is not implemented yet, so
-    /// `provider_event_active` is always false.
     async fn report_bundle_outcome(
         &self,
         entry_point: Address,
@@ -1109,7 +1120,12 @@ where
         }
         if let Err(error) = self
             .pool
-            .report_bundle_outcome(entry_point, ops, outcome, false)
+            .report_bundle_outcome(
+                entry_point,
+                ops,
+                outcome,
+                self.provider_event_signal.is_active(),
+            )
             .await
         {
             warn!("Failed to report bundle outcome to pool: {error}");
@@ -1843,6 +1859,9 @@ mod tests {
                 ..
             })
         ));
+
+        // the accepted submission was recorded in the provider-health window
+        assert_eq!(sender.provider_event_signal.observations(), 1);
     }
 
     #[tokio::test]
@@ -2774,7 +2793,11 @@ mod tests {
         ));
     }
 
-    async fn run_send_error_reports_outcome(error: TxSenderError, outcome: BundleOutcome) {
+    async fn run_send_error_reports_outcome(
+        error: TxSenderError,
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+    ) {
         let Mocks {
             mut mock_proposer_t,
             mut mock_tracker,
@@ -2803,8 +2826,10 @@ mod tests {
             .returning(|_, _| Ok(vec![demo_pool_op()]));
         mock_pool
             .expect_report_bundle_outcome()
-            .withf(move |_, ops, reported, provider_event_active| {
-                ops == &[B256::ZERO] && *reported == outcome && !provider_event_active
+            .withf(move |_, ops, reported, event_active| {
+                ops == &[B256::ZERO]
+                    && *reported == outcome
+                    && *event_active == provider_event_active
             })
             .times(1)
             .returning(|_, _, _, _| Ok(()));
@@ -2831,8 +2856,31 @@ mod tests {
 
         let mut sender = new_sender(mock_proposer_t, mock_pool);
 
+        let observations_before = if provider_event_active {
+            // Saturate the signal's window with failures to activate an event.
+            for _ in 0..10 {
+                sender.provider_event_signal.record_failure();
+            }
+            assert!(sender.provider_event_signal.is_active());
+            10
+        } else {
+            0
+        };
+
         let update = state.wait_for_trigger().await.unwrap();
         sender.step_after_trigger(&mut state, update).await.unwrap();
+
+        // Only non-terminal failures are recorded in the provider-health
+        // window; terminal errors are excluded.
+        let expected_observations = if outcome == BundleOutcome::NonTerminalFailure {
+            observations_before + 1
+        } else {
+            observations_before
+        };
+        assert_eq!(
+            sender.provider_event_signal.observations(),
+            expected_observations
+        );
     }
 
     #[tokio::test]
@@ -2843,6 +2891,7 @@ mod tests {
                 message: "internal error".to_string(),
             },
             BundleOutcome::TerminalFailure,
+            false,
         )
         .await;
     }
@@ -2852,6 +2901,17 @@ mod tests {
         run_send_error_reports_outcome(
             TxSenderError::SenderUnavailable(anyhow::anyhow!("provider outage")),
             BundleOutcome::NonTerminalFailure,
+            false,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_non_terminal_error_during_provider_event() {
+        run_send_error_reports_outcome(
+            TxSenderError::SenderUnavailable(anyhow::anyhow!("provider outage")),
+            BundleOutcome::NonTerminalFailure,
+            true,
         )
         .await;
     }
@@ -3016,6 +3076,7 @@ mod tests {
                 max_replacement_underpriced_blocks: 3,
             },
             broadcast::channel(1000).0,
+            Arc::new(ProviderEventSignal::default()),
         )
     }
 
@@ -3049,6 +3110,7 @@ mod tests {
                 max_replacement_underpriced_blocks: 3,
             },
             broadcast::channel(1000).0,
+            Arc::new(ProviderEventSignal::default()),
         )
     }
 

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -24,7 +24,7 @@ use rundler_task::TaskSpawner;
 use rundler_types::{
     builder::BundlingMode,
     chain::ChainSpec,
-    pool::{AddressUpdate, NewHead, Pool},
+    pool::{AddressUpdate, BundleOutcome, NewHead, Pool},
 };
 use rundler_utils::{emit::WithEntryPoint, eth};
 use tokio::{
@@ -42,7 +42,7 @@ use crate::{
     assigner::{Assigner, AssignmentResult},
     bundle_proposer::{BundleData, BundleProposalRequest, BundleProposerError, BundleProposerT},
     emit::{BuilderEvent, BundleTxDetails},
-    sender::TxSenderError,
+    sender::{RpcOutcomeClass, TxSenderError},
     transaction_tracker::{
         TrackerState, TrackerUpdate, TransactionTracker, TransactionTrackerError,
     },
@@ -934,6 +934,8 @@ where
         );
         self.record_histogram_ep("builder_bundle_txn_size_bytes", entry_point, tx_size as f64);
 
+        let uo_hashes: Vec<B256> = ops.iter().map(|(_, hash)| *hash).collect();
+
         match send_result {
             Ok(tx_hash) => {
                 let ops = Arc::new(ops);
@@ -953,8 +955,10 @@ where
                     ),
                 );
 
+                self.report_bundle_outcome(entry_point, uo_hashes.clone(), BundleOutcome::Success)
+                    .await;
+
                 // Notify the pool about the pending bundle
-                let uo_hashes: Vec<B256> = ops.iter().map(|(_, hash)| *hash).collect();
                 if let Err(e) = self
                     .pool
                     .notify_pending_bundle(
@@ -971,66 +975,93 @@ where
 
                 Ok(SendBundleAttemptResult::Success(ops))
             }
-            Err(TransactionTrackerError::Sender(error)) => match error {
-                TxSenderError::NonceTooLow => {
-                    self.increment_counter_ep("builder_bundle_txn_nonce_too_low", entry_point, 1);
-                    warn!("Bundle attempt nonce too low");
-                    Ok(SendBundleAttemptResult::NonceTooLow)
+            Err(TransactionTrackerError::Sender(error)) => {
+                match error.classify() {
+                    RpcOutcomeClass::Terminal => {
+                        self.report_bundle_outcome(
+                            entry_point,
+                            uo_hashes,
+                            BundleOutcome::TerminalFailure,
+                        )
+                        .await;
+                    }
+                    RpcOutcomeClass::NonTerminal => {
+                        self.report_bundle_outcome(
+                            entry_point,
+                            uo_hashes,
+                            BundleOutcome::NonTerminalFailure,
+                        )
+                        .await;
+                    }
+                    // Neutral errors have dedicated handling below and are
+                    // evidence of neither poison nor provider health.
+                    RpcOutcomeClass::Neutral => {}
                 }
-                TxSenderError::Underpriced => {
-                    self.increment_counter_ep("builder_bundle_txn_underpriced", entry_point, 1);
-                    warn!("Bundle attempt underpriced");
-                    Ok(SendBundleAttemptResult::Underpriced)
+                match error {
+                    TxSenderError::NonceTooLow => {
+                        self.increment_counter_ep(
+                            "builder_bundle_txn_nonce_too_low",
+                            entry_point,
+                            1,
+                        );
+                        warn!("Bundle attempt nonce too low");
+                        Ok(SendBundleAttemptResult::NonceTooLow)
+                    }
+                    TxSenderError::Underpriced => {
+                        self.increment_counter_ep("builder_bundle_txn_underpriced", entry_point, 1);
+                        warn!("Bundle attempt underpriced");
+                        Ok(SendBundleAttemptResult::Underpriced)
+                    }
+                    TxSenderError::ReplacementUnderpriced => {
+                        self.increment_counter_ep(
+                            "builder_bundle_replacement_underpriced",
+                            entry_point,
+                            1,
+                        );
+                        warn!("Bundle attempt replacement transaction underpriced");
+                        Ok(SendBundleAttemptResult::ReplacementUnderpriced)
+                    }
+                    TxSenderError::ConditionNotMet => {
+                        self.increment_counter_ep(
+                            "builder_bundle_txn_condition_not_met",
+                            entry_point,
+                            1,
+                        );
+                        warn!("Bundle attempt condition not met");
+                        Ok(SendBundleAttemptResult::ConditionNotMet)
+                    }
+                    TxSenderError::Rejected => {
+                        self.increment_counter_ep("builder_bundle_txn_rejected", entry_point, 1);
+                        warn!("Bundle attempt rejected");
+                        Ok(SendBundleAttemptResult::Rejected)
+                    }
+                    TxSenderError::InsufficientFunds => {
+                        self.increment_counter_ep(
+                            "builder_bundle_txn_insufficient_funds",
+                            entry_point,
+                            1,
+                        );
+                        error!("Bundle attempt insufficient funds");
+                        Ok(SendBundleAttemptResult::InsufficientFunds)
+                    }
+                    TxSenderError::IntrinsicGasTooLow => {
+                        let tx_bytes = tx.input.input().map_or_else(
+                            || String::from("0x"),
+                            |data| format!("0x{}", hex::encode(data)),
+                        );
+                        error!("Bundle transaction intrinsic gas too low: tx_bytes={tx_bytes}");
+                        Err(anyhow::anyhow!("intrinsic gas too low"))
+                    }
+                    error @ (TxSenderError::TerminalRpcError { .. }
+                    | TxSenderError::UnrecognizedRpc { .. }
+                    | TxSenderError::SenderUnavailable(_)
+                    | TxSenderError::SoftCancelFailed
+                    | TxSenderError::Other(_)) => {
+                        error!("Failed to send bundle: {error}");
+                        Err(error.into())
+                    }
                 }
-                TxSenderError::ReplacementUnderpriced => {
-                    self.increment_counter_ep(
-                        "builder_bundle_replacement_underpriced",
-                        entry_point,
-                        1,
-                    );
-                    warn!("Bundle attempt replacement transaction underpriced");
-                    Ok(SendBundleAttemptResult::ReplacementUnderpriced)
-                }
-                TxSenderError::ConditionNotMet => {
-                    self.increment_counter_ep(
-                        "builder_bundle_txn_condition_not_met",
-                        entry_point,
-                        1,
-                    );
-                    warn!("Bundle attempt condition not met");
-                    Ok(SendBundleAttemptResult::ConditionNotMet)
-                }
-                TxSenderError::Rejected => {
-                    self.increment_counter_ep("builder_bundle_txn_rejected", entry_point, 1);
-                    warn!("Bundle attempt rejected");
-                    Ok(SendBundleAttemptResult::Rejected)
-                }
-                TxSenderError::InsufficientFunds => {
-                    self.increment_counter_ep(
-                        "builder_bundle_txn_insufficient_funds",
-                        entry_point,
-                        1,
-                    );
-                    error!("Bundle attempt insufficient funds");
-                    Ok(SendBundleAttemptResult::InsufficientFunds)
-                }
-                TxSenderError::IntrinsicGasTooLow => {
-                    let tx_bytes = tx.input.input().map_or_else(
-                        || String::from("0x"),
-                        |data| format!("0x{}", hex::encode(data)),
-                    );
-                    error!("Bundle transaction intrinsic gas too low: tx_bytes={tx_bytes}");
-                    Err(anyhow::anyhow!("intrinsic gas too low"))
-                }
-                error @ (TxSenderError::TerminalRpcError { .. }
-                | TxSenderError::UnrecognizedRpc { .. }
-                | TxSenderError::SenderUnavailable(_)
-                | TxSenderError::SoftCancelFailed
-                | TxSenderError::Other(_)) => {
-                    error!("Failed to send bundle: {error}");
-                    Err(error.into())
-                }
-            },
+            }
             Err(TransactionTrackerError::Other(e)) => {
                 error!("Failed to send bundle with unexpected tracker error: {e:?}");
                 Err(e)
@@ -1056,6 +1087,29 @@ where
             .context("builder should remove rejected ops from pool")
     }
 
+    /// Reports the final outcome of a bundle submission attempt to the pool for
+    /// poison user operation tracking. Best effort: failures are logged.
+    ///
+    /// Provider-event detection is not implemented yet, so
+    /// `provider_event_active` is always false.
+    async fn report_bundle_outcome(
+        &self,
+        entry_point: Address,
+        ops: Vec<B256>,
+        outcome: BundleOutcome,
+    ) {
+        if ops.is_empty() {
+            return;
+        }
+        if let Err(error) = self
+            .pool
+            .report_bundle_outcome(entry_point, ops, outcome, false)
+            .await
+        {
+            warn!("Failed to report bundle outcome to pool: {error}");
+        }
+    }
+
     async fn process_revert(
         &self,
         tx_hash: B256,
@@ -1073,9 +1127,16 @@ where
             "Unknown entry point config: {ep_address:?}, filter_id: {filter_id:?}"
         ))?;
 
-        let to_remove = proposer.process_revert(tx_hash).await?;
+        let outcome = proposer.process_revert(tx_hash).await?;
 
-        self.remove_ops_from_pool_by_hash(ep_address, to_remove)
+        self.report_bundle_outcome(
+            ep_address,
+            outcome.to_mark_suspect,
+            BundleOutcome::MarkSuspect,
+        )
+        .await;
+
+        self.remove_ops_from_pool_by_hash(ep_address, outcome.to_remove)
             .await
     }
 
@@ -1623,7 +1684,7 @@ mod tests {
     use super::*;
     use crate::{
         assigner::{AssignmentResult, EntrypointInfo},
-        bundle_proposer::{BundleData, MockBundleProposerT},
+        bundle_proposer::{BundleData, MockBundleProposerT, RevertOutcome},
         bundle_sender::{BundleSenderImpl, MockTrigger},
         transaction_tracker::MockTransactionTracker,
     };
@@ -1745,6 +1806,13 @@ mod tests {
             .expect_notify_pending_bundle()
             .times(1)
             .returning(|_, _, _, _, _| Ok(()));
+        mock_pool
+            .expect_report_bundle_outcome()
+            .withf(|_, ops, outcome, provider_event_active| {
+                ops == &[B256::ZERO] && *outcome == BundleOutcome::Success && !provider_event_active
+            })
+            .times(1)
+            .returning(|_, _, _, _| Ok(()));
 
         mock_make_bundle(&mut mock_proposer_t, 1, vec![(Address::ZERO, B256::ZERO)]);
 
@@ -2566,6 +2634,9 @@ mod tests {
             })
         });
 
+        // neutral errors are not evidence: no outcome is reported
+        mock_pool.expect_report_bundle_outcome().times(0);
+
         // Sender will set condition_not_met flag and pass it to next make_bundle call
         // (tested implicitly via state transition to Building with retry)
 
@@ -2654,7 +2725,7 @@ mod tests {
         // Mock the proposer's process_revert to return empty (no ops to remove)
         mock_proposer_t
             .expect_process_revert()
-            .returning(|_| Box::pin(async { Ok(vec![]) }));
+            .returning(|_| Box::pin(async { Ok(RevertOutcome::default()) }));
 
         mock_pool.expect_remove_ops().returning(|_, _| Ok(()));
 
@@ -2695,6 +2766,191 @@ mod tests {
                 underpriced_info: None,
             })
         ));
+    }
+
+    async fn run_send_error_reports_outcome(error: TxSenderError, outcome: BundleOutcome) {
+        let Mocks {
+            mut mock_proposer_t,
+            mut mock_tracker,
+            mut mock_trigger,
+            mut mock_pool,
+        } = new_mocks();
+
+        let mut seq = Sequence::new();
+        add_trigger_no_update_last_block(&mut mock_trigger, &mut seq, 1);
+
+        setup_tracker_default(&mut mock_tracker);
+        mock_tracker.expect_reset().returning(|| Box::pin(async {}));
+
+        mock_pool
+            .expect_get_ops_summaries()
+            .times(1)
+            .returning(|_, _, _, _| {
+                Ok(vec![pool_op_summary(
+                    ENTRY_POINT_ADDRESS_V0_6,
+                    Address::ZERO,
+                )])
+            });
+        mock_pool
+            .expect_get_ops_by_hashes()
+            .times(1)
+            .returning(|_, _| Ok(vec![demo_pool_op()]));
+        mock_pool
+            .expect_report_bundle_outcome()
+            .withf(move |_, ops, reported, provider_event_active| {
+                ops == &[B256::ZERO] && *reported == outcome && !provider_event_active
+            })
+            .times(1)
+            .returning(|_, _, _, _| Ok(()));
+
+        mock_make_bundle(&mut mock_proposer_t, 1, vec![(Address::ZERO, B256::ZERO)]);
+
+        let error = std::sync::Mutex::new(Some(error));
+        mock_tracker
+            .expect_send_transaction()
+            .returning(move |_, _, _| {
+                let error = error.lock().unwrap().take().unwrap();
+                Box::pin(async move { Err(TransactionTrackerError::Sender(error)) })
+            });
+
+        let mut state = new_state_with(
+            mock_trigger,
+            mock_tracker,
+            InnerState::Building(BuildingState {
+                wait_for_trigger: true,
+                fee_increase_count: 0,
+                underpriced_info: None,
+            }),
+        );
+
+        let mut sender = new_sender(mock_proposer_t, mock_pool);
+
+        let update = state.wait_for_trigger().await.unwrap();
+        sender.step_after_trigger(&mut state, update).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_terminal_error_reports_terminal_failure() {
+        run_send_error_reports_outcome(
+            TxSenderError::TerminalRpcError {
+                code: -32000,
+                message: "internal error".to_string(),
+            },
+            BundleOutcome::TerminalFailure,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_non_terminal_error_reports_non_terminal_failure() {
+        run_send_error_reports_outcome(
+            TxSenderError::SenderUnavailable(anyhow::anyhow!("provider outage")),
+            BundleOutcome::NonTerminalFailure,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_revert_reports_suspects_and_removes() {
+        let Mocks {
+            mut mock_proposer_t,
+            mut mock_tracker,
+            mut mock_trigger,
+            mut mock_pool,
+        } = new_mocks();
+
+        let mut seq = Sequence::new();
+        add_trigger_wait_for_block_last_block(&mut mock_trigger, &mut seq, 1);
+
+        let mined = new_head_mined(2);
+        let mined_clone = mined.clone();
+
+        mock_trigger
+            .expect_wait_for_block()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move || {
+                Box::pin({
+                    let mined = mined_clone.clone();
+                    async move { Ok(mined) }
+                })
+            });
+        mock_trigger
+            .expect_last_block()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(mined);
+
+        mock_tracker.expect_address().return_const(Address::ZERO);
+
+        mock_tracker.expect_process_update().once().returning(|_| {
+            Box::pin(async {
+                Ok(Some(TrackerUpdate::Mined {
+                    block_number: 2,
+                    nonce: 0,
+                    gas_limit: None,
+                    gas_used: None,
+                    gas_price: None,
+                    tx_hash: B256::ZERO,
+                    attempt_number: 0,
+                    is_success: false, // revert
+                }))
+            })
+        });
+
+        let removed = B256::repeat_byte(1);
+        let suspect_a = B256::repeat_byte(2);
+        let suspect_b = B256::repeat_byte(3);
+
+        mock_proposer_t.expect_process_revert().returning(move |_| {
+            Box::pin(async move {
+                Ok(RevertOutcome {
+                    to_remove: vec![removed],
+                    to_mark_suspect: vec![suspect_a, suspect_b],
+                })
+            })
+        });
+
+        mock_pool
+            .expect_report_bundle_outcome()
+            .withf(move |_, ops, outcome, provider_event_active| {
+                ops == &[suspect_a, suspect_b]
+                    && *outcome == BundleOutcome::MarkSuspect
+                    && !provider_event_active
+            })
+            .times(1)
+            .returning(|_, _, _, _| Ok(()));
+        mock_pool
+            .expect_remove_ops()
+            .withf(move |_, ops| ops == &[removed])
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let mut sender = new_sender(mock_proposer_t, mock_pool);
+
+        // Establish pin so process_revert can find the proposer
+        sender.assigner.test_establish_pin(
+            Address::default(),
+            &[Address::ZERO],
+            (ENTRY_POINT_ADDRESS_V0_6, None),
+        );
+
+        let mut state = new_state_with(
+            mock_trigger,
+            mock_tracker,
+            InnerState::Pending(PendingState {
+                until: 3,
+                fee_increase_count: 0,
+            }),
+        );
+
+        // first step has no update
+        let update = state.wait_for_trigger().await.unwrap();
+        sender.step_after_trigger(&mut state, update).await.unwrap();
+
+        // second step is mined as a revert: suspects reported, removals removed
+        let update = state.wait_for_trigger().await.unwrap();
+        sender.step_after_trigger(&mut state, update).await.unwrap();
     }
 
     struct Mocks {

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -22,6 +22,7 @@ use rand::Rng;
 use rundler_provider::FeeEstimator;
 use rundler_task::TaskSpawner;
 use rundler_types::{
+    UserOperation,
     builder::BundlingMode,
     chain::ChainSpec,
     pool::{AddressUpdate, BundleOutcome, NewHead, Pool},
@@ -776,6 +777,11 @@ where
                 let entry_point = assignment.entry_point;
                 let filter_id = assignment.filter_id;
                 let ops = assignment.operations;
+
+                if assignment.is_isolation {
+                    let hashes: Vec<B256> = ops.iter().map(|op| op.uo.hash()).collect();
+                    info!("Sending isolation bundle for suspect ops {hashes:?}");
+                }
 
                 // Build and send bundle. Keep this as a single result path so assigner
                 // cleanup runs for all outcomes, including hard errors.

--- a/crates/builder/src/sender/health.rs
+++ b/crates/builder/src/sender/health.rs
@@ -1,0 +1,209 @@
+// This file is part of Rundler.
+//
+// Rundler is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Rundler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Rundler.
+// If not, see https://www.gnu.org/licenses/.
+
+use std::{
+    collections::VecDeque,
+    sync::{
+        Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use metrics::Gauge;
+use metrics_derive::Metrics;
+
+/// Number of most recent non-neutral final submission outcomes considered.
+const WINDOW_SIZE: usize = 20;
+/// Minimum observations in the window before an event can be entered.
+const MIN_OBSERVATIONS: usize = 10;
+/// Failure ratio at or above which an event is entered.
+const ENTER_FAILURE_RATIO: f64 = 0.30;
+/// Failure ratio below which an active event is exited.
+const EXIT_FAILURE_RATIO: f64 = 0.10;
+
+/// Rolling-window detector for provider-health events, per the provider-event
+/// signal in `docs/designs/poison-user-operations.md`.
+///
+/// One signal exists per submission route and is shared by its builders. Only
+/// final submission outcomes — after provider retries and fallbacks are
+/// exhausted — are recorded: successes and non-terminal provider failures.
+/// Neutral operational errors and terminal RPC errors are excluded from the
+/// window by the caller.
+///
+/// Entering requires at least `MIN_OBSERVATIONS` with at least
+/// `ENTER_FAILURE_RATIO` failures; exiting requires the failure ratio to drop
+/// below `EXIT_FAILURE_RATIO`. The different thresholds prevent flapping.
+pub(crate) struct ProviderEventSignal {
+    /// Recent outcomes, `true` for a failure.
+    window: Mutex<VecDeque<bool>>,
+    active: AtomicBool,
+    metrics: ProviderEventMetrics,
+}
+
+impl Default for ProviderEventSignal {
+    fn default() -> Self {
+        Self {
+            window: Mutex::new(VecDeque::with_capacity(WINDOW_SIZE)),
+            active: AtomicBool::new(false),
+            metrics: ProviderEventMetrics::default(),
+        }
+    }
+}
+
+impl ProviderEventSignal {
+    /// Records a final successful submission.
+    pub(crate) fn record_success(&self) {
+        self.record(false);
+    }
+
+    /// Records a final non-terminal provider failure.
+    pub(crate) fn record_failure(&self) {
+        self.record(true);
+    }
+
+    /// Returns true while a provider event is active.
+    pub(crate) fn is_active(&self) -> bool {
+        self.active.load(Ordering::Relaxed)
+    }
+
+    /// Number of outcomes currently in the window, for tests.
+    #[cfg(test)]
+    pub(crate) fn observations(&self) -> usize {
+        self.window.lock().unwrap().len()
+    }
+
+    fn record(&self, failure: bool) {
+        let mut window = self.window.lock().unwrap();
+        if window.len() == WINDOW_SIZE {
+            window.pop_front();
+        }
+        window.push_back(failure);
+
+        let failures = window.iter().filter(|f| **f).count();
+        let ratio = failures as f64 / window.len() as f64;
+
+        if self.active.load(Ordering::Relaxed) {
+            if ratio < EXIT_FAILURE_RATIO {
+                self.active.store(false, Ordering::Relaxed);
+                self.metrics.provider_event_active.set(0.0);
+                tracing::info!(
+                    "Provider event ended: {failures} failures in last {} submissions",
+                    window.len()
+                );
+            }
+        } else if window.len() >= MIN_OBSERVATIONS && ratio >= ENTER_FAILURE_RATIO {
+            self.active.store(true, Ordering::Relaxed);
+            self.metrics.provider_event_active.set(1.0);
+            tracing::warn!(
+                "Provider event detected: {failures} failures in last {} submissions, pausing poison user operation evidence",
+                window.len()
+            );
+        }
+    }
+}
+
+#[derive(Metrics)]
+#[metrics(scope = "builder_sender")]
+struct ProviderEventMetrics {
+    #[metric(describe = "whether a provider-health event is currently active.")]
+    provider_event_active: Gauge,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stays_inactive_below_min_observations() {
+        let signal = ProviderEventSignal::default();
+        // 100% failures, but fewer than MIN_OBSERVATIONS
+        for _ in 0..MIN_OBSERVATIONS - 1 {
+            signal.record_failure();
+        }
+        assert!(!signal.is_active());
+    }
+
+    #[test]
+    fn enters_event_at_failure_ratio() {
+        let signal = ProviderEventSignal::default();
+        for _ in 0..7 {
+            signal.record_success();
+        }
+        for _ in 0..2 {
+            signal.record_failure();
+        }
+        // 9 observations: below the minimum even at the enter ratio
+        assert!(!signal.is_active());
+        signal.record_failure();
+        // 3 failures in 10 observations reaches the 30% enter threshold
+        assert!(signal.is_active());
+    }
+
+    #[test]
+    fn stays_below_enter_ratio() {
+        let signal = ProviderEventSignal::default();
+        for _ in 0..8 {
+            signal.record_success();
+        }
+        for _ in 0..2 {
+            signal.record_failure();
+        }
+        // 2 failures in 10 observations is below the 30% enter threshold
+        assert!(!signal.is_active());
+    }
+
+    #[test]
+    fn exits_event_below_exit_ratio() {
+        let signal = ProviderEventSignal::default();
+        for _ in 0..7 {
+            signal.record_success();
+        }
+        for _ in 0..3 {
+            signal.record_failure();
+        }
+        assert!(signal.is_active());
+
+        // successes push the failures out of the window; the event ends only
+        // once fewer than 10% of the window are failures
+        for _ in 0..18 {
+            signal.record_success();
+        }
+        // two of the failures are still within the last 20 outcomes:
+        // 2/20 = 10%, not yet below the exit ratio (hysteresis)
+        assert!(signal.is_active());
+        signal.record_success();
+        // 1 failure in 20 = 5%, below the 10% exit ratio
+        assert!(!signal.is_active());
+    }
+
+    #[test]
+    fn old_outcomes_roll_off_the_window() {
+        let signal = ProviderEventSignal::default();
+        for _ in 0..6 {
+            signal.record_failure();
+        }
+        for _ in 0..WINDOW_SIZE {
+            signal.record_success();
+        }
+        // the failures have been fully evicted
+        assert!(!signal.is_active());
+        for _ in 0..5 {
+            signal.record_failure();
+        }
+        // 5 failures in the last 20 = 25%, below the enter threshold
+        assert!(!signal.is_active());
+        signal.record_failure();
+        // 6 in 20 = 30%
+        assert!(signal.is_active());
+    }
+}

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -14,6 +14,7 @@
 mod bloxroute;
 mod fallback;
 mod flashbots;
+mod health;
 mod polygon_private;
 mod raw;
 
@@ -25,6 +26,7 @@ pub(crate) use bloxroute::PolygonBloxrouteTransactionSender;
 use enum_dispatch::enum_dispatch;
 pub(crate) use fallback::FallbackTransactionSender;
 pub(crate) use flashbots::FlashbotsTransactionSender;
+pub(crate) use health::ProviderEventSignal;
 #[cfg(test)]
 use mockall::automock;
 pub(crate) use raw::RawTransactionSender;

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -112,7 +112,6 @@ pub(crate) enum TxSenderError {
 /// Classification of a submission failure for poison user operation handling.
 ///
 /// See `docs/designs/poison-user-operations.md`.
-#[allow(dead_code)] // consumed once the bundle sender reports outcomes to the pool
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum RpcOutcomeClass {
     /// Final rejection; retrying the identical transaction cannot succeed.
@@ -126,7 +125,6 @@ pub(crate) enum RpcOutcomeClass {
 
 impl TxSenderError {
     /// Classifies this error for poison user operation handling.
-    #[allow(dead_code)] // consumed once the bundle sender reports outcomes to the pool
     pub(crate) fn classify(&self) -> RpcOutcomeClass {
         match self {
             TxSenderError::IntrinsicGasTooLow | TxSenderError::TerminalRpcError { .. } => {

--- a/crates/builder/src/task.rs
+++ b/crates/builder/src/task.rs
@@ -47,7 +47,7 @@ use crate::{
     bundle_sender::{self, BundleSender, BundleSenderAction, BundleSenderImpl},
     delegation_sender::{DelegationSenderTask, Settings as DelegationSettings},
     emit::BuilderEvent,
-    sender::TransactionSenderArgs,
+    sender::{ProviderEventSignal, TransactionSenderArgs},
     server::{self, LocalBuilderBuilder},
     transaction_tracker::{self, TransactionTrackerImpl},
 };
@@ -487,6 +487,10 @@ where
             }),
         );
 
+        // All builders submit through the same route (sender_args), so they
+        // share one provider-health signal.
+        let provider_event_signal = Arc::new(ProviderEventSignal::default());
+
         let mut bundle_sender_actions = vec![];
         for i in 0..self.args.num_signers {
             let bundle_sender_action = self
@@ -497,6 +501,7 @@ where
                     proposers.clone(),
                     i as usize,
                     heads_tx.subscribe(),
+                    provider_event_signal.clone(),
                 )
                 .await?;
             bundle_sender_actions.push(bundle_sender_action);
@@ -504,6 +509,7 @@ where
         Ok((bundle_sender_actions, heads_tx))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn create_bundle_builder<T>(
         &self,
         task_spawner: &T,
@@ -512,6 +518,7 @@ where
         proposers: Arc<HashMap<ProposerKey, Box<dyn BundleProposerT>>>,
         index: usize,
         heads_rx: broadcast::Receiver<Arc<NewHead>>,
+        provider_event_signal: Arc<ProviderEventSignal>,
     ) -> anyhow::Result<mpsc::Sender<BundleSenderAction>>
     where
         T: TaskSpawnerExt,
@@ -559,6 +566,7 @@ where
             self.pool.clone(),
             sender_settings,
             self.event_sender.clone(),
+            provider_event_signal,
         );
 
         // Spawn each sender as its own independent task

--- a/crates/pool/src/emit.rs
+++ b/crates/pool/src/emit.rs
@@ -103,7 +103,7 @@ pub enum EntityReputation {
 }
 
 /// Reason an operation was removed from the pool
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum OpRemovalReason {
     /// Removal was requested
     Requested,

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -280,11 +280,21 @@ where
         provider_event_active: bool,
         now: Instant,
     ) -> Vec<(B256, OpRemovalReason)> {
-        // Master switch for poison UO handling: when disabled, bundle
-        // outcomes change no UO state and no operation is ever suspected
-        // or removed by this flow.
+        // Master switch for poison UO handling: when disabled, no suspect
+        // state is tracked, so `MarkSuspect` has nothing to fall back on and
+        // reverts to the behavior it replaced — removing every op in an
+        // unattributed multi-op revert — so those ops are not left live with
+        // no path to eviction. Every other outcome is genuinely new
+        // functionality with no pre-existing behavior, so it stays a no-op.
         if !self.config.suspect_tracking_enabled {
-            return Vec::new();
+            return match outcome {
+                BundleOutcome::MarkSuspect => ops
+                    .iter()
+                    .filter(|hash| self.by_hash.contains_key(*hash))
+                    .map(|hash| (*hash, OpRemovalReason::Requested))
+                    .collect(),
+                _ => Vec::new(),
+            };
         }
 
         let suspect_threshold = self.config.rpc_failures_before_suspect;
@@ -2513,7 +2523,14 @@ mod tests {
             Instant::now(),
         );
         assert!(terminal.is_empty());
-        pool.apply_bundle_outcome(&[hash], BundleOutcome::MarkSuspect, false, Instant::now());
+
+        // MarkSuspect is the one exception: with tracking off there is no
+        // suspect state to fall back on, so it reverts to the pre-feature
+        // behavior it replaced and removes the op outright, rather than
+        // silently leaving an unattributed-revert op live forever.
+        let mark_suspect =
+            pool.apply_bundle_outcome(&[hash], BundleOutcome::MarkSuspect, false, Instant::now());
+        assert_eq!(mark_suspect, vec![(hash, OpRemovalReason::Requested)]);
 
         assert_eq!(pool.by_hash[&hash].failures(), 0);
         assert_eq!(pool.best_operations().count(), 1);

--- a/crates/pool/src/mempool/uo_pool.rs
+++ b/crates/pool/src/mempool/uo_pool.rs
@@ -1215,6 +1215,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn report_bundle_outcome_mark_suspect_removes_when_tracking_disabled() {
+        // With the master switch off there is no suspect state to mark, so an
+        // unattributed multi-op revert (MarkSuspect) must fall back to the
+        // pre-feature behavior of removing the op outright, rather than
+        // silently leaving it live with no path to eviction.
+        let op = create_op(Address::random(), 0, 0, None);
+        let config = PoolConfig {
+            suspect_tracking_enabled: false,
+            ..default_config()
+        };
+        let pool = create_pool_with_config(config, vec![op.clone()]);
+        let hash = pool
+            .add_operation(OperationOrigin::Local, op.op, default_perms())
+            .await
+            .unwrap();
+
+        pool.report_bundle_outcome(&[hash], BundleOutcome::MarkSuspect, false);
+        assert!(pool.get_user_operation_by_hash(hash).is_none());
+    }
+
+    #[tokio::test]
     async fn clear() {
         let ops = vec![
             create_op(Address::random(), 0, 3, None),

--- a/crates/types/src/pool/traits.rs
+++ b/crates/types/src/pool/traits.rs
@@ -96,9 +96,15 @@ pub trait Pool: Send + Sync {
 
     /// Get summaries of operations from the pool
     ///
-    /// Returns up to `max_ops` non-suspect operations, plus up to `max_suspects`
-    /// suspect operations whose isolation retry delay has elapsed, marked with
-    /// `suspect: true`. Suspects do not count against `max_ops`.
+    /// Returns up to `max_ops` non-suspect operations, followed by up to
+    /// `max_suspects` suspect operations whose isolation retry delay has
+    /// elapsed, marked with `suspect: true`. Suspects do not count against
+    /// `max_ops` and are always ordered after non-suspects in the returned
+    /// vec — but that ordering is an implementation detail, not something to
+    /// index into: callers that need to separate the two groups (e.g. the
+    /// builder's assigner) must partition on the `suspect` flag on each
+    /// summary rather than assume position, since the non-suspect share can
+    /// itself be shorter than `max_ops`.
     async fn get_ops_summaries(
         &self,
         entry_point: Address,

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -324,6 +324,13 @@ exclusion behind PR 4.
   all.
 - Ships last deliberately — without it the system is fully functional, just without
   outage protection (bounded in the interim only by the backoff spacing from PR 2).
+- Deliberately independent of `FallbackTransactionSender`'s own consecutive-failure
+  failover: that counter reacts to a handful of consecutive errors from one builder's
+  primary sender so it can reroute traffic quickly, while this signal needs a larger,
+  hysteretic sample across all of a route's builders before it gates something as
+  consequential as pausing removal pool-wide. It's also circular to feed one from the
+  other — the signal only observes outcomes *after* failover has already run. The two
+  stay independently tunable.
 
 ## Related work
 

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -173,8 +173,10 @@ state.
 
 ## State ownership
 
-The submission route owns the provider-event signal; the pool consumes it as a single
-boolean gate on suspect removal progress. The pool owns each UO's failure counter (from
+One provider-event signal exists per submission route, shared by the route's builders;
+the bundle sender records final outcomes into it downstream of provider retries and
+fallbacks, and the pool consumes it as a single boolean gate on suspect removal
+progress. The pool owns each UO's failure counter (from
 which suspect status is derived) and suspect retry time so they are shared across
 builders and cleared with the UO lifecycle. This state is in-memory and does not track
 transaction hashes for deduplication.
@@ -297,15 +299,19 @@ exclusion behind PR 4.
 ### PR 5 — Provider-event signal
 
 - Implement the rolling window (last 20 non-neutral final outcomes; enter event at ≥10
-  observations with ≥30% failures, exit below 10%) as a small shared struct owned by
-  the submission route. Record outcomes in `FallbackTransactionSender`
-  (`crates/builder/src/sender/fallback.rs`) after retries/fallbacks are exhausted —
-  success, `ProviderFailure`, or neutral (excluded). Non-fallback senders wrap the same
-  recorder.
-- Expose it as a shared `Arc` boolean checked by the bundle sender when calling
-  `report_bundle_outcome` (the `provider_event_active` flag from PR 2). Its only
-  effect: pause suspect removal progress. Suspect creation and backoff are
-  unaffected, and no counters are cleared on enter/exit.
+  observations with ≥30% failures, exit below 10%) as a small shared struct
+  (`ProviderEventSignal`, `crates/builder/src/sender/health.rs`), one per submission
+  route, shared by the route's builders.
+- Record outcomes in the bundle sender where it already classifies final submission
+  results (`send_bundle_from_data`): this sits downstream of the
+  `FallbackTransactionSender`'s internal retries and failover, so only final outcomes
+  after retries/fallbacks are observed — success, non-terminal provider failure, or
+  neutral/terminal (excluded). Cancellation transactions are not recorded.
+- The bundle sender checks the signal when calling `report_bundle_outcome` (the
+  `provider_event_active` flag from PR 2), recording a failure before reporting it so
+  the report is gated by the freshest state. The signal's only effect: pause suspect
+  removal progress. Suspect creation and backoff are unaffected, and no counters are
+  cleared on enter/exit.
 - Consider recording only transport-level failures (timeouts, connection failures,
   sender unavailable) in the window and excluding error responses: a node that
   evaluates a transaction and answers is not an outage, and rejected-with-a-response

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -78,9 +78,14 @@ reject the transaction.
 | Known operational error | Any | Preserve existing behavior. |
 
 The entire flow is gated behind `--pool.suspect_tracking_enabled` (default `false`).
-When disabled, bundle outcomes change no UO state: no operation is ever suspected or
-removed by this system. This allows the mechanism to ship dark and be enabled
-deliberately once every stage — including the provider-event signal — is deployed.
+When disabled, no operation is ever suspected, and no new removal path (RPC-failure
+thresholds, terminal-error suspicion) fires. The one exception: an unattributed
+multi-op revert still removes every op, exactly as it did before this system existed —
+disabling the switch must not regress bundling to the pre-feature livelock this
+mechanism was partly designed to close (see
+`INVESTIGATION-empty-revert-bundle-livelock.md`). This allows the mechanism to ship
+dark and be enabled deliberately once every stage — including the provider-event
+signal — is deployed.
 
 Provider retries and configured fallbacks are exhausted before an RPC outcome enters
 this flow. A successful fallback has no effect on UO state.


### PR DESCRIPTION
Part of the poison user operation design (PRs 3, 4, and 5 of 5 — completing the series, see `docs/designs/poison-user-operations.md`). Stacked on #1313. PRs 3 and 4 are combined because PR 3 alone would leave suspects excluded from bundles with nothing draining them; PR 5 rides along because it reduces to a small module plus two lines at the choke point PR 3 created.

## Proposed Changes

### Failure flow in the bundle sender (PR 3)

- Report every bundle submission outcome to the pool via `report_bundle_outcome`: `Success` on acceptance (resets failure counters, clearing suspect status), and on error, classify via `TxSenderError::classify()` — terminal errors report `TerminalFailure` (pool removes a sole op, marks larger bundles suspect), non-terminal errors report `NonTerminalFailure` (pool advances failure counters). Neutral operational errors (underpriced, nonce-too-low, etc.) keep their dedicated handling and are not reported.
- Split `process_revert` into a `RevertOutcome` of removals and suspect markings: an unattributed mined revert (`None | Revert | PostOpRevert`, or no revert data) removes a sole op but marks every op of a larger bundle suspect instead of removing all of them. Attributed reverts (`FailedOp`, signature validation, submission proxy) still remove.

### Suspect scheduling in the assigner (PR 4)

- Fetch due suspects alongside normal summaries (`max_suspects`) and hand them out as tagged single-operation isolation assignments, never mixed into normal bundles.
- While normal work is eligible, cap concurrent isolation at `max(1, num_signers / 2)` so suspects cannot starve normal bundles; once normal work is exhausted, any idle builder may isolate. The limit is recomputed per assignment and in-flight isolation work is never canceled.
- Suspects respect the same sender locks and fee filtering as normal work; replacement attempts never start new isolation work (an accepted in-flight bundle has already cleared its ops' suspect status).
- With a single builder signer, the scheduler cannot guarantee progress for both work classes when both remain continuously eligible — documented on the CLI args.

### Provider-event signal (PR 5)

- `ProviderEventSignal`: a rolling window of the last 20 non-neutral final submission outcomes; enter an event at ≥ 10 observations with ≥ 30% failures, exit below 10% (hysteresis prevents flapping). One signal per submission route, shared by the route's builders; exposed as a `builder_sender_provider_event_active` gauge.
- Outcomes are recorded at the bundle-sender choke point where final results are already classified — downstream of the fallback sender's internal retries and failover, so only final outcomes enter the window. Successes and non-terminal provider failures are recorded; neutral and terminal errors are excluded, as are cancellation transactions.
- The live signal state is passed as `provider_event_active` when reporting outcomes; a failure is recorded before it is reported so the report is gated by the freshest state. Pool-side (from PR 2), an active event pauses suspect removal progress only.

**Still dark**: all suspect state changes remain behind PR 2's `--pool.suspect_tracking_enabled` master switch (default `false`). With it off, reports change no UO state and the pool returns no suspects to isolate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
