### PR TITLE
feat(pool,builder): add poison user operation telemetry (PR 6)

### DIFF
--- a/crates/builder/src/assigner.rs
+++ b/crates/builder/src/assigner.rs
@@ -251,21 +251,29 @@ impl Assigner {
         // suspects cannot starve normal bundles; once normal work is
         // exhausted, any idle builder may drain suspects. Recomputed on every
         // assignment.
+        let isolation_limit = if candidates.is_empty() {
+            self.num_signers
+        } else {
+            (self.num_signers / 2).max(1)
+        };
+        self.metrics.isolation_limit.set(isolation_limit as f64);
+
         if !suspect_candidates.is_empty() {
-            let isolation_limit = if candidates.is_empty() {
-                self.num_signers
-            } else {
-                (self.num_signers / 2).max(1)
-            };
             // Reserve the isolation slot under the same lock as the capacity
             // check: concurrent builders calling assign_work must not both
             // read a count below the limit and then both insert, exceeding
             // isolation_limit. Released below if no suspect ends up
-            // claimable, so a failed attempt doesn't waste the slot.
+            // claimable, so a failed attempt doesn't waste the slot. The
+            // gauge is refreshed inside every critical section that touches
+            // `isolating_builders` so it can't go stale between mutations.
             let reserved = {
                 let mut state = self.state.lock().unwrap();
-                state.isolating_builders.len() < isolation_limit
-                    && state.isolating_builders.insert(builder_address)
+                let reserved = state.isolating_builders.len() < isolation_limit
+                    && state.isolating_builders.insert(builder_address);
+                self.metrics
+                    .isolating_builders
+                    .set(state.isolating_builders.len() as f64);
+                reserved
             };
             if reserved {
                 match self
@@ -279,18 +287,18 @@ impl Assigner {
                 {
                     Ok(Some(assignment)) => return Ok(AssignmentResult::Assigned(assignment)),
                     Ok(None) => {
-                        self.state
-                            .lock()
-                            .unwrap()
+                        let mut state = self.state.lock().unwrap();
+                        state.isolating_builders.remove(&builder_address);
+                        self.metrics
                             .isolating_builders
-                            .remove(&builder_address);
+                            .set(state.isolating_builders.len() as f64);
                     }
                     Err(e) => {
-                        self.state
-                            .lock()
-                            .unwrap()
+                        let mut state = self.state.lock().unwrap();
+                        state.isolating_builders.remove(&builder_address);
+                        self.metrics
                             .isolating_builders
-                            .remove(&builder_address);
+                            .set(state.isolating_builders.len() as f64);
                         return Err(e);
                     }
                 }
@@ -819,6 +827,9 @@ impl Assigner {
                 state.builder_to_uo_senders.remove(&builder_address);
                 state.builder_to_pinned_proposer.remove(&builder_address);
                 state.isolating_builders.remove(&builder_address);
+                self.metrics
+                    .isolating_builders
+                    .set(state.isolating_builders.len() as f64);
             }
         }
 
@@ -845,6 +856,9 @@ impl Assigner {
             .map(ep_metrics_for_key);
         state.builder_to_pinned_proposer.remove(&builder_address);
         state.isolating_builders.remove(&builder_address);
+        self.metrics
+            .isolating_builders
+            .set(state.isolating_builders.len() as f64);
         let Some(builder_senders) = state.builder_to_uo_senders.remove(&builder_address) else {
             return;
         };
@@ -907,6 +921,10 @@ impl Assigner {
 struct GlobalMetrics {
     #[metric(describe = "the number of active builders.")]
     active_builders: Gauge,
+    #[metric(describe = "the computed isolation capacity limit for the current assignment cycle.")]
+    isolation_limit: Gauge,
+    #[metric(describe = "the number of builders currently holding an isolation assignment.")]
+    isolating_builders: Gauge,
 }
 
 #[derive(Metrics)]

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -1118,6 +1118,15 @@ where
         if ops.is_empty() {
             return;
         }
+
+        let outcome_metric = match outcome {
+            BundleOutcome::Success => "builder_bundle_outcome_success",
+            BundleOutcome::NonTerminalFailure => "builder_bundle_outcome_non_terminal_failure",
+            BundleOutcome::TerminalFailure => "builder_bundle_outcome_terminal_failure",
+            BundleOutcome::MarkSuspect => "builder_bundle_outcome_mark_suspect",
+        };
+        self.increment_counter_ep(outcome_metric, entry_point, 1);
+
         if let Err(error) = self
             .pool
             .report_bundle_outcome(
@@ -1128,6 +1137,7 @@ where
             )
             .await
         {
+            self.increment_counter_ep("builder_bundle_outcome_report_failed", entry_point, 1);
             warn!("Failed to report bundle outcome to pool: {error}");
         }
     }

--- a/crates/builder/src/sender/health.rs
+++ b/crates/builder/src/sender/health.rs
@@ -19,7 +19,7 @@ use std::{
     },
 };
 
-use metrics::Gauge;
+use metrics::{Counter, Gauge};
 use metrics_derive::Metrics;
 
 /// Number of most recent non-neutral final submission outcomes considered.
@@ -104,6 +104,7 @@ impl ProviderEventSignal {
         } else if window.len() >= MIN_OBSERVATIONS && ratio >= ENTER_FAILURE_RATIO {
             self.active.store(true, Ordering::Relaxed);
             self.metrics.provider_event_active.set(1.0);
+            self.metrics.provider_events_total.increment(1);
             tracing::warn!(
                 "Provider event detected: {failures} failures in last {} submissions, pausing poison user operation evidence",
                 window.len()
@@ -117,6 +118,8 @@ impl ProviderEventSignal {
 struct ProviderEventMetrics {
     #[metric(describe = "whether a provider-health event is currently active.")]
     provider_event_active: Gauge,
+    #[metric(describe = "the total number of times a provider-health event was entered.")]
+    provider_events_total: Counter,
 }
 
 #[cfg(test)]

--- a/crates/pool/src/emit.rs
+++ b/crates/pool/src/emit.rs
@@ -47,6 +47,18 @@ pub enum OpPoolEvent {
         /// Removal reason
         reason: OpRemovalReason,
     },
+    /// An operation was marked as a poison-UO suspect
+    MarkedSuspect {
+        /// Operation hash
+        op_hash: B256,
+        /// What triggered the suspicion
+        trigger: SuspectTrigger,
+    },
+    /// A suspect operation was cleared by a successful submission
+    SuspectCleared {
+        /// Operation hash
+        op_hash: B256,
+    },
     /// All operations for an entity were removed from the pool
     RemovedEntity {
         /// The removed entity
@@ -154,6 +166,18 @@ pub enum OpRemovalReason {
     RepeatedNonTerminalRpcFailure,
 }
 
+/// What triggered a UO being marked suspect. See
+/// `docs/designs/poison-user-operations.md`.
+#[derive(Clone, Copy, Debug)]
+pub enum SuspectTrigger {
+    /// An ambiguous multi-UO failure (unattributed mined revert or terminal
+    /// RPC error on a bundle of more than one op) forced suspicion
+    /// immediately.
+    MultiOpFailure,
+    /// The non-terminal RPC failure counter reached the suspect threshold.
+    Threshold,
+}
+
 impl EntitySummary {
     pub fn set_status(&mut self, kind: EntityType, status: EntityStatus) {
         match kind {
@@ -207,6 +231,20 @@ impl Display for OpPoolEvent {
                     }
                     _ => write!(f, "    Reason: {:?}", reason),
                 }
+            }
+            OpPoolEvent::MarkedSuspect { op_hash, trigger } => {
+                write!(
+                    f,
+                    "Marked op as poison UO suspect.    Op hash: {:?}    Trigger: {:?}",
+                    op_hash, trigger
+                )
+            }
+            OpPoolEvent::SuspectCleared { op_hash } => {
+                write!(
+                    f,
+                    "Cleared poison UO suspect status.    Op hash: {:?}",
+                    op_hash
+                )
             }
             OpPoolEvent::RemovedEntity { entity } => {
                 write!(

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -39,7 +39,11 @@ use tokio::sync::broadcast;
 use tracing::info;
 
 use super::{MempoolResult, PoolConfig, entity_tracker::EntityCounter, size::SizeTracker};
-use crate::{PoolEvent, chain::MinedOp, emit::OpRemovalReason};
+use crate::{
+    PoolEvent,
+    chain::MinedOp,
+    emit::{OpRemovalReason, SuspectTrigger},
+};
 
 #[derive(Debug, Clone)]
 pub(crate) struct PoolInnerConfig {
@@ -137,6 +141,14 @@ where
         event_sender: broadcast::Sender<WithEntryPoint<PoolEvent>>,
     ) -> Self {
         let entry_point = config.entry_point.to_string();
+        let metrics = PoolMetrics::new_with_labels(&[("entry_point", entry_point)]);
+        metrics
+            .suspect_tracking_enabled
+            .set(if config.suspect_tracking_enabled {
+                1.0
+            } else {
+                0.0
+            });
         Self {
             config,
             da_gas_oracle,
@@ -155,7 +167,7 @@ where
             pool_size: SizeTracker::default(),
             cache_size: SizeTracker::default(),
             prev_block_number: 0,
-            metrics: PoolMetrics::new_with_labels(&[("entry_point", entry_point)]),
+            metrics,
             event_sender,
         }
     }
@@ -304,7 +316,13 @@ where
             BundleOutcome::Success => {
                 for hash in ops {
                     if let Some(op) = self.by_hash.get(hash) {
+                        let was_suspect = op.is_suspect(suspect_threshold);
                         op.reset_failures();
+                        if was_suspect {
+                            self.metrics.num_suspect_ops.decrement(1.0);
+                            self.metrics.num_suspects_cleared.increment(1);
+                            self.emit(PoolEvent::SuspectCleared { op_hash: *hash });
+                        }
                     }
                 }
             }
@@ -327,18 +345,28 @@ where
                         );
                         continue;
                     }
+                    let was_suspect = op.is_suspect(suspect_threshold);
                     let failures = op.record_failure(
                         now,
                         suspect_threshold,
                         self.config.suspect_rpc_backoff_initial,
                         self.config.suspect_rpc_backoff_max,
                     );
+                    if !was_suspect && failures >= suspect_threshold {
+                        self.metrics.num_suspect_ops.increment(1.0);
+                        self.metrics.num_marked_suspect_threshold.increment(1);
+                        self.emit(PoolEvent::MarkedSuspect {
+                            op_hash: *hash,
+                            trigger: SuspectTrigger::Threshold,
+                        });
+                    }
                     if self.config.max_suspect_rpc_failures > 0
                         && failures
                             >= suspect_threshold
                                 .saturating_add(self.config.max_suspect_rpc_failures)
                     {
                         to_remove.push((*hash, OpRemovalReason::RepeatedNonTerminalRpcFailure));
+                        self.metrics.num_suspects_removed.increment(1);
                     }
                 }
             }
@@ -346,11 +374,12 @@ where
                 if let [hash] = ops {
                     if self.by_hash.contains_key(hash) {
                         to_remove.push((*hash, OpRemovalReason::TerminalRpcError));
+                        self.metrics.num_suspects_removed.increment(1);
                     }
                 } else {
                     for hash in ops {
                         if let Some(op) = self.by_hash.get(hash) {
-                            op.mark_suspect(suspect_threshold);
+                            self.mark_suspect_and_record(*hash, op, suspect_threshold);
                         }
                     }
                 }
@@ -358,13 +387,37 @@ where
             BundleOutcome::MarkSuspect => {
                 for hash in ops {
                     if let Some(op) = self.by_hash.get(hash) {
-                        op.mark_suspect(suspect_threshold);
+                        self.mark_suspect_and_record(*hash, op, suspect_threshold);
                     }
                 }
             }
         }
 
         to_remove
+    }
+
+    /// Marks an operation suspect and records the transition (suspect gauge,
+    /// multi-op-failure counter, `MarkedSuspect` event) unless it was already
+    /// a suspect, per the ambiguous multi-UO failure paths in the failure
+    /// flow table.
+    fn mark_suspect_and_record(
+        &self,
+        hash: B256,
+        op: &OrderedPoolOperation,
+        suspect_threshold: u32,
+    ) {
+        let was_suspect = op.is_suspect(suspect_threshold);
+        op.mark_suspect(suspect_threshold);
+        if !was_suspect {
+            self.metrics.num_suspect_ops.increment(1.0);
+            self.metrics
+                .num_marked_suspect_multi_op_failure
+                .increment(1);
+            self.emit(PoolEvent::MarkedSuspect {
+                op_hash: hash,
+                trigger: SuspectTrigger::MultiOpFailure,
+            });
+        }
     }
 
     pub(crate) fn all_operations(&self) -> impl Iterator<Item = Arc<PoolOperation>> + '_ {
@@ -905,6 +958,13 @@ where
         block_number: Option<u64>,
     ) -> Option<Arc<PoolOperation>> {
         let op = self.by_hash.remove(&hash)?;
+        // Recompute the current suspect population on every removal path
+        // (mined, expired, replaced, entity-removed, poison-ops removal,
+        // etc.) so the gauge never leaks regardless of why a suspect left
+        // the pool.
+        if op.is_suspect(self.config.rpc_failures_before_suspect) {
+            self.metrics.num_suspect_ops.decrement(1.0);
+        }
         let id = &op.po.uo.id();
         self.by_id.remove(id);
         self.best.remove(&op);
@@ -1205,6 +1265,24 @@ struct PoolMetrics {
     num_7702_ops_added: Counter,
     #[metric(describe = "the number of ops added")]
     num_ops_added: Counter,
+    #[metric(describe = "the number of suspect ops currently in the pool.")]
+    num_suspect_ops: Gauge,
+    #[metric(describe = "the number of ops marked suspect by an ambiguous multi-op failure.")]
+    num_marked_suspect_multi_op_failure: Counter,
+    #[metric(
+        describe = "the number of ops marked suspect by reaching the non-terminal RPC failure threshold."
+    )]
+    num_marked_suspect_threshold: Counter,
+    #[metric(describe = "the number of suspects cleared by a successful submission.")]
+    num_suspects_cleared: Counter,
+    #[metric(
+        describe = "the number of suspects removed after a terminal RPC error or repeated non-terminal RPC failures."
+    )]
+    num_suspects_removed: Counter,
+    #[metric(
+        describe = "whether poison user operation suspect tracking is enabled (1) or disabled (0)."
+    )]
+    suspect_tracking_enabled: Gauge,
 }
 
 #[cfg(test)]

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -209,8 +209,8 @@ helper (`builder_sender` scope) for anything that varies by submission route.
 | `num_suspects_cleared` | Counter | pool | Liveness | Successful submissions that reset a suspect's counter — the recovery path the provider-resilience tradeoff depends on. |
 | `num_suspects_removed` | Counter | pool | Liveness | Removals via `TerminalRpcError` or `RepeatedNonTerminalRpcFailure`, combined. |
 | `suspect_tracking_enabled` | Gauge (0/1) | pool | — | Master switch state, set once at construction; lets a dashboard confirm rollout state without cross-referencing CLI flags. |
-| `ep_isolation_limit` | Gauge, per entry point | assigner | Fairness | The computed cap for the current assignment cycle: `max(1, num_signers / 2)` while normal work is eligible, otherwise uncapped. |
-| `ep_isolating_builders` | Gauge, per entry point | assigner | Fairness | Current size of `isolating_builders`. Paired with the limit, shows whether isolation is capacity-starved or simply idle. |
+| `isolation_limit` | Gauge, global | assigner | Fairness | The computed cap for the current assignment cycle: `max(1, num_signers / 2)` while normal work is eligible, otherwise uncapped. Global, not per entry point — isolation capacity is shared by one builder pool across all configured entrypoints. |
+| `isolating_builders` | Gauge, global | assigner | Fairness | Current size of `isolating_builders`. Paired with the limit, shows whether isolation is capacity-starved or simply idle. |
 | `builder_bundle_outcome_success` / `_non_terminal_failure` / `_terminal_failure` / `_mark_suspect` | Counter, per sender + entry point | sender | Liveness / Provider resilience | One counter per `BundleOutcome` reported via `report_bundle_outcome`, at the same call sites that classify the submission result. |
 | `builder_bundle_outcome_report_failed` | Counter, per sender + entry point | sender | — | The existing "Failed to report bundle outcome to pool" warning, counted. A sustained rate means pool suspect state is silently diverging from what actually happened on submission. |
 | `provider_events_total` | Counter | sender | Provider resilience | Total enter transitions, alongside the existing `provider_event_active` gauge — a rate here is a flapping detector the gauge alone can't show. |
@@ -241,7 +241,7 @@ rather than by crate:
 
 - **Liveness** — `num_suspect_ops` over time; marked/cleared/removed rates plotted
   together to show whether isolation is keeping pace.
-- **Fairness** — `ep_isolating_builders` vs. `ep_isolation_limit` vs. `num_signers`,
+- **Fairness** — `isolating_builders` vs. `isolation_limit` vs. `num_signers`,
   alongside isolation- vs. normal-assignment rates.
 - **Provider resilience** — `provider_event_active` as a state timeline with
   `provider_events_total` rate overlaid, and suspect-removal rate on the same timeline to

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -186,6 +186,81 @@ which suspect status is derived) and suspect retry time so they are shared acros
 builders and cleared with the UO lifecycle. This state is in-memory and does not track
 transaction hashes for deduplication.
 
+## Telemetry
+
+The mechanism's internal state is otherwise invisible in production: `apply_bundle_outcome`
+performs no logging today, and the only existing signals are `ep_isolation_assignments`,
+`provider_event_active`, and generic removal logging via `OpRemovalReason`. The additions
+below are scoped to what each goal needs to be observable, not to instrument every
+internal transition.
+
+### Metrics
+
+New metrics follow the existing per-crate conventions: derived `#[derive(Metrics)]`
+structs scoped `op_pool` (pool.rs) and `builder_assigner` (assigner.rs), and per-sender,
+per-entry-point labeled counters via the bundle sender's existing `increment_counter_ep`
+helper (`builder_sender` scope) for anything that varies by submission route.
+
+| Metric | Type | Where | Goal | Purpose |
+| --- | --- | --- | --- | --- |
+| `num_suspect_ops` | Gauge | pool | Liveness | Current suspect population — the primary signal for whether suspects are accumulating faster than isolation drains them. |
+| `num_marked_suspect_multi_op_failure` | Counter | pool | Liveness | Suspicions forced immediately by an unattributed mined revert or a terminal RPC error on a bundle of more than one op. |
+| `num_marked_suspect_threshold` | Counter | pool | Liveness | Suspicions from the non-terminal failure counter reaching `rpc_failures_before_suspect`. |
+| `num_suspects_cleared` | Counter | pool | Liveness | Successful submissions that reset a suspect's counter — the recovery path the provider-resilience tradeoff depends on. |
+| `num_suspects_removed` | Counter | pool | Liveness | Removals via `TerminalRpcError` or `RepeatedNonTerminalRpcFailure`, combined. |
+| `suspect_tracking_enabled` | Gauge (0/1) | pool | — | Master switch state, set once at construction; lets a dashboard confirm rollout state without cross-referencing CLI flags. |
+| `ep_isolation_limit` | Gauge, per entry point | assigner | Fairness | The computed cap for the current assignment cycle: `max(1, num_signers / 2)` while normal work is eligible, otherwise uncapped. |
+| `ep_isolating_builders` | Gauge, per entry point | assigner | Fairness | Current size of `isolating_builders`. Paired with the limit, shows whether isolation is capacity-starved or simply idle. |
+| `builder_bundle_outcome_success` / `_non_terminal_failure` / `_terminal_failure` / `_mark_suspect` | Counter, per sender + entry point | sender | Liveness / Provider resilience | One counter per `BundleOutcome` reported via `report_bundle_outcome`, at the same call sites that classify the submission result. |
+| `builder_bundle_outcome_report_failed` | Counter, per sender + entry point | sender | — | The existing "Failed to report bundle outcome to pool" warning, counted. A sustained rate means pool suspect state is silently diverging from what actually happened on submission. |
+| `provider_events_total` | Counter | sender | Provider resilience | Total enter transitions, alongside the existing `provider_event_active` gauge — a rate here is a flapping detector the gauge alone can't show. |
+
+`ep_isolation_assignments` and `provider_event_active` (both existing) are unchanged.
+
+None of these are labeled by `op_hash`, consistent with the existing convention (the
+bundle sender labels only by `sender`/`entry_point`) and necessary to keep the Prometheus
+endpoint's cardinality bounded under a poison-op herd.
+
+### Logs
+
+Two new `OpPoolEvent` variants (`crates/pool/src/emit.rs`), logged for free at `info` via
+the existing generic sink the same way `RemovedOp` already is:
+
+- `MarkedSuspect { op_hash, trigger }` — `trigger` distinguishes multi-op-failure from
+  threshold, mirroring the metric split above.
+- `SuspectCleared { op_hash }`.
+
+`OpPoolEvent` is an in-process broadcast channel only, never serialized over the pool's
+gRPC boundary, so these additions carry no proto or remote-client cost.
+
+### Dashboards
+
+No dashboard or alerting config exists in this repo today; these panels are the first,
+built on the Prometheus endpoint already exposed by the metrics CLI. Organized by goal
+rather than by crate:
+
+- **Liveness** — `num_suspect_ops` over time; marked/cleared/removed rates plotted
+  together to show whether isolation is keeping pace.
+- **Fairness** — `ep_isolating_builders` vs. `ep_isolation_limit` vs. `num_signers`,
+  alongside isolation- vs. normal-assignment rates.
+- **Provider resilience** — `provider_event_active` as a state timeline with
+  `provider_events_total` rate overlaid, and suspect-removal rate on the same timeline to
+  visually confirm removals pause while an event is active.
+
+### Alerts
+
+- **Suspects accumulating without draining**: `num_suspect_ops` sustained high while
+  `num_suspects_cleared` is ~0 — isolation starvation or a systemic problem beyond a
+  couple poison ops.
+- **Provider event flapping**: high rate of `provider_events_total` — enter/exit
+  thresholds likely miscalibrated for that route.
+- **Sustained provider event**: `provider_event_active == 1` for longer than an
+  operator-chosen duration — treat as an outage independent of the poison-ops mechanism.
+- **Master-switch drift**: `suspect_tracking_enabled` differing across a fleet for the
+  same entry point — config skew that should never occur post-rollout.
+- **Outcome-report failures**: sustained `builder_bundle_outcome_report_failed` rate —
+  pool state silently diverging from actual submission outcomes.
+
 ## Tradeoffs
 
 - **Liveness versus false removal:** eventual removal protects bundling, but
@@ -209,9 +284,10 @@ transaction hashes for deduplication.
 
 ## Implementation plan
 
-Five self-contained PRs that build in order. PRs 1–2 are inert plumbing (no visible
-behavior change), PR 3 is the behavior switch, and PRs 4–5 are independent of each
-other once PR 3 lands.
+Six self-contained PRs that build in order. PRs 1–2 are inert plumbing (no visible
+behavior change), PR 3 is the behavior switch, PRs 4–5 are independent of each
+other once PR 3 lands, and PR 6 (telemetry) is additive and lands incrementally
+alongside 2–5 — each metric only becomes meaningful once its source PR is in.
 
 ### PR 1 — Terminal vs. non-terminal error classification (foundation)
 
@@ -331,6 +407,24 @@ exclusion behind PR 4.
   consequential as pausing removal pool-wide. It's also circular to feed one from the
   other — the signal only observes outcomes *after* failover has already run. The two
   stay independently tunable.
+
+### PR 6 — Telemetry
+
+Adds the metrics, logs, dashboards, and alerts from the Telemetry section. Independent
+of PR 4–5 internally, but each metric only becomes meaningful once its source PR has
+landed (isolation metrics need PR 4, provider-event metrics need PR 5), so it lands
+incrementally alongside them rather than all at once.
+
+- Pool metrics (extending `PoolMetrics` in `crates/pool/src/mempool/pool.rs`) and the two
+  new `OpPoolEvent` variants (`crates/pool/src/emit.rs`), wired at the
+  `apply_bundle_outcome` call sites already added in PR 2.
+- Assigner metrics (extending `PerEntrypointMetrics` in `crates/builder/src/assigner.rs`),
+  set alongside the existing `ep_isolation_assignments` increment.
+- Sender metrics (`crates/builder/src/bundle_sender.rs`), via the existing
+  `increment_counter_ep` helper at the `report_bundle_outcome` call sites (PR 3) and the
+  two existing `warn!` sites for report failures.
+- `provider_events_total` (`crates/builder/src/sender/health.rs`), incremented alongside
+  the existing `provider_event_active` gauge sets.
 
 ## Related work
 


### PR DESCRIPTION
## Summary

Implements PR 6 from `docs/designs/poison-user-operations.md` (also added in
this PR): the telemetry section discussed on top of PR 3+4. Stacked on
#1314.

- **docs**: adds the Telemetry section (Metrics, Logs, Dashboards, Alerts)
  and a PR 6 entry in the implementation plan.
- **pool** (`op_pool` scope): live `num_suspect_ops` gauge maintained
  incrementally at every suspect/clear/removal transition (not a per-call
  pool scan — removal is hooked at the single `remove_operation_internal`
  choke point so the gauge can't leak regardless of *why* a suspect leaves
  the pool); `num_marked_suspect_multi_op_failure` /
  `num_marked_suspect_threshold` / `num_suspects_cleared` /
  `num_suspects_removed` counters; a `suspect_tracking_enabled` gauge set
  once at construction. Two new `OpPoolEvent` variants, `MarkedSuspect` and
  `SuspectCleared`, logged for free via the existing generic event sink (no
  proto impact — `OpPoolEvent` never crosses the pool's gRPC boundary).
- **builder** (`builder_assigner` / `builder_sender` scopes): global
  `isolation_limit` / `isolating_builders` gauges in the assigner, recomputed
  every assignment cycle (this data is global, not per-entrypoint, unlike
  the existing `ep_isolation_assignments` counter); a per-sender
  `report_bundle_outcome` classification breakdown
  (`builder_bundle_outcome_{success,non_terminal_failure,terminal_failure,mark_suspect}`)
  plus a `builder_bundle_outcome_report_failed` counter, both added at the
  bundle sender's single existing `report_bundle_outcome` helper; a
  `provider_events_total` counter alongside the existing
  `provider_event_active` gauge.

No config, CLI, or behavior changes — purely additive observability on top
of the already-landed suspect-tracking/isolation/provider-event mechanisms.

## Test plan

- [x] `cargo check -p rundler-pool -p rundler-builder`
- [x] `cargo clippy -p rundler-pool -p rundler-builder --all-targets -- -D warnings` (clean)
- [x] `cargo test -p rundler-pool -p rundler-builder --lib` (264 passed, all pre-existing suspect/assigner/health tests green — telemetry is additive and behavior-preserving)
- [x] `make fmt` (no changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)