### PR TITLE
feat(pool,builder): poison user operation detection, isolation, and telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5416,11 +5416,13 @@ version = "0.11.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
+ "alloy-transport",
  "anyhow",
  "async-trait",
  "enum_dispatch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5501,6 +5501,7 @@ dependencies = [
  "mockall",
  "parking_lot",
  "prost 0.13.4",
+ "rand 0.8.5",
  "reth-tasks",
  "rundler-contracts",
  "rundler-provider",

--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -333,6 +333,7 @@ impl BuilderArgs {
         let raw_args = || RawSenderArgs {
             submit_url: self.submit_url.clone().unwrap_or_else(|| rpc_url.into()),
             use_conditional_rpc: false,
+            internal_rpc_error_is_terminal: chain_spec.internal_rpc_error_is_terminal,
         };
 
         // Wrap `primary` in a FallbackSenderArgs if recovery is configured.
@@ -353,6 +354,7 @@ impl BuilderArgs {
             TransactionSenderKind::Raw => Ok(TransactionSenderArgs::Raw(RawSenderArgs {
                 submit_url: self.submit_url.clone().unwrap_or_else(|| rpc_url.into()),
                 use_conditional_rpc: self.use_conditional_rpc,
+                internal_rpc_error_is_terminal: chain_spec.internal_rpc_error_is_terminal,
             })),
             TransactionSenderKind::PolygonPrivate => {
                 let primary = TransactionSenderArgs::PolygonPrivate(PolygonPrivateArgs {

--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -333,7 +333,7 @@ impl BuilderArgs {
         let raw_args = || RawSenderArgs {
             submit_url: self.submit_url.clone().unwrap_or_else(|| rpc_url.into()),
             use_conditional_rpc: false,
-            internal_rpc_error_is_terminal: chain_spec.internal_rpc_error_is_terminal,
+            chain_spec: chain_spec.clone(),
         };
 
         // Wrap `primary` in a FallbackSenderArgs if recovery is configured.
@@ -354,7 +354,7 @@ impl BuilderArgs {
             TransactionSenderKind::Raw => Ok(TransactionSenderArgs::Raw(RawSenderArgs {
                 submit_url: self.submit_url.clone().unwrap_or_else(|| rpc_url.into()),
                 use_conditional_rpc: self.use_conditional_rpc,
-                internal_rpc_error_is_terminal: chain_spec.internal_rpc_error_is_terminal,
+                chain_spec: chain_spec.clone(),
             })),
             TransactionSenderKind::PolygonPrivate => {
                 let primary = TransactionSenderArgs::PolygonPrivate(PolygonPrivateArgs {

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -186,7 +186,10 @@ pub struct PoolArgs {
     pub suspect_tracking_enabled: bool,
 
     /// Number of non-terminal RPC submission failures before a user operation
-    /// becomes a suspect and is only submitted alone.
+    /// becomes a suspect and is only submitted alone. Must be at least 1: at
+    /// 0, every fresh operation would satisfy `failures >= threshold`
+    /// immediately, and a successful submission resetting failures to 0
+    /// would make it look suspect again on its very next attempt.
     ///
     /// With a single builder signer, the scheduler cannot guarantee progress
     /// for both suspect and normal work when both remain continuously
@@ -195,7 +198,8 @@ pub struct PoolArgs {
         long = "pool.rpc_failures_before_suspect",
         name = "pool.rpc_failures_before_suspect",
         env = "POOL_RPC_FAILURES_BEFORE_SUSPECT",
-        default_value = "3"
+        default_value = "3",
+        value_parser = clap::value_parser!(u32).range(1..)
     )]
     pub rpc_failures_before_suspect: u32,
 

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -187,6 +187,10 @@ pub struct PoolArgs {
 
     /// Number of non-terminal RPC submission failures before a user operation
     /// becomes a suspect and is only submitted alone.
+    ///
+    /// With a single builder signer, the scheduler cannot guarantee progress
+    /// for both suspect and normal work when both remain continuously
+    /// eligible.
     #[arg(
         long = "pool.rpc_failures_before_suspect",
         name = "pool.rpc_failures_before_suspect",

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -174,6 +174,49 @@ pub struct PoolArgs {
         env = "POOL_MAX_TIME_IN_POOL_SECS"
     )]
     pub max_time_in_pool_secs: Option<u64>,
+
+    /// Number of non-terminal RPC submission failures before a user operation
+    /// becomes a suspect and is only submitted alone.
+    #[arg(
+        long = "pool.rpc_failures_before_suspect",
+        name = "pool.rpc_failures_before_suspect",
+        env = "POOL_RPC_FAILURES_BEFORE_SUSPECT",
+        default_value = "3"
+    )]
+    pub rpc_failures_before_suspect: u32,
+
+    /// Number of non-terminal RPC submission failures a suspect is allowed
+    /// before it is removed from the pool. 0 disables removal.
+    ///
+    /// The suspect backoff schedule spaces these failures; a provider incident
+    /// outlasting the cumulative backoff can remove healthy operations. Raise
+    /// this threshold to tolerate longer incidents.
+    #[arg(
+        long = "pool.max_suspect_rpc_failures",
+        name = "pool.max_suspect_rpc_failures",
+        env = "POOL_MAX_SUSPECT_RPC_FAILURES",
+        default_value = "3"
+    )]
+    pub max_suspect_rpc_failures: u32,
+
+    /// Initial delay in seconds between suspect isolation attempts, doubling
+    /// with each failure.
+    #[arg(
+        long = "pool.suspect_rpc_backoff_initial_secs",
+        name = "pool.suspect_rpc_backoff_initial_secs",
+        env = "POOL_SUSPECT_RPC_BACKOFF_INITIAL_SECS",
+        default_value = "1"
+    )]
+    pub suspect_rpc_backoff_initial_secs: u64,
+
+    /// Maximum delay in seconds between suspect isolation attempts.
+    #[arg(
+        long = "pool.suspect_rpc_backoff_max_secs",
+        name = "pool.suspect_rpc_backoff_max_secs",
+        env = "POOL_SUSPECT_RPC_BACKOFF_MAX_SECS",
+        default_value = "600"
+    )]
+    pub suspect_rpc_backoff_max_secs: u64,
 }
 
 impl PoolArgs {
@@ -229,6 +272,10 @@ impl PoolArgs {
                 .verification_gas_limit_efficiency_reject_threshold,
             max_time_in_pool: self.max_time_in_pool_secs.map(Duration::from_secs),
             max_expected_storage_slots: common.max_expected_storage_slots.unwrap_or(usize::MAX),
+            rpc_failures_before_suspect: self.rpc_failures_before_suspect,
+            max_suspect_rpc_failures: self.max_suspect_rpc_failures,
+            suspect_rpc_backoff_initial: Duration::from_secs(self.suspect_rpc_backoff_initial_secs),
+            suspect_rpc_backoff_max: Duration::from_secs(self.suspect_rpc_backoff_max_secs),
         };
 
         let mut pool_configs = vec![];

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -175,6 +175,16 @@ pub struct PoolArgs {
     )]
     pub max_time_in_pool_secs: Option<u64>,
 
+    /// Master switch for poison user operation handling (suspect tracking,
+    /// isolation, and removal). Disabled by default.
+    #[arg(
+        long = "pool.suspect_tracking_enabled",
+        name = "pool.suspect_tracking_enabled",
+        env = "POOL_SUSPECT_TRACKING_ENABLED",
+        default_value = "false"
+    )]
+    pub suspect_tracking_enabled: bool,
+
     /// Number of non-terminal RPC submission failures before a user operation
     /// becomes a suspect and is only submitted alone.
     #[arg(
@@ -272,6 +282,7 @@ impl PoolArgs {
                 .verification_gas_limit_efficiency_reject_threshold,
             max_time_in_pool: self.max_time_in_pool_secs.map(Duration::from_secs),
             max_expected_storage_slots: common.max_expected_storage_slots.unwrap_or(usize::MAX),
+            suspect_tracking_enabled: self.suspect_tracking_enabled,
             rpc_failures_before_suspect: self.rpc_failures_before_suspect,
             max_suspect_rpc_failures: self.max_suspect_rpc_failures,
             suspect_rpc_backoff_initial: Duration::from_secs(self.suspect_rpc_backoff_initial_secs),

--- a/bin/rundler/src/cli/pool.rs
+++ b/bin/rundler/src/cli/pool.rs
@@ -205,7 +205,7 @@ pub struct PoolArgs {
         long = "pool.max_suspect_rpc_failures",
         name = "pool.max_suspect_rpc_failures",
         env = "POOL_MAX_SUSPECT_RPC_FAILURES",
-        default_value = "3"
+        default_value = "8"
     )]
     pub max_suspect_rpc_failures: u32,
 

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -53,6 +53,7 @@ mockall.workspace = true
 rundler-provider = { workspace = true, features = ["test-utils"] }
 rundler-sim = { workspace = true, features = ["test-utils"] }
 rundler-types = { workspace = true, features = ["test-utils"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -46,7 +46,9 @@ tonic-reflection.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+alloy-json-rpc.workspace = true
 alloy-rpc-types-eth.workspace = true
+alloy-transport.workspace = true
 mockall.workspace = true
 rundler-provider = { workspace = true, features = ["test-utils"] }
 rundler-sim = { workspace = true, features = ["test-utils"] }

--- a/crates/builder/src/assigner.rs
+++ b/crates/builder/src/assigner.rs
@@ -251,21 +251,29 @@ impl Assigner {
         // suspects cannot starve normal bundles; once normal work is
         // exhausted, any idle builder may drain suspects. Recomputed on every
         // assignment.
+        let isolation_limit = if candidates.is_empty() {
+            self.num_signers
+        } else {
+            (self.num_signers / 2).max(1)
+        };
+        self.metrics.isolation_limit.set(isolation_limit as f64);
+
         if !suspect_candidates.is_empty() {
-            let isolation_limit = if candidates.is_empty() {
-                self.num_signers
-            } else {
-                (self.num_signers / 2).max(1)
-            };
             // Reserve the isolation slot under the same lock as the capacity
             // check: concurrent builders calling assign_work must not both
             // read a count below the limit and then both insert, exceeding
             // isolation_limit. Released below if no suspect ends up
-            // claimable, so a failed attempt doesn't waste the slot.
+            // claimable, so a failed attempt doesn't waste the slot. The
+            // gauge is refreshed inside every critical section that touches
+            // `isolating_builders` so it can't go stale between mutations.
             let reserved = {
                 let mut state = self.state.lock().unwrap();
-                state.isolating_builders.len() < isolation_limit
-                    && state.isolating_builders.insert(builder_address)
+                let reserved = state.isolating_builders.len() < isolation_limit
+                    && state.isolating_builders.insert(builder_address);
+                self.metrics
+                    .isolating_builders
+                    .set(state.isolating_builders.len() as f64);
+                reserved
             };
             if reserved {
                 match self
@@ -279,18 +287,18 @@ impl Assigner {
                 {
                     Ok(Some(assignment)) => return Ok(AssignmentResult::Assigned(assignment)),
                     Ok(None) => {
-                        self.state
-                            .lock()
-                            .unwrap()
+                        let mut state = self.state.lock().unwrap();
+                        state.isolating_builders.remove(&builder_address);
+                        self.metrics
                             .isolating_builders
-                            .remove(&builder_address);
+                            .set(state.isolating_builders.len() as f64);
                     }
                     Err(e) => {
-                        self.state
-                            .lock()
-                            .unwrap()
+                        let mut state = self.state.lock().unwrap();
+                        state.isolating_builders.remove(&builder_address);
+                        self.metrics
                             .isolating_builders
-                            .remove(&builder_address);
+                            .set(state.isolating_builders.len() as f64);
                         return Err(e);
                     }
                 }
@@ -819,6 +827,9 @@ impl Assigner {
                 state.builder_to_uo_senders.remove(&builder_address);
                 state.builder_to_pinned_proposer.remove(&builder_address);
                 state.isolating_builders.remove(&builder_address);
+                self.metrics
+                    .isolating_builders
+                    .set(state.isolating_builders.len() as f64);
             }
         }
 
@@ -845,6 +856,9 @@ impl Assigner {
             .map(ep_metrics_for_key);
         state.builder_to_pinned_proposer.remove(&builder_address);
         state.isolating_builders.remove(&builder_address);
+        self.metrics
+            .isolating_builders
+            .set(state.isolating_builders.len() as f64);
         let Some(builder_senders) = state.builder_to_uo_senders.remove(&builder_address) else {
             return;
         };
@@ -907,6 +921,10 @@ impl Assigner {
 struct GlobalMetrics {
     #[metric(describe = "the number of active builders.")]
     active_builders: Gauge,
+    #[metric(describe = "the computed isolation capacity limit for the current assignment cycle.")]
+    isolation_limit: Gauge,
+    #[metric(describe = "the number of builders currently holding an isolation assignment.")]
+    isolating_builders: Gauge,
 }
 
 #[derive(Metrics)]

--- a/crates/builder/src/assigner.rs
+++ b/crates/builder/src/assigner.rs
@@ -109,6 +109,17 @@ struct State {
     /// look like ordinary work by the time it needs replacing. Cleared
     /// wherever `builder_to_pinned_proposer`/`isolating_builders` are.
     builder_to_isolation_hash: HashMap<Address, B256>,
+    /// Monotonic counter incremented each time an entrypoint is chosen for an
+    /// isolation assignment. Tracked independently of `global_cycle` so
+    /// isolation rotation doesn't affect normal-work starvation accounting.
+    isolation_cycle: u64,
+    /// Tracks when each entrypoint was last chosen for an isolation
+    /// assignment (by `isolation_cycle`). Mirrors `entrypoint_last_selected`'s
+    /// role for normal work: without it, suspect candidates are attempted in
+    /// fixed config order every call, so an entrypoint with due suspects that
+    /// happen to be unassignable this cycle can permanently block isolation
+    /// slots from reaching suspects on other entrypoints.
+    entrypoint_last_isolated: HashMap<ProposerKey, u64>,
 }
 
 /// A candidate entrypoint for assignment, used during priority-based selection.
@@ -226,10 +237,16 @@ impl Assigner {
             .entrypoints
             .iter()
             .map(|ep| {
+                // Request a full page of due suspects, not just `num_signers`:
+                // suspects are returned best-fee-first, and later filtering
+                // (locks/fees/block height) happens after this query. Capping
+                // here at a small number risked permanently hiding a lower-fee
+                // but eligible suspect behind a handful of stuck/unassignable
+                // ones ahead of it in the truncated page.
                 self.pool.get_ops_summaries(
                     ep.address,
                     self.max_pool_ops_per_request,
-                    self.num_signers as u64,
+                    self.max_pool_ops_per_request,
                     ep.filter_id.clone(),
                 )
             })
@@ -278,6 +295,24 @@ impl Assigner {
         self.metrics.isolation_limit.set(isolation_limit as f64);
 
         if !suspect_candidates.is_empty() {
+            // Rotate entrypoint order by least-recently-isolated first (stable
+            // sort keeps never-isolated entrypoints in config order relative
+            // to each other). Without this, suspects are always tried in
+            // fixed config order, so an entrypoint that's always got enough
+            // due suspects to fill isolation capacity can starve every other
+            // entrypoint's suspects indefinitely - the same starvation
+            // problem entrypoint_last_selected already solves for normal work.
+            {
+                let state = self.state.lock().unwrap();
+                suspect_candidates.sort_by_key(|(ep, _)| {
+                    state
+                        .entrypoint_last_isolated
+                        .get(&ep.key())
+                        .copied()
+                        .unwrap_or(0)
+                });
+            }
+
             // Reserve the isolation slot under the same lock as the capacity
             // check: concurrent builders calling assign_work must not both
             // read a count below the limit and then both insert, exceeding
@@ -499,6 +534,14 @@ impl Assigner {
                     state
                         .builder_to_isolation_hash
                         .insert(builder_address, hash);
+                    // Record this entrypoint as most-recently-isolated so the
+                    // rotation in assign_work's caller moves on to other
+                    // entrypoints with due suspects next time.
+                    state.isolation_cycle += 1;
+                    let isolation_cycle = state.isolation_cycle;
+                    state
+                        .entrypoint_last_isolated
+                        .insert(ep.key(), isolation_cycle);
                 }
                 ep_metrics_for(&ep).ep_isolation_assignments.increment(1);
 
@@ -1539,6 +1582,36 @@ mod tests {
         assert!(matches!(result, AssignmentResult::NoOperations));
     }
 
+    #[tokio::test]
+    async fn test_suspect_query_requests_full_page_not_num_signers() {
+        // Suspects come back best-fee-first, and lock/fee/block-height
+        // filtering happens only after this query returns. Capping the
+        // query itself at `num_signers` could hide an eligible suspect
+        // behind a handful of unassignable ones ahead of it in the
+        // truncated page, so the query must request a full page (matching
+        // `max_ops`) instead.
+        let requested_max_suspects = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let requested_max_suspects_clone = requested_max_suspects.clone();
+        let mut mock_pool = MockPool::new();
+        mock_pool
+            .expect_get_ops_summaries()
+            .returning(move |_, _, max_suspects, _| {
+                requested_max_suspects_clone
+                    .store(max_suspects, std::sync::atomic::Ordering::SeqCst);
+                Ok(vec![])
+            });
+        // num_signers deliberately small and distinct from max_pool_ops_per_request
+        // so a regression back to `num_signers` would be caught.
+        let assigner = Assigner::new(Box::new(mock_pool), test_entrypoints(), 2, 1024, 10, 0.50);
+        let _ = assign_default(&assigner, address(0)).await;
+
+        assert_eq!(
+            requested_max_suspects.load(std::sync::atomic::Ordering::SeqCst),
+            1024,
+            "suspect query should request a full page (max_pool_ops_per_request), not num_signers"
+        );
+    }
+
     fn address(i: u64) -> Address {
         Address::from([i as u8; 20])
     }
@@ -1645,6 +1718,96 @@ mod tests {
         assert_ne!(
             r4.entry_point, first,
             "Cycle 4: should alternate to other EP"
+        );
+    }
+
+    fn mock_pool_two_eps_with_suspects(
+        ep1_ops: Vec<PoolOperation>,
+        ep1_suspects: Vec<Address>,
+        ep2_ops: Vec<PoolOperation>,
+        ep2_suspects: Vec<Address>,
+    ) -> MockPool {
+        let mut mock_pool = MockPool::new();
+        let ep1_ops_clone = ep1_ops.clone();
+        let ep2_ops_clone = ep2_ops.clone();
+        mock_pool
+            .expect_get_ops_summaries()
+            .returning(move |ep, _, _, _| {
+                let (ops, suspects) = if ep == TEST_ENTRY_POINT {
+                    (&ep1_ops_clone, &ep1_suspects)
+                } else {
+                    (&ep2_ops_clone, &ep2_suspects)
+                };
+                Ok(ops
+                    .iter()
+                    .map(|op| {
+                        let mut summary: PoolOperationSummary = op.into();
+                        summary.suspect = suspects.contains(&op.uo.sender());
+                        summary
+                    })
+                    .collect::<Vec<_>>())
+            });
+        mock_pool
+            .expect_get_ops_by_hashes()
+            .returning(move |ep, hashes| {
+                let ops = if ep == TEST_ENTRY_POINT {
+                    &ep1_ops
+                } else {
+                    &ep2_ops
+                };
+                Ok(ops
+                    .iter()
+                    .filter(|op| hashes.contains(&op.uo.hash()))
+                    .cloned()
+                    .collect::<Vec<_>>())
+            });
+        mock_pool
+    }
+
+    #[tokio::test]
+    async fn test_isolation_rotates_across_entrypoints() {
+        // EP1 has 2 due suspects (address(1), address(2)) plus a normal op
+        // (address(4)) so isolation stays capacity-limited to 1 slot
+        // (num_signers=2 -> isolation_limit = max(1, num_signers/2) = 1
+        // while normal work is eligible). EP2 has a single due suspect
+        // (address(3)) and no normal work.
+        //
+        // Before rotation tracking, suspect candidates were always tried in
+        // fixed config order [EP1, EP2]. Since EP1's suspects are always
+        // assignable once released, every single isolation slot would go to
+        // EP1 forever, and EP2's suspect would never be reached. With
+        // last-isolated rotation, isolation assignments should alternate
+        // between the two entrypoints instead.
+        let ep1_ops =
+            create_test_ops_for_entrypoint(&[address(1), address(2), address(4)], TEST_ENTRY_POINT);
+        let ep2_ops = create_test_ops_for_entrypoint(&[address(3)], TEST_ENTRY_POINT_2);
+        let mock_pool = mock_pool_two_eps_with_suspects(
+            ep1_ops,
+            vec![address(1), address(2)],
+            ep2_ops,
+            vec![address(3)],
+        );
+        let assigner = Assigner::new(Box::new(mock_pool), two_entrypoints(), 2, 1024, 1024, 0.50);
+
+        let mut entry_points = Vec::new();
+        for i in 0..4 {
+            let assignment = assign_cycle(&assigner, address(0)).await;
+            assert!(
+                assignment.is_isolation,
+                "round {i} should be an isolation assignment"
+            );
+            entry_points.push(assignment.entry_point);
+        }
+
+        assert_eq!(
+            entry_points,
+            vec![
+                TEST_ENTRY_POINT,
+                TEST_ENTRY_POINT_2,
+                TEST_ENTRY_POINT,
+                TEST_ENTRY_POINT_2,
+            ],
+            "isolation should alternate across entrypoints instead of starving EP2"
         );
     }
 

--- a/crates/builder/src/assigner.rs
+++ b/crates/builder/src/assigner.rs
@@ -16,7 +16,7 @@ use std::{
     sync::Mutex,
 };
 
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, B256, U256};
 use anyhow::bail;
 use metrics::{Counter, Gauge};
 use metrics_derive::Metrics;
@@ -102,6 +102,13 @@ struct State {
     /// Builders currently holding an isolation assignment for a suspect
     /// operation. Bounds isolation capacity while normal work is eligible.
     isolating_builders: HashSet<Address>,
+    /// The op hash a builder is isolating, if any. Tracked independently of
+    /// the pool's suspect flag: `Success` clears suspect status as soon as
+    /// the RPC accepts a transaction, well before it's mined, so a stuck
+    /// isolation transaction needing a fee-bump replacement would otherwise
+    /// look like ordinary work by the time it needs replacing. Cleared
+    /// wherever `builder_to_pinned_proposer`/`isolating_builders` are.
+    builder_to_isolation_hash: HashMap<Address, B256>,
 }
 
 /// A candidate entrypoint for assignment, used during priority-based selection.
@@ -163,9 +170,9 @@ impl Assigner {
     ) -> anyhow::Result<AssignmentResult> {
         // If builder has confirmed locks, stay pinned to the same entrypoint.
         // This skips the all-entrypoint pool queries and candidate sorting.
-        let pinned_target = {
+        let (pinned_target, isolation_hash) = {
             let state = self.state.lock().unwrap();
-            state
+            let pinned_target = state
                 .builder_to_pinned_proposer
                 .get(&builder_address)
                 .cloned()
@@ -181,9 +188,21 @@ impl Assigner {
                                     .is_some_and(|(_, ls)| *ls == LockState::Confirmed)
                             })
                         })
-                })
+                });
+            let isolation_hash = pinned_target.as_ref().and_then(|_| {
+                state
+                    .builder_to_isolation_hash
+                    .get(&builder_address)
+                    .copied()
+            });
+            (pinned_target, isolation_hash)
         };
         if let Some(pinned_proposer) = pinned_target {
+            if let Some(hash) = isolation_hash {
+                return self
+                    .assign_isolation_replacement(builder_address, hash, pinned_proposer)
+                    .await;
+            }
             return self
                 .assign_work_for_entrypoint(
                     builder_address,
@@ -477,6 +496,9 @@ impl Assigner {
                     state
                         .builder_to_pinned_proposer
                         .insert(builder_address, ep.key());
+                    state
+                        .builder_to_isolation_hash
+                        .insert(builder_address, hash);
                 }
                 ep_metrics_for(&ep).ep_isolation_assignments.increment(1);
 
@@ -577,6 +599,45 @@ impl Assigner {
             is_isolation: false,
         };
         tracing::info!("Builder Assigner: assignment: {assignment:?}");
+
+        Ok(AssignmentResult::Assigned(assignment))
+    }
+
+    /// Re-supplies the same single suspect operation for a pinned builder
+    /// that needs to replace a pending isolation bundle (e.g. a fee bump).
+    ///
+    /// `Success` clears an op's suspect flag as soon as the RPC accepts the
+    /// transaction, well before it is mined, so by the time a stuck
+    /// isolation transaction needs replacing, the pool no longer reports the
+    /// op as suspect. Falling through to `assign_work_for_entrypoint` at
+    /// that point would query ordinary (non-suspect) work: `assign_ops_internal`
+    /// could then merge other senders into a multi-op replacement bundle -
+    /// reintroducing exactly the contamination risk isolation exists to
+    /// prevent - or drop the op entirely if it now fails the fee/block
+    /// filters, leaving its pending transaction untracked. Tracking the
+    /// isolation hash independently of pool suspect state avoids both: this
+    /// always returns the original op alone, or no work if it has left the
+    /// pool.
+    async fn assign_isolation_replacement(
+        &self,
+        builder_address: Address,
+        hash: B256,
+        proposer_key: ProposerKey,
+    ) -> anyhow::Result<AssignmentResult> {
+        let Some(op) = self.pool.get_op_by_hash(hash).await? else {
+            tracing::warn!(
+                "Builder Assigner: isolation op {hash:?} for builder {builder_address:?} no longer in pool, cannot replace"
+            );
+            return Ok(AssignmentResult::NoOperations);
+        };
+
+        let assignment = WorkAssignment {
+            entry_point: proposer_key.0,
+            filter_id: proposer_key.1,
+            operations: vec![op],
+            is_isolation: true,
+        };
+        tracing::info!("Builder Assigner: isolation replacement assignment: {assignment:?}");
 
         Ok(AssignmentResult::Assigned(assignment))
     }
@@ -827,6 +888,7 @@ impl Assigner {
                 state.builder_to_uo_senders.remove(&builder_address);
                 state.builder_to_pinned_proposer.remove(&builder_address);
                 state.isolating_builders.remove(&builder_address);
+                state.builder_to_isolation_hash.remove(&builder_address);
                 self.metrics
                     .isolating_builders
                     .set(state.isolating_builders.len() as f64);
@@ -856,6 +918,7 @@ impl Assigner {
             .map(ep_metrics_for_key);
         state.builder_to_pinned_proposer.remove(&builder_address);
         state.isolating_builders.remove(&builder_address);
+        state.builder_to_isolation_hash.remove(&builder_address);
         self.metrics
             .isolating_builders
             .set(state.isolating_builders.len() as f64);
@@ -1328,6 +1391,47 @@ mod tests {
 
         let second = assign_expect_default(&assigner, address(11)).await;
         assert!(second.is_isolation);
+    }
+
+    #[tokio::test]
+    async fn test_isolation_replacement_stays_singleton_and_pinned() {
+        // 1 suspect + 2 normal ops. Once the isolation bundle is sent and its
+        // sender confirmed (simulating the RPC accepting it - which reports
+        // Success and clears the op's suspect flag in the real pool, well
+        // before it's mined), a replacement/fee-bump attempt for the same
+        // builder must keep re-supplying just the original suspect alone,
+        // not fall back to ordinary (now non-suspect-looking) multi-op work.
+        let ops = create_test_ops(&[address(1), address(2), address(3)]);
+        let suspect_op = ops
+            .iter()
+            .find(|op| op.uo.sender() == address(3))
+            .unwrap()
+            .clone();
+        let mut mock_pool = mock_pool_with_suspects(ops, vec![address(3)]);
+        mock_pool
+            .expect_get_op_by_hash()
+            .returning(move |hash| Ok((hash == suspect_op.uo.hash()).then(|| suspect_op.clone())));
+        let assigner = Assigner::new(Box::new(mock_pool), test_entrypoints(), 4, 10, 10, 0.50);
+
+        let isolation = assign_expect_default(&assigner, address(10)).await;
+        assert!(isolation.is_isolation);
+        assert_eq!(isolation.operations.len(), 1);
+        assert_eq!(isolation.operations[0].uo.sender(), address(3));
+
+        // Simulate the bundle sender confirming the isolation bundle was
+        // sent (this is what promotes the sender's lock to `Confirmed`,
+        // making the builder eligible for the pinned-replacement path).
+        assigner
+            .confirm_senders_drop_unused(address(10), &[address(3)])
+            .unwrap();
+
+        // Replacement attempt for the same builder: must stay singleton and
+        // keep targeting the original suspect, not the normal ops for
+        // address(1)/address(2) that a fresh query would otherwise offer.
+        let replacement = assign_expect_default(&assigner, address(10)).await;
+        assert!(replacement.is_isolation);
+        assert_eq!(replacement.operations.len(), 1);
+        assert_eq!(replacement.operations[0].uo.sender(), address(3));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/builder/src/assigner.rs
+++ b/crates/builder/src/assigner.rs
@@ -52,6 +52,9 @@ pub(crate) struct WorkAssignment {
     pub filter_id: Option<String>,
     /// The assigned operations
     pub operations: Vec<PoolOperation>,
+    /// Whether this is an isolation bundle for a single suspect operation.
+    /// See `docs/designs/poison-user-operations.md`.
+    pub is_isolation: bool,
 }
 
 /// Detailed result of attempting to assign work.
@@ -96,6 +99,9 @@ struct State {
     entrypoint_last_selected: HashMap<ProposerKey, u64>,
     /// Tracks which entrypoint a builder is pinned to for replacement attempts
     builder_to_pinned_proposer: HashMap<Address, ProposerKey>,
+    /// Builders currently holding an isolation assignment for a suspect
+    /// operation. Bounds isolation capacity while normal work is eligible.
+    isolating_builders: HashSet<Address>,
 }
 
 /// A candidate entrypoint for assignment, used during priority-based selection.
@@ -204,7 +210,7 @@ impl Assigner {
                 self.pool.get_ops_summaries(
                     ep.address,
                     self.max_pool_ops_per_request,
-                    0, // suspect isolation scheduling is not implemented yet
+                    self.num_signers as u64,
                     ep.filter_id.clone(),
                 )
             })
@@ -212,6 +218,7 @@ impl Assigner {
         let query_results = futures_util::future::join_all(query_futures).await;
 
         let mut candidates = Vec::new();
+        let mut suspect_candidates = Vec::new();
         let mut fee_filtered_candidate_exists = false;
         for (entrypoint_idx, (ep, result)) in self
             .entrypoints
@@ -219,7 +226,10 @@ impl Assigner {
             .zip(query_results.into_iter())
             .enumerate()
         {
-            let ops = result?;
+            let (suspects, ops): (Vec<_>, Vec<_>) = result?.into_iter().partition(|op| op.suspect);
+            if !suspects.is_empty() {
+                suspect_candidates.push((ep.clone(), suspects));
+            }
             let (assignable_count, eligible_count) =
                 self.count_ops(&ops, builder_address, max_sim_block_number, &required_fees);
             let ep_metrics = ep_metrics_for(ep);
@@ -233,6 +243,32 @@ impl Assigner {
                 });
             } else if assignable_count > 0 {
                 fee_filtered_candidate_exists = true;
+            }
+        }
+
+        // Isolation is filled before normal work: while normal work is
+        // eligible, at most `max(1, num_signers / 2)` builders isolate so
+        // suspects cannot starve normal bundles; once normal work is
+        // exhausted, any idle builder may drain suspects. Recomputed on every
+        // assignment.
+        if !suspect_candidates.is_empty() {
+            let isolation_limit = if candidates.is_empty() {
+                self.num_signers
+            } else {
+                (self.num_signers / 2).max(1)
+            };
+            let isolating_count = self.state.lock().unwrap().isolating_builders.len();
+            if isolating_count < isolation_limit
+                && let Some(assignment) = self
+                    .assign_isolation_work(
+                        builder_address,
+                        suspect_candidates,
+                        max_sim_block_number,
+                        &required_fees,
+                    )
+                    .await?
+            {
+                return Ok(AssignmentResult::Assigned(assignment));
             }
         }
 
@@ -361,10 +397,62 @@ impl Assigner {
                 entry_point: candidate.ep.address,
                 filter_id: candidate.ep.filter_id,
                 operations: assigned_ops,
+                is_isolation: false,
             }));
         }
 
         Ok(AssignmentResult::NoOperations)
+    }
+
+    /// Attempts to assign a single-operation isolation bundle for one due
+    /// suspect. Returns `None` if no suspect is claimable by this builder.
+    async fn assign_isolation_work(
+        &self,
+        builder_address: Address,
+        suspect_candidates: Vec<(EntrypointInfo, Vec<PoolOperationSummary>)>,
+        max_sim_block_number: u64,
+        required_fees: &GasFees,
+    ) -> anyhow::Result<Option<WorkAssignment>> {
+        for (ep, suspects) in suspect_candidates {
+            for suspect in suspects {
+                let hash = suspect.hash;
+                let assigned_ops = self
+                    .assign_ops_internal(
+                        builder_address,
+                        &ep,
+                        vec![suspect],
+                        max_sim_block_number,
+                        required_fees,
+                    )
+                    .await?;
+                if assigned_ops.is_empty() {
+                    continue;
+                }
+
+                tracing::info!(
+                    "Builder Assigner: isolation assignment of suspect op {hash:?} to builder {builder_address:?}"
+                );
+                {
+                    let mut state = self.state.lock().unwrap();
+                    state.isolating_builders.insert(builder_address);
+                    // Pin so revert processing can find the proposer; suspects
+                    // do not refresh starvation tracking for normal work.
+                    state
+                        .builder_to_pinned_proposer
+                        .insert(builder_address, ep.key());
+                }
+                ep_metrics_for(&ep).ep_isolation_assignments.increment(1);
+
+                return Ok(Some(WorkAssignment {
+                    entry_point: ep.address,
+                    filter_id: ep.filter_id,
+                    operations: assigned_ops,
+                    is_isolation: true,
+                }));
+            }
+        }
+
+        Ok(None)
     }
 
     /// Assigns work for a specific entrypoint configuration.
@@ -383,7 +471,10 @@ impl Assigner {
             .get_ops_summaries(
                 entry_point,
                 self.max_pool_ops_per_request,
-                0, // suspect isolation scheduling is not implemented yet
+                // Replacement attempts never start new isolation work: an
+                // in-flight accepted bundle has already cleared its ops'
+                // suspect status, so suspects are not requested here.
+                0,
                 filter_id.clone(),
             )
             .await?;
@@ -446,6 +537,7 @@ impl Assigner {
             entry_point,
             filter_id,
             operations: assigned_ops,
+            is_isolation: false,
         };
         tracing::info!("Builder Assigner: assignment: {assignment:?}");
 
@@ -697,6 +789,7 @@ impl Assigner {
                 self.metrics.active_builders.decrement(1);
                 state.builder_to_uo_senders.remove(&builder_address);
                 state.builder_to_pinned_proposer.remove(&builder_address);
+                state.isolating_builders.remove(&builder_address);
             }
         }
 
@@ -722,6 +815,7 @@ impl Assigner {
             .get(&builder_address)
             .map(ep_metrics_for_key);
         state.builder_to_pinned_proposer.remove(&builder_address);
+        state.isolating_builders.remove(&builder_address);
         let Some(builder_senders) = state.builder_to_uo_senders.remove(&builder_address) else {
             return;
         };
@@ -810,6 +904,8 @@ struct PerEntrypointMetrics {
     ep_starvation_wakeups: Counter,
     #[metric(describe = "the last-seen eligible op count for this entrypoint.")]
     ep_eligible_ops: Gauge,
+    #[metric(describe = "the total number of suspect isolation assignments from this entrypoint.")]
+    ep_isolation_assignments: Counter,
 }
 
 fn ep_metrics_for(ep: &EntrypointInfo) -> PerEntrypointMetrics {
@@ -1075,6 +1171,148 @@ mod tests {
             err.to_string().contains("lock contract broken"),
             "unexpected error: {err:#}"
         );
+    }
+
+    fn mock_pool_with_suspects(ops: Vec<PoolOperation>, suspect_senders: Vec<Address>) -> MockPool {
+        let mut mock_pool = MockPool::new();
+        let ops_cloned = ops.clone();
+        mock_pool
+            .expect_get_ops_summaries()
+            .returning(move |_, _, max_suspects, _| {
+                Ok(ops_cloned
+                    .iter()
+                    .map(|op| {
+                        let mut summary: PoolOperationSummary = op.into();
+                        summary.suspect = suspect_senders.contains(&op.uo.sender());
+                        summary
+                    })
+                    .filter(|summary| !summary.suspect || max_suspects > 0)
+                    .collect::<Vec<_>>())
+            });
+        mock_pool
+            .expect_get_ops_by_hashes()
+            .returning(move |_, hashes| {
+                Ok(ops
+                    .iter()
+                    .filter(|op| hashes.contains(&op.uo.hash()))
+                    .cloned()
+                    .collect::<Vec<_>>())
+            });
+        mock_pool
+    }
+
+    #[tokio::test]
+    async fn test_suspect_isolated_alone() {
+        // 1 suspect + 2 normal ops with 4 signers: isolation limit is 2
+        let ops = create_test_ops(&[address(1), address(2), address(3)]);
+        let mock_pool = mock_pool_with_suspects(ops, vec![address(3)]);
+        let assigner = Assigner::new(Box::new(mock_pool), test_entrypoints(), 4, 10, 10, 0.50);
+
+        // the first builder isolates the suspect
+        let isolation = assign_expect_default(&assigner, address(10)).await;
+        assert!(isolation.is_isolation);
+        assert_eq!(isolation.operations.len(), 1);
+        assert_eq!(isolation.operations[0].uo.sender(), address(3));
+
+        // the suspect is locked, so the second builder receives the normal work
+        let normal = assign_expect_default(&assigner, address(11)).await;
+        assert!(!normal.is_isolation);
+        assert_eq!(normal.operations.len(), 2);
+        assert!(
+            normal
+                .operations
+                .iter()
+                .all(|op| op.uo.sender() != address(3))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_isolation_capped_while_normal_work_eligible() {
+        // 2 suspects + 1 normal op with 2 signers: isolation limit is 1
+        let ops = create_test_ops(&[address(1), address(2), address(3)]);
+        let mock_pool = mock_pool_with_suspects(ops, vec![address(2), address(3)]);
+        let assigner = Assigner::new(Box::new(mock_pool), test_entrypoints(), 2, 10, 10, 0.50);
+
+        let first = assign_expect_default(&assigner, address(10)).await;
+        assert!(first.is_isolation);
+
+        // isolation capacity is used up: the second builder gets normal work
+        // even though a second suspect is due
+        let second = assign_expect_default(&assigner, address(11)).await;
+        assert!(!second.is_isolation);
+        assert_eq!(second.operations.len(), 1);
+        assert_eq!(second.operations[0].uo.sender(), address(1));
+    }
+
+    #[tokio::test]
+    async fn test_isolation_expands_when_no_normal_work() {
+        // only suspects with 2 signers: every builder may isolate
+        let ops = create_test_ops(&[address(1), address(2)]);
+        let mock_pool = mock_pool_with_suspects(ops, vec![address(1), address(2)]);
+        let assigner = Assigner::new(Box::new(mock_pool), test_entrypoints(), 2, 10, 10, 0.50);
+
+        let first = assign_expect_default(&assigner, address(10)).await;
+        assert!(first.is_isolation);
+        assert_eq!(first.operations.len(), 1);
+
+        let second = assign_expect_default(&assigner, address(11)).await;
+        assert!(second.is_isolation);
+        assert_eq!(second.operations.len(), 1);
+        assert_ne!(
+            first.operations[0].uo.sender(),
+            second.operations[0].uo.sender()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_isolation_slot_freed_after_release() {
+        let ops = create_test_ops(&[address(1), address(2), address(3)]);
+        let mock_pool = mock_pool_with_suspects(ops, vec![address(2), address(3)]);
+        let assigner = Assigner::new(Box::new(mock_pool), test_entrypoints(), 2, 10, 10, 0.50);
+
+        let first = assign_expect_default(&assigner, address(10)).await;
+        assert!(first.is_isolation);
+
+        // the isolation limit is recomputed per assignment: releasing the
+        // isolating builder frees its slot for the next assignment
+        assigner.release_all(address(10));
+
+        let second = assign_expect_default(&assigner, address(11)).await;
+        assert!(second.is_isolation);
+    }
+
+    #[tokio::test]
+    async fn test_locked_suspect_not_reassigned() {
+        let ops = create_test_ops(&[address(1)]);
+        let mock_pool = mock_pool_with_suspects(ops, vec![address(1)]);
+        let assigner = Assigner::new(Box::new(mock_pool), test_entrypoints(), 4, 10, 10, 0.50);
+
+        let first = assign_expect_default(&assigner, address(10)).await;
+        assert!(first.is_isolation);
+
+        let second = assign_default(&assigner, address(11)).await;
+        assert!(matches!(second, AssignmentResult::NoOperations));
+    }
+
+    #[tokio::test]
+    async fn test_suspect_respects_fee_filter() {
+        // the suspect op has zero fees and doesn't meet the fee requirement
+        let ops = create_test_ops(&[address(1)]);
+        let mock_pool = mock_pool_with_suspects(ops, vec![address(1)]);
+        let assigner = Assigner::new(Box::new(mock_pool), test_entrypoints(), 4, 10, 10, 0.50);
+
+        let result = assigner
+            .assign_work(
+                address(10),
+                u64::MAX,
+                GasFees {
+                    max_fee_per_gas: 1,
+                    max_priority_fee_per_gas: 1,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(matches!(result, AssignmentResult::NoOperations));
     }
 
     fn address(i: u64) -> Address {

--- a/crates/builder/src/assigner.rs
+++ b/crates/builder/src/assigner.rs
@@ -257,18 +257,43 @@ impl Assigner {
             } else {
                 (self.num_signers / 2).max(1)
             };
-            let isolating_count = self.state.lock().unwrap().isolating_builders.len();
-            if isolating_count < isolation_limit
-                && let Some(assignment) = self
+            // Reserve the isolation slot under the same lock as the capacity
+            // check: concurrent builders calling assign_work must not both
+            // read a count below the limit and then both insert, exceeding
+            // isolation_limit. Released below if no suspect ends up
+            // claimable, so a failed attempt doesn't waste the slot.
+            let reserved = {
+                let mut state = self.state.lock().unwrap();
+                state.isolating_builders.len() < isolation_limit
+                    && state.isolating_builders.insert(builder_address)
+            };
+            if reserved {
+                match self
                     .assign_isolation_work(
                         builder_address,
                         suspect_candidates,
                         max_sim_block_number,
                         &required_fees,
                     )
-                    .await?
-            {
-                return Ok(AssignmentResult::Assigned(assignment));
+                    .await
+                {
+                    Ok(Some(assignment)) => return Ok(AssignmentResult::Assigned(assignment)),
+                    Ok(None) => {
+                        self.state
+                            .lock()
+                            .unwrap()
+                            .isolating_builders
+                            .remove(&builder_address);
+                    }
+                    Err(e) => {
+                        self.state
+                            .lock()
+                            .unwrap()
+                            .isolating_builders
+                            .remove(&builder_address);
+                        return Err(e);
+                    }
+                }
             }
         }
 
@@ -406,6 +431,10 @@ impl Assigner {
 
     /// Attempts to assign a single-operation isolation bundle for one due
     /// suspect. Returns `None` if no suspect is claimable by this builder.
+    ///
+    /// The caller must have already reserved `builder_address`'s isolation
+    /// slot in `isolating_builders` before calling this, and releases it if
+    /// `None` or an error is returned.
     async fn assign_isolation_work(
         &self,
         builder_address: Address,
@@ -434,7 +463,7 @@ impl Assigner {
                 );
                 {
                     let mut state = self.state.lock().unwrap();
-                    state.isolating_builders.insert(builder_address);
+                    // isolating_builders was already reserved by the caller.
                     // Pin so revert processing can find the proposer; suspects
                     // do not refresh starvation tracking for normal work.
                     state
@@ -925,6 +954,8 @@ fn ep_metrics_for_key(key: &ProposerKey) -> PerEntrypointMetrics {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use alloy_primitives::B256;
     use rundler_types::{
         EntityInfos, UserOperation, UserOperationPermissions, ValidTimeRange,
@@ -1279,6 +1310,77 @@ mod tests {
 
         let second = assign_expect_default(&assigner, address(11)).await;
         assert!(second.is_isolation);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_isolation_reservation_atomic_under_concurrency() {
+        // 2 suspects + 1 normal op with 2 signers: isolation limit is 1.
+        // Two builders race to isolate concurrently; the capacity check and
+        // the isolating_builders reservation must happen under the same lock
+        // so at most 1 can claim the single slot, even when both requests
+        // are genuinely running in parallel (not just interleaved awaits).
+        let ops = create_test_ops(&[address(1), address(2), address(3)]);
+        let suspect_senders = [address(2), address(3)];
+        let ops_for_summaries = ops.clone();
+        let mut mock_pool = MockPool::new();
+        mock_pool
+            .expect_get_ops_summaries()
+            .returning(move |_, _, max_suspects, _| {
+                Ok(ops_for_summaries
+                    .iter()
+                    .map(|op| {
+                        let mut summary: PoolOperationSummary = op.into();
+                        summary.suspect = suspect_senders.contains(&op.uo.sender());
+                        summary
+                    })
+                    .filter(|summary| !summary.suspect || max_suspects > 0)
+                    .collect::<Vec<_>>())
+            });
+        let ops_for_hashes = ops.clone();
+        mock_pool
+            .expect_get_ops_by_hashes()
+            .returning(move |_, hashes| {
+                // Widen the race window so both concurrent callers are
+                // inside assign_isolation_work at the same time.
+                std::thread::sleep(std::time::Duration::from_millis(20));
+                Ok(ops_for_hashes
+                    .iter()
+                    .filter(|op| hashes.contains(&op.uo.hash()))
+                    .cloned()
+                    .collect::<Vec<_>>())
+            });
+
+        let assigner = Arc::new(Assigner::new(
+            Box::new(mock_pool),
+            test_entrypoints(),
+            2,
+            10,
+            10,
+            0.50,
+        ));
+
+        let a1 = assigner.clone();
+        let a2 = assigner.clone();
+        let h1 = tokio::spawn(async move {
+            a1.assign_work(address(10), u64::MAX, GasFees::default())
+                .await
+        });
+        let h2 = tokio::spawn(async move {
+            a2.assign_work(address(11), u64::MAX, GasFees::default())
+                .await
+        });
+
+        let r1 = h1.await.unwrap().unwrap();
+        let r2 = h2.await.unwrap().unwrap();
+
+        let isolating_count = [&r1, &r2]
+            .into_iter()
+            .filter(|r| matches!(r, AssignmentResult::Assigned(a) if a.is_isolation))
+            .count();
+        assert_eq!(
+            isolating_count, 1,
+            "exactly one concurrent request should claim the single isolation slot"
+        );
     }
 
     #[tokio::test]

--- a/crates/builder/src/assigner.rs
+++ b/crates/builder/src/assigner.rs
@@ -204,6 +204,7 @@ impl Assigner {
                 self.pool.get_ops_summaries(
                     ep.address,
                     self.max_pool_ops_per_request,
+                    0, // suspect isolation scheduling is not implemented yet
                     ep.filter_id.clone(),
                 )
             })
@@ -382,6 +383,7 @@ impl Assigner {
             .get_ops_summaries(
                 entry_point,
                 self.max_pool_ops_per_request,
+                0, // suspect isolation scheduling is not implemented yet
                 filter_id.clone(),
             )
             .await?;
@@ -847,7 +849,7 @@ mod tests {
         let ops_cloned = ops.clone();
         mock_pool
             .expect_get_ops_summaries()
-            .returning(move |_, _, _| {
+            .returning(move |_, _, _, _| {
                 Ok(ops_cloned.iter().map(|op| op.into()).collect::<Vec<_>>())
             });
         mock_pool
@@ -867,7 +869,7 @@ mod tests {
         let ep2_ops_clone = ep2_ops.clone();
         mock_pool
             .expect_get_ops_summaries()
-            .returning(move |ep, _, _| {
+            .returning(move |ep, _, _, _| {
                 if ep == TEST_ENTRY_POINT {
                     Ok(ep1_ops_clone.iter().map(|op| op.into()).collect())
                 } else {
@@ -1252,7 +1254,7 @@ mod tests {
         let ep2_ops_clone = ep2_ops.clone();
         mock_pool
             .expect_get_ops_summaries()
-            .returning(move |ep, _, _| {
+            .returning(move |ep, _, _, _| {
                 if ep == TEST_ENTRY_POINT {
                     Ok(ep1_ops_clone.iter().map(|op| op.into()).collect())
                 } else {
@@ -1317,7 +1319,7 @@ mod tests {
         let all_ops_for_summaries = all_ops.clone();
         mock_pool
             .expect_get_ops_summaries()
-            .returning(move |_, _, _| {
+            .returning(move |_, _, _, _| {
                 Ok(all_ops_for_summaries
                     .iter()
                     .map(|op| op.into())
@@ -1416,7 +1418,7 @@ mod tests {
 
         mock_pool
             .expect_get_ops_summaries()
-            .returning(move |ep, _, _| {
+            .returning(move |ep, _, _, _| {
                 let count = call_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 if count < 2 {
                     // First call (assign_work queries both EPs): return ops
@@ -1504,7 +1506,7 @@ mod tests {
         let mut mock_pool = MockPool::new();
         mock_pool
             .expect_get_ops_summaries()
-            .returning(move |_, _, _| {
+            .returning(move |_, _, _, _| {
                 Ok(low_fee_ops.iter().map(|op| op.into()).collect::<Vec<_>>())
             });
 

--- a/crates/builder/src/bundle_proposer.rs
+++ b/crates/builder/src/bundle_proposer.rs
@@ -129,6 +129,40 @@ impl BundleData {
     }
 }
 
+/// Result of processing a reverted bundle transaction, per the failure flow in
+/// `docs/designs/poison-user-operations.md`.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct RevertOutcome {
+    /// Op hashes to remove from the pool.
+    pub(crate) to_remove: Vec<B256>,
+    /// Op hashes to mark suspect in the pool.
+    pub(crate) to_mark_suspect: Vec<B256>,
+}
+
+impl RevertOutcome {
+    /// Outcome that removes the given operations.
+    fn remove(to_remove: Vec<B256>) -> Self {
+        Self {
+            to_remove,
+            ..Self::default()
+        }
+    }
+
+    /// Outcome for a revert attributable to no single operation: a sole
+    /// operation is removed, while every operation of a larger bundle is
+    /// marked suspect.
+    fn unattributed(hashes: Vec<B256>) -> Self {
+        if hashes.len() > 1 {
+            Self {
+                to_mark_suspect: hashes,
+                ..Self::default()
+            }
+        } else {
+            Self::remove(hashes)
+        }
+    }
+}
+
 /// Request parameters for building a bundle.
 #[derive(Debug)]
 pub(crate) struct BundleProposalRequest {
@@ -164,9 +198,10 @@ pub(crate) trait BundleProposerT: Send + Sync {
     async fn make_bundle(&self, request: BundleProposalRequest)
     -> BundleProposerResult<BundleData>;
 
-    /// Process a reverted bundle transaction and return op hashes to remove from pool.
+    /// Process a reverted bundle transaction and return op hashes to remove from
+    /// pool or mark suspect.
     /// Fetches the trace and transaction internally, then decodes and processes the revert.
-    async fn process_revert(&self, tx_hash: B256) -> anyhow::Result<Vec<B256>>;
+    async fn process_revert(&self, tx_hash: B256) -> anyhow::Result<RevertOutcome>;
 }
 
 pub(crate) struct BundleProposerImpl<EP, BP> {
@@ -402,7 +437,7 @@ where
         })
     }
 
-    async fn process_revert(&self, tx_hash: B256) -> anyhow::Result<Vec<B256>> {
+    async fn process_revert(&self, tx_hash: B256) -> anyhow::Result<RevertOutcome> {
         let address = *self.ep_providers.entry_point().address();
         let chain_spec = &self.settings.chain_spec;
 
@@ -452,19 +487,22 @@ where
                 }
             };
 
+        let all_op_hashes: Vec<B256> = ops
+            .iter()
+            .flat_map(|ops| ops.user_ops.iter().map(|op| op.hash()))
+            .collect();
+
         let Some(revert_data) = revert_data else {
-            // No revert data - remove all ops
-            return Ok(ops
-                .iter()
-                .flat_map(|ops| ops.user_ops.iter().map(|op| op.hash()))
-                .collect());
+            // No revert data attributes the revert to no single op
+            warn!("no revert data for reverted bundle, treating as unattributed");
+            return Ok(RevertOutcome::unattributed(all_op_hashes));
         };
 
         // If we have a submission proxy, use it to process the revert first
         if let Some(proxy) = &self.settings.submission_proxy {
             let to_remove = proxy.process_revert(revert_data, &ops).await;
             if !to_remove.is_empty() {
-                return Ok(to_remove);
+                return Ok(RevertOutcome::remove(to_remove));
             }
         }
 
@@ -486,29 +524,31 @@ where
             }
             Some(HandleOpsOut::FailedOp(index, _)) => {
                 warn!("removing op from pool for reverted bundle op index {index:?}");
-                Ok(ops
-                    .iter()
-                    .flat_map(|ops| ops.user_ops.iter())
-                    .nth(index)
-                    .map(|op| vec![op.hash()])
-                    .unwrap_or_default())
+                Ok(RevertOutcome::remove(
+                    ops.iter()
+                        .flat_map(|ops| ops.user_ops.iter())
+                        .nth(index)
+                        .map(|op| vec![op.hash()])
+                        .unwrap_or_default(),
+                ))
             }
             Some(HandleOpsOut::SignatureValidationFailed(aggregator)) => {
                 warn!(
                     "removing all ops from pool for reverted bundle for aggregator {aggregator:?}"
                 );
-                Ok(ops
-                    .iter()
-                    .find(|op| op.aggregator == aggregator)
-                    .map(|ops| ops.user_ops.iter().map(|op| op.hash()).collect())
-                    .unwrap_or_default())
+                Ok(RevertOutcome::remove(
+                    ops.iter()
+                        .find(|op| op.aggregator == aggregator)
+                        .map(|ops| ops.user_ops.iter().map(|op| op.hash()).collect())
+                        .unwrap_or_default(),
+                ))
             }
             None | Some(HandleOpsOut::Revert(_)) | Some(HandleOpsOut::PostOpRevert) => {
-                warn!("removing all ops from pool for reverted bundle");
-                Ok(ops
-                    .iter()
-                    .flat_map(|ops| ops.user_ops.iter().map(|op| op.hash()))
-                    .collect())
+                warn!(
+                    "unattributed revert for bundle of {} ops",
+                    all_op_hashes.len()
+                );
+                Ok(RevertOutcome::unattributed(all_op_hashes))
             }
         }
     }
@@ -4904,5 +4944,37 @@ mod tests {
         agg.expect_aggregate_signatures()
             .returning(move |_| Ok(signature.clone()));
         agg
+    }
+
+    #[test]
+    fn test_unattributed_revert_of_sole_op_removes() {
+        let hash = B256::repeat_byte(1);
+        assert_eq!(
+            RevertOutcome::unattributed(vec![hash]),
+            RevertOutcome {
+                to_remove: vec![hash],
+                to_mark_suspect: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_unattributed_revert_of_multiple_ops_marks_suspect() {
+        let hashes = vec![B256::repeat_byte(1), B256::repeat_byte(2)];
+        assert_eq!(
+            RevertOutcome::unattributed(hashes.clone()),
+            RevertOutcome {
+                to_remove: vec![],
+                to_mark_suspect: hashes,
+            }
+        );
+    }
+
+    #[test]
+    fn test_unattributed_revert_of_no_ops_is_empty() {
+        assert_eq!(
+            RevertOutcome::unattributed(vec![]),
+            RevertOutcome::default()
+        );
     }
 }

--- a/crates/builder/src/bundle_proposer.rs
+++ b/crates/builder/src/bundle_proposer.rs
@@ -65,6 +65,7 @@ pub(crate) struct Bundle<UO: UserOperation> {
     pub(crate) gas_fees: GasFees,
     pub(crate) expected_storage: ExpectedStorage,
     pub(crate) rejected_ops: Vec<UO>,
+    pub(crate) suspect_ops: Vec<UO>,
     pub(crate) entity_updates: Vec<EntityUpdate>,
 }
 
@@ -76,6 +77,7 @@ impl<UO: UserOperation> Default for Bundle<UO> {
             gas_fees: GasFees::default(),
             expected_storage: ExpectedStorage::default(),
             rejected_ops: Vec::new(),
+            suspect_ops: Vec::new(),
             entity_updates: Vec::new(),
         }
     }
@@ -118,6 +120,9 @@ pub(crate) struct BundleData {
     pub(crate) ops: Vec<(Address, B256)>,
     /// Hashes of rejected operations to remove from pool
     pub(crate) rejected_op_hashes: Vec<B256>,
+    /// Hashes of operations to mark suspect in the pool (ambiguous multi-op
+    /// revert - avoids evicting ops that may be innocent)
+    pub(crate) suspect_op_hashes: Vec<B256>,
     /// Entity updates to apply to pool
     pub(crate) entity_updates: Vec<EntityUpdate>,
 }
@@ -372,6 +377,7 @@ where
                     gas_fees: bundle_fees,
                     expected_storage: context.bundle_expected_storage.inner,
                     rejected_ops: context.rejected_ops.iter().map(|po| po.0.clone()).collect(),
+                    suspect_ops: context.suspect_ops.iter().map(|po| po.0.clone()).collect(),
                     entity_updates: context.entity_updates.into_values().collect(),
                 });
             }
@@ -382,6 +388,7 @@ where
 
         Ok(Bundle {
             rejected_ops: context.rejected_ops.iter().map(|po| po.0.clone()).collect(),
+            suspect_ops: context.suspect_ops.iter().map(|po| po.0.clone()).collect(),
             entity_updates: context.entity_updates.into_values().collect(),
             gas_fees: bundle_fees,
             ..Default::default()
@@ -411,6 +418,7 @@ where
             .map(|op| (op.sender(), op.hash()))
             .collect();
         let rejected_op_hashes: Vec<_> = bundle.rejected_ops.iter().map(|op| op.hash()).collect();
+        let suspect_op_hashes: Vec<_> = bundle.suspect_ops.iter().map(|op| op.hash()).collect();
 
         // Build the transaction if bundle is not empty
         let tx = if bundle.is_empty() {
@@ -433,6 +441,7 @@ where
             gas_fees: bundle.gas_fees,
             ops,
             rejected_op_hashes,
+            suspect_op_hashes,
             entity_updates: bundle.entity_updates,
         })
     }
@@ -1135,8 +1144,18 @@ where
         None
     }
 
-    async fn reject_bundle(&self, context: &mut ProposalContext<EP::UO>) {
-        context.reject_all();
+    // If there's a single op in the bundle, an unattributed revert leaves no
+    // ambiguity about who's responsible - reject and remove it directly. With
+    // multiple ops, removing all of them would permanently evict innocent
+    // ops that happened to share the bundle; mark them all suspect instead,
+    // mirroring RevertOutcome::unattributed's split for the post-submission
+    // on-chain revert path.
+    async fn reject_or_mark_suspect_bundle(&self, context: &mut ProposalContext<EP::UO>) {
+        if context.iter_ops().count() > 1 {
+            context.mark_all_suspect();
+        } else {
+            context.reject_all();
+        }
     }
 
     async fn reject_hash(&self, context: &mut ProposalContext<EP::UO>, hash: B256) -> bool {
@@ -1294,15 +1313,15 @@ where
 
                     if !removed {
                         warn!(
-                            "HandleOps reverted during gas estimation, proxy {proxy:?} returned no hashes to remove. Rejecting full bundle. revert data: {revert_data:?}"
+                            "HandleOps reverted during gas estimation, proxy {proxy:?} returned no hashes to remove. Rejecting/marking suspect the full bundle. revert data: {revert_data:?}"
                         );
-                        self.reject_bundle(context).await;
+                        self.reject_or_mark_suspect_bundle(context).await;
                     }
                 } else {
                     warn!(
-                        "HandleOps reverted during gas estimation. Rejecting full bundle. revert data: {revert_data:?}"
+                        "HandleOps reverted during gas estimation. Rejecting/marking suspect the full bundle. revert data: {revert_data:?}"
                     );
-                    self.reject_bundle(context).await;
+                    self.reject_or_mark_suspect_bundle(context).await;
                 }
 
                 Ok(None)
@@ -1721,6 +1740,7 @@ struct ProposalContext<UO> {
     sender_eoa: Address,
     groups_by_aggregator: LinkedHashMap<Address, AggregatorGroup<UO>>,
     rejected_ops: Vec<(UO, EntityInfos)>,
+    suspect_ops: Vec<(UO, EntityInfos)>,
     // This is a BTreeMap so that the conversion to a Vec<EntityUpdate> is deterministic, mainly for tests
     entity_updates: BTreeMap<Address, EntityUpdate>,
     bundle_expected_storage: BundleExpectedStorage,
@@ -1747,6 +1767,7 @@ impl<UO: UserOperation> ProposalContext<UO> {
             sender_eoa,
             groups_by_aggregator: LinkedHashMap::<Address, AggregatorGroup<UO>>::new(),
             rejected_ops: Vec::<(UO, EntityInfos)>::new(),
+            suspect_ops: Vec::<(UO, EntityInfos)>::new(),
             entity_updates: BTreeMap::new(),
             bundle_expected_storage: BundleExpectedStorage::default(),
         }
@@ -1794,6 +1815,12 @@ impl<UO: UserOperation> ProposalContext<UO> {
         }
     }
 
+    fn mark_all_suspect(&mut self) {
+        for _ in 0..self.iter_ops_with_simulations().count() {
+            let _ = self.mark_suspect_index(0);
+        }
+    }
+
     /// Returns the address of the op's aggregator if the aggregator's signature
     /// may need to be recomputed.
     #[must_use = "rejected op but did not update aggregator signatures"]
@@ -1818,6 +1845,39 @@ impl<UO: UserOperation> ProposalContext<UO> {
         };
         // If we just removed the last op from a group, delete that group.
         // Otherwise, the signature is invalidated and we need to recompute it.
+        if self.groups_by_aggregator[&found_aggregator]
+            .ops_with_simulations
+            .is_empty()
+        {
+            self.groups_by_aggregator.remove(&found_aggregator);
+            None
+        } else {
+            Some(found_aggregator)
+        }
+    }
+
+    /// Same as `reject_index`, but marks the op suspect instead of rejecting
+    /// it outright.
+    #[must_use = "marked op suspect but did not update aggregator signatures"]
+    fn mark_suspect_index(&mut self, i: usize) -> Option<Address> {
+        let mut remaining_i = i;
+        let mut found_aggregator: Option<Address> = None;
+        for (&aggregator, group) in &mut self.groups_by_aggregator {
+            if remaining_i < group.ops_with_simulations.len() {
+                let suspect = group.ops_with_simulations.remove(remaining_i);
+                self.mark_op_suspect(suspect);
+                found_aggregator = Some(aggregator);
+                break;
+            }
+            remaining_i -= group.ops_with_simulations.len();
+        }
+        let Some(found_aggregator) = found_aggregator else {
+            error!(
+                "The entry point indicated a failed op at index {i}, but the bundle size is only {}",
+                i - remaining_i
+            );
+            return None;
+        };
         if self.groups_by_aggregator[&found_aggregator]
             .ops_with_simulations
             .is_empty()
@@ -1927,6 +1987,15 @@ impl<UO: UserOperation> ProposalContext<UO> {
         // remove associated storage slots
         self.bundle_expected_storage
             .remove(&rejected.simulation.expected_storage);
+    }
+
+    fn mark_op_suspect(&mut self, suspect: OpWithSimulation<UO>) {
+        self.suspect_ops
+            .push((suspect.op, suspect.simulation.entity_infos));
+
+        // remove associated storage slots
+        self.bundle_expected_storage
+            .remove(&suspect.simulation.expected_storage);
     }
 
     fn to_ops_per_aggregator(&self) -> Vec<UserOpsPerAggregator<UO>> {
@@ -3319,6 +3388,7 @@ mod tests {
             sender_eoa: Address::ZERO,
             groups_by_aggregator,
             rejected_ops: vec![],
+            suspect_ops: vec![],
             entity_updates: BTreeMap::new(),
             bundle_expected_storage: BundleExpectedStorage::default(),
         };
@@ -3368,6 +3438,7 @@ mod tests {
             sender_eoa: Address::ZERO,
             groups_by_aggregator,
             rejected_ops: vec![],
+            suspect_ops: vec![],
             entity_updates: BTreeMap::new(),
             bundle_expected_storage: BundleExpectedStorage::default(),
         };
@@ -3429,6 +3500,7 @@ mod tests {
             sender_eoa: Address::ZERO,
             groups_by_aggregator,
             rejected_ops: vec![],
+            suspect_ops: vec![],
             entity_updates: BTreeMap::new(),
             bundle_expected_storage: BundleExpectedStorage::default(),
         };
@@ -3491,6 +3563,7 @@ mod tests {
             sender_eoa: Address::ZERO,
             groups_by_aggregator: groups_without_authorization,
             rejected_ops: vec![],
+            suspect_ops: vec![],
             entity_updates: BTreeMap::new(),
             bundle_expected_storage: BundleExpectedStorage::default(),
         };
@@ -3511,6 +3584,7 @@ mod tests {
             sender_eoa: Address::ZERO,
             groups_by_aggregator: groups_with_authorization,
             rejected_ops: vec![],
+            suspect_ops: vec![],
             entity_updates: BTreeMap::new(),
             bundle_expected_storage: BundleExpectedStorage::default(),
         };
@@ -3920,6 +3994,76 @@ mod tests {
         .await;
 
         assert_eq!(bundle.ops_per_aggregator, vec![]);
+    }
+
+    #[tokio::test]
+    async fn test_ambiguous_revert_single_op_removed() {
+        let op = op_with_sender(address(1));
+
+        let bundle = mock_make_bundle(
+            vec![MockOp {
+                op: op.clone(),
+                simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                perms: UserOperationPermissions::default(),
+            }],
+            vec![],
+            vec![HandleOpsOut::Revert(bytes(1))],
+            vec![],
+            0,
+            0,
+            false,
+            ExpectedStorage::default(),
+            false,
+            vec![],
+            None,
+            U256::MAX,
+            None,
+        )
+        .await;
+
+        assert_eq!(bundle.ops_per_aggregator, vec![]);
+        assert_eq!(bundle.rejected_ops, vec![op]);
+        assert_eq!(bundle.suspect_ops, vec![]);
+    }
+
+    #[tokio::test]
+    async fn test_ambiguous_revert_multi_op_marks_suspect() {
+        let op0 = op_with_sender(address(1));
+        let op1 = op_with_sender(address(2));
+
+        let bundle = mock_make_bundle(
+            vec![
+                MockOp {
+                    op: op0.clone(),
+                    simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    perms: UserOperationPermissions::default(),
+                },
+                MockOp {
+                    op: op1.clone(),
+                    simulation_result: Box::new(|| Ok(SimulationResult::default())),
+                    perms: UserOperationPermissions::default(),
+                },
+            ],
+            vec![],
+            vec![HandleOpsOut::Revert(bytes(1))],
+            vec![],
+            0,
+            0,
+            false,
+            ExpectedStorage::default(),
+            false,
+            vec![],
+            None,
+            U256::MAX,
+            None,
+        )
+        .await;
+
+        assert_eq!(bundle.ops_per_aggregator, vec![]);
+        assert_eq!(bundle.rejected_ops, vec![]);
+        assert_eq!(bundle.suspect_ops.len(), 2);
+        assert!(bundle.suspect_ops.contains(&op0));
+        assert!(bundle.suspect_ops.contains(&op1));
     }
 
     #[tokio::test]

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -1683,7 +1683,7 @@ mod tests {
         mock_pool
             .expect_get_ops_summaries()
             .times(1)
-            .returning(|_, _, _| {
+            .returning(|_, _, _, _| {
                 Ok(vec![pool_op_summary(
                     ENTRY_POINT_ADDRESS_V0_6,
                     Address::ZERO,
@@ -1731,7 +1731,7 @@ mod tests {
         mock_pool
             .expect_get_ops_summaries()
             .times(1)
-            .returning(|_, _, _| {
+            .returning(|_, _, _, _| {
                 Ok(vec![pool_op_summary(
                     ENTRY_POINT_ADDRESS_V0_6,
                     Address::ZERO,
@@ -1804,15 +1804,17 @@ mod tests {
         // The other EP is never queried since the builder is pinned.
         mock_pool
             .expect_get_ops_summaries()
-            .withf(move |entry_point, _, filter| {
+            .withf(move |entry_point, _, _, filter| {
                 *entry_point == pinned_entry_point
                     && filter.as_deref() == expected_filter.as_deref()
             })
             .times(1)
-            .returning(move |_, _, _| Ok(vec![pool_op_summary(pinned_entry_point, Address::ZERO)]));
+            .returning(move |_, _, _, _| {
+                Ok(vec![pool_op_summary(pinned_entry_point, Address::ZERO)])
+            });
         mock_pool
             .expect_get_ops_summaries()
-            .withf(move |entry_point, _, _| *entry_point == other_entry_point)
+            .withf(move |entry_point, _, _, _| *entry_point == other_entry_point)
             .times(0);
 
         mock_pool
@@ -1883,19 +1885,21 @@ mod tests {
         // along with the other EP.
         mock_pool
             .expect_get_ops_summaries()
-            .withf(move |entry_point, _, filter| {
+            .withf(move |entry_point, _, _, filter| {
                 *entry_point == pinned_entry_point
                     && filter.as_deref() == expected_filter.as_deref()
             })
             .times(2)
-            .returning(move |_, _, _| Ok(vec![pool_op_summary(pinned_entry_point, Address::ZERO)]));
+            .returning(move |_, _, _, _| {
+                Ok(vec![pool_op_summary(pinned_entry_point, Address::ZERO)])
+            });
         mock_pool
             .expect_get_ops_summaries()
-            .withf(move |entry_point, _, filter| {
+            .withf(move |entry_point, _, _, filter| {
                 *entry_point == other_entry_point && filter.is_none()
             })
             .times(1)
-            .returning(move |_, _, _| {
+            .returning(move |_, _, _, _| {
                 Ok(vec![PoolOperationSummary {
                     hash: B256::from([1; 32]),
                     ..pool_op_summary(other_entry_point, Address::from([1; 20]))
@@ -2123,7 +2127,7 @@ mod tests {
         mock_pool
             .expect_get_ops_summaries()
             .times(1)
-            .returning(|_, _, _| {
+            .returning(|_, _, _, _| {
                 Ok(vec![PoolOperationSummary {
                     max_fee_per_gas: 10,
                     max_priority_fee_per_gas: 2,
@@ -2276,7 +2280,7 @@ mod tests {
         mock_pool
             .expect_get_ops_summaries()
             .times(2)
-            .returning(|_, _, _| {
+            .returning(|_, _, _, _| {
                 Ok(vec![pool_op_summary(
                     ENTRY_POINT_ADDRESS_V0_6,
                     Address::from([9; 20]),
@@ -2341,7 +2345,9 @@ mod tests {
         mock_pool
             .expect_get_ops_summaries()
             .times(3)
-            .returning(move |_, _, _| Ok(vec![pool_op_summary(ENTRY_POINT_ADDRESS_V0_6, sender)]));
+            .returning(move |_, _, _, _| {
+                Ok(vec![pool_op_summary(ENTRY_POINT_ADDRESS_V0_6, sender)])
+            });
         mock_pool
             .expect_get_ops_by_hashes()
             .times(1)
@@ -2420,7 +2426,9 @@ mod tests {
 
         mock_pool
             .expect_get_ops_summaries()
-            .returning(move |_, _, _| Ok(vec![pool_op_summary(ENTRY_POINT_ADDRESS_V0_6, sender)]));
+            .returning(move |_, _, _, _| {
+                Ok(vec![pool_op_summary(ENTRY_POINT_ADDRESS_V0_6, sender)])
+            });
         mock_pool
             .expect_get_ops_by_hashes()
             .returning(|_, _| Ok(vec![demo_pool_op()]));
@@ -2536,7 +2544,7 @@ mod tests {
         mock_pool
             .expect_get_ops_summaries()
             .times(1)
-            .returning(|_, _, _| {
+            .returning(|_, _, _, _| {
                 Ok(vec![pool_op_summary(
                     ENTRY_POINT_ADDRESS_V0_6,
                     Address::ZERO,
@@ -2864,6 +2872,7 @@ mod tests {
             max_priority_fee_per_gas: 0,
             gas_limit: 0,
             bundler_sponsorship_max_cost: None,
+            suspect: false,
         }
     }
 

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -43,7 +43,7 @@ use crate::{
     assigner::{Assigner, AssignmentResult},
     bundle_proposer::{BundleData, BundleProposalRequest, BundleProposerError, BundleProposerT},
     emit::{BuilderEvent, BundleTxDetails},
-    sender::{RpcOutcomeClass, TxSenderError},
+    sender::{ProviderEventSignal, RpcOutcomeClass, TxSenderError},
     transaction_tracker::{
         TrackerState, TrackerUpdate, TransactionTracker, TransactionTrackerError,
     },
@@ -81,6 +81,10 @@ pub(crate) struct BundleSenderImpl<T, C> {
     pool: C,
     settings: Settings,
     event_sender: broadcast::Sender<WithEntryPoint<BuilderEvent>>,
+    /// Provider-health signal for the submission route, shared with the other
+    /// builders on the route. Final submission outcomes are recorded here and
+    /// its state gates poison user operation evidence in the pool.
+    provider_event_signal: Arc<ProviderEventSignal>,
 }
 
 pub enum BundleSenderAction {
@@ -230,6 +234,7 @@ where
         pool: C,
         settings: Settings,
         event_sender: broadcast::Sender<WithEntryPoint<BuilderEvent>>,
+        provider_event_signal: Arc<ProviderEventSignal>,
     ) -> Self {
         Self {
             builder_tag,
@@ -244,6 +249,7 @@ where
             pool,
             settings,
             event_sender,
+            provider_event_signal,
         }
     }
 
@@ -946,6 +952,8 @@ where
             Ok(tx_hash) => {
                 let ops = Arc::new(ops);
 
+                self.provider_event_signal.record_success();
+
                 self.emit_for_entrypoint(
                     entry_point,
                     BuilderEvent::formed_bundle(
@@ -983,6 +991,8 @@ where
             }
             Err(TransactionTrackerError::Sender(error)) => {
                 match error.classify() {
+                    // Terminal errors definitively reject the transaction and
+                    // are excluded from the provider-health window.
                     RpcOutcomeClass::Terminal => {
                         self.report_bundle_outcome(
                             entry_point,
@@ -992,6 +1002,10 @@ where
                         .await;
                     }
                     RpcOutcomeClass::NonTerminal => {
+                        // Record before reporting so the report is gated by
+                        // the freshest signal state, including an event this
+                        // failure itself triggers.
+                        self.provider_event_signal.record_failure();
                         self.report_bundle_outcome(
                             entry_point,
                             uo_hashes,
@@ -1095,9 +1109,6 @@ where
 
     /// Reports the final outcome of a bundle submission attempt to the pool for
     /// poison user operation tracking. Best effort: failures are logged.
-    ///
-    /// Provider-event detection is not implemented yet, so
-    /// `provider_event_active` is always false.
     async fn report_bundle_outcome(
         &self,
         entry_point: Address,
@@ -1109,7 +1120,12 @@ where
         }
         if let Err(error) = self
             .pool
-            .report_bundle_outcome(entry_point, ops, outcome, false)
+            .report_bundle_outcome(
+                entry_point,
+                ops,
+                outcome,
+                self.provider_event_signal.is_active(),
+            )
             .await
         {
             warn!("Failed to report bundle outcome to pool: {error}");
@@ -1843,6 +1859,9 @@ mod tests {
                 ..
             })
         ));
+
+        // the accepted submission was recorded in the provider-health window
+        assert_eq!(sender.provider_event_signal.observations(), 1);
     }
 
     #[tokio::test]
@@ -2774,7 +2793,11 @@ mod tests {
         ));
     }
 
-    async fn run_send_error_reports_outcome(error: TxSenderError, outcome: BundleOutcome) {
+    async fn run_send_error_reports_outcome(
+        error: TxSenderError,
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+    ) {
         let Mocks {
             mut mock_proposer_t,
             mut mock_tracker,
@@ -2803,8 +2826,10 @@ mod tests {
             .returning(|_, _| Ok(vec![demo_pool_op()]));
         mock_pool
             .expect_report_bundle_outcome()
-            .withf(move |_, ops, reported, provider_event_active| {
-                ops == &[B256::ZERO] && *reported == outcome && !provider_event_active
+            .withf(move |_, ops, reported, event_active| {
+                ops == &[B256::ZERO]
+                    && *reported == outcome
+                    && *event_active == provider_event_active
             })
             .times(1)
             .returning(|_, _, _, _| Ok(()));
@@ -2831,8 +2856,31 @@ mod tests {
 
         let mut sender = new_sender(mock_proposer_t, mock_pool);
 
+        let observations_before = if provider_event_active {
+            // Saturate the signal's window with failures to activate an event.
+            for _ in 0..10 {
+                sender.provider_event_signal.record_failure();
+            }
+            assert!(sender.provider_event_signal.is_active());
+            10
+        } else {
+            0
+        };
+
         let update = state.wait_for_trigger().await.unwrap();
         sender.step_after_trigger(&mut state, update).await.unwrap();
+
+        // Only non-terminal failures are recorded in the provider-health
+        // window; terminal errors are excluded.
+        let expected_observations = if outcome == BundleOutcome::NonTerminalFailure {
+            observations_before + 1
+        } else {
+            observations_before
+        };
+        assert_eq!(
+            sender.provider_event_signal.observations(),
+            expected_observations
+        );
     }
 
     #[tokio::test]
@@ -2843,6 +2891,7 @@ mod tests {
                 message: "internal error".to_string(),
             },
             BundleOutcome::TerminalFailure,
+            false,
         )
         .await;
     }
@@ -2852,6 +2901,17 @@ mod tests {
         run_send_error_reports_outcome(
             TxSenderError::SenderUnavailable(anyhow::anyhow!("provider outage")),
             BundleOutcome::NonTerminalFailure,
+            false,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_non_terminal_error_during_provider_event() {
+        run_send_error_reports_outcome(
+            TxSenderError::SenderUnavailable(anyhow::anyhow!("provider outage")),
+            BundleOutcome::NonTerminalFailure,
+            true,
         )
         .await;
     }
@@ -3016,6 +3076,7 @@ mod tests {
                 max_replacement_underpriced_blocks: 3,
             },
             broadcast::channel(1000).0,
+            Arc::new(ProviderEventSignal::default()),
         )
     }
 
@@ -3049,6 +3110,7 @@ mod tests {
                 max_replacement_underpriced_blocks: 3,
             },
             broadcast::channel(1000).0,
+            Arc::new(ProviderEventSignal::default()),
         )
     }
 

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -24,7 +24,7 @@ use rundler_task::TaskSpawner;
 use rundler_types::{
     builder::BundlingMode,
     chain::ChainSpec,
-    pool::{AddressUpdate, NewHead, Pool},
+    pool::{AddressUpdate, BundleOutcome, NewHead, Pool},
 };
 use rundler_utils::{emit::WithEntryPoint, eth};
 use tokio::{
@@ -42,7 +42,7 @@ use crate::{
     assigner::{Assigner, AssignmentResult},
     bundle_proposer::{BundleData, BundleProposalRequest, BundleProposerError, BundleProposerT},
     emit::{BuilderEvent, BundleTxDetails},
-    sender::TxSenderError,
+    sender::{RpcOutcomeClass, TxSenderError},
     transaction_tracker::{
         TrackerState, TrackerUpdate, TransactionTracker, TransactionTrackerError,
     },
@@ -934,6 +934,8 @@ where
         );
         self.record_histogram_ep("builder_bundle_txn_size_bytes", entry_point, tx_size as f64);
 
+        let uo_hashes: Vec<B256> = ops.iter().map(|(_, hash)| *hash).collect();
+
         match send_result {
             Ok(tx_hash) => {
                 let ops = Arc::new(ops);
@@ -953,8 +955,10 @@ where
                     ),
                 );
 
+                self.report_bundle_outcome(entry_point, uo_hashes.clone(), BundleOutcome::Success)
+                    .await;
+
                 // Notify the pool about the pending bundle
-                let uo_hashes: Vec<B256> = ops.iter().map(|(_, hash)| *hash).collect();
                 if let Err(e) = self
                     .pool
                     .notify_pending_bundle(
@@ -971,66 +975,93 @@ where
 
                 Ok(SendBundleAttemptResult::Success(ops))
             }
-            Err(TransactionTrackerError::Sender(error)) => match error {
-                TxSenderError::NonceTooLow => {
-                    self.increment_counter_ep("builder_bundle_txn_nonce_too_low", entry_point, 1);
-                    warn!("Bundle attempt nonce too low");
-                    Ok(SendBundleAttemptResult::NonceTooLow)
+            Err(TransactionTrackerError::Sender(error)) => {
+                match error.classify() {
+                    RpcOutcomeClass::Terminal => {
+                        self.report_bundle_outcome(
+                            entry_point,
+                            uo_hashes,
+                            BundleOutcome::TerminalFailure,
+                        )
+                        .await;
+                    }
+                    RpcOutcomeClass::NonTerminal => {
+                        self.report_bundle_outcome(
+                            entry_point,
+                            uo_hashes,
+                            BundleOutcome::NonTerminalFailure,
+                        )
+                        .await;
+                    }
+                    // Neutral errors have dedicated handling below and are
+                    // evidence of neither poison nor provider health.
+                    RpcOutcomeClass::Neutral => {}
                 }
-                TxSenderError::Underpriced => {
-                    self.increment_counter_ep("builder_bundle_txn_underpriced", entry_point, 1);
-                    warn!("Bundle attempt underpriced");
-                    Ok(SendBundleAttemptResult::Underpriced)
+                match error {
+                    TxSenderError::NonceTooLow => {
+                        self.increment_counter_ep(
+                            "builder_bundle_txn_nonce_too_low",
+                            entry_point,
+                            1,
+                        );
+                        warn!("Bundle attempt nonce too low");
+                        Ok(SendBundleAttemptResult::NonceTooLow)
+                    }
+                    TxSenderError::Underpriced => {
+                        self.increment_counter_ep("builder_bundle_txn_underpriced", entry_point, 1);
+                        warn!("Bundle attempt underpriced");
+                        Ok(SendBundleAttemptResult::Underpriced)
+                    }
+                    TxSenderError::ReplacementUnderpriced => {
+                        self.increment_counter_ep(
+                            "builder_bundle_replacement_underpriced",
+                            entry_point,
+                            1,
+                        );
+                        warn!("Bundle attempt replacement transaction underpriced");
+                        Ok(SendBundleAttemptResult::ReplacementUnderpriced)
+                    }
+                    TxSenderError::ConditionNotMet => {
+                        self.increment_counter_ep(
+                            "builder_bundle_txn_condition_not_met",
+                            entry_point,
+                            1,
+                        );
+                        warn!("Bundle attempt condition not met");
+                        Ok(SendBundleAttemptResult::ConditionNotMet)
+                    }
+                    TxSenderError::Rejected => {
+                        self.increment_counter_ep("builder_bundle_txn_rejected", entry_point, 1);
+                        warn!("Bundle attempt rejected");
+                        Ok(SendBundleAttemptResult::Rejected)
+                    }
+                    TxSenderError::InsufficientFunds => {
+                        self.increment_counter_ep(
+                            "builder_bundle_txn_insufficient_funds",
+                            entry_point,
+                            1,
+                        );
+                        error!("Bundle attempt insufficient funds");
+                        Ok(SendBundleAttemptResult::InsufficientFunds)
+                    }
+                    TxSenderError::IntrinsicGasTooLow => {
+                        let tx_bytes = tx.input.input().map_or_else(
+                            || String::from("0x"),
+                            |data| format!("0x{}", hex::encode(data)),
+                        );
+                        error!("Bundle transaction intrinsic gas too low: tx_bytes={tx_bytes}");
+                        Err(anyhow::anyhow!("intrinsic gas too low"))
+                    }
+                    error @ (TxSenderError::TerminalRpcError { .. }
+                    | TxSenderError::UnrecognizedRpc { .. }
+                    | TxSenderError::SenderUnavailable(_)
+                    | TxSenderError::SoftCancelFailed
+                    | TxSenderError::Other(_)) => {
+                        error!("Failed to send bundle: {error}");
+                        Err(error.into())
+                    }
                 }
-                TxSenderError::ReplacementUnderpriced => {
-                    self.increment_counter_ep(
-                        "builder_bundle_replacement_underpriced",
-                        entry_point,
-                        1,
-                    );
-                    warn!("Bundle attempt replacement transaction underpriced");
-                    Ok(SendBundleAttemptResult::ReplacementUnderpriced)
-                }
-                TxSenderError::ConditionNotMet => {
-                    self.increment_counter_ep(
-                        "builder_bundle_txn_condition_not_met",
-                        entry_point,
-                        1,
-                    );
-                    warn!("Bundle attempt condition not met");
-                    Ok(SendBundleAttemptResult::ConditionNotMet)
-                }
-                TxSenderError::Rejected => {
-                    self.increment_counter_ep("builder_bundle_txn_rejected", entry_point, 1);
-                    warn!("Bundle attempt rejected");
-                    Ok(SendBundleAttemptResult::Rejected)
-                }
-                TxSenderError::InsufficientFunds => {
-                    self.increment_counter_ep(
-                        "builder_bundle_txn_insufficient_funds",
-                        entry_point,
-                        1,
-                    );
-                    error!("Bundle attempt insufficient funds");
-                    Ok(SendBundleAttemptResult::InsufficientFunds)
-                }
-                TxSenderError::IntrinsicGasTooLow => {
-                    let tx_bytes = tx.input.input().map_or_else(
-                        || String::from("0x"),
-                        |data| format!("0x{}", hex::encode(data)),
-                    );
-                    error!("Bundle transaction intrinsic gas too low: tx_bytes={tx_bytes}");
-                    Err(anyhow::anyhow!("intrinsic gas too low"))
-                }
-                error @ (TxSenderError::TerminalRpcError { .. }
-                | TxSenderError::UnrecognizedRpc { .. }
-                | TxSenderError::SenderUnavailable(_)
-                | TxSenderError::SoftCancelFailed
-                | TxSenderError::Other(_)) => {
-                    error!("Failed to send bundle: {error}");
-                    Err(error.into())
-                }
-            },
+            }
             Err(TransactionTrackerError::Other(e)) => {
                 error!("Failed to send bundle with unexpected tracker error: {e:?}");
                 Err(e)
@@ -1056,6 +1087,29 @@ where
             .context("builder should remove rejected ops from pool")
     }
 
+    /// Reports the final outcome of a bundle submission attempt to the pool for
+    /// poison user operation tracking. Best effort: failures are logged.
+    ///
+    /// Provider-event detection is not implemented yet, so
+    /// `provider_event_active` is always false.
+    async fn report_bundle_outcome(
+        &self,
+        entry_point: Address,
+        ops: Vec<B256>,
+        outcome: BundleOutcome,
+    ) {
+        if ops.is_empty() {
+            return;
+        }
+        if let Err(error) = self
+            .pool
+            .report_bundle_outcome(entry_point, ops, outcome, false)
+            .await
+        {
+            warn!("Failed to report bundle outcome to pool: {error}");
+        }
+    }
+
     async fn process_revert(
         &self,
         tx_hash: B256,
@@ -1073,9 +1127,16 @@ where
             "Unknown entry point config: {ep_address:?}, filter_id: {filter_id:?}"
         ))?;
 
-        let to_remove = proposer.process_revert(tx_hash).await?;
+        let outcome = proposer.process_revert(tx_hash).await?;
 
-        self.remove_ops_from_pool_by_hash(ep_address, to_remove)
+        self.report_bundle_outcome(
+            ep_address,
+            outcome.to_mark_suspect,
+            BundleOutcome::MarkSuspect,
+        )
+        .await;
+
+        self.remove_ops_from_pool_by_hash(ep_address, outcome.to_remove)
             .await
     }
 
@@ -1623,7 +1684,7 @@ mod tests {
     use super::*;
     use crate::{
         assigner::{AssignmentResult, EntrypointInfo},
-        bundle_proposer::{BundleData, MockBundleProposerT},
+        bundle_proposer::{BundleData, MockBundleProposerT, RevertOutcome},
         bundle_sender::{BundleSenderImpl, MockTrigger},
         transaction_tracker::MockTransactionTracker,
     };
@@ -1745,6 +1806,13 @@ mod tests {
             .expect_notify_pending_bundle()
             .times(1)
             .returning(|_, _, _, _, _| Ok(()));
+        mock_pool
+            .expect_report_bundle_outcome()
+            .withf(|_, ops, outcome, provider_event_active| {
+                ops == &[B256::ZERO] && *outcome == BundleOutcome::Success && !provider_event_active
+            })
+            .times(1)
+            .returning(|_, _, _, _| Ok(()));
 
         mock_make_bundle(&mut mock_proposer_t, 1, vec![(Address::ZERO, B256::ZERO)]);
 
@@ -2566,6 +2634,9 @@ mod tests {
             })
         });
 
+        // neutral errors are not evidence: no outcome is reported
+        mock_pool.expect_report_bundle_outcome().times(0);
+
         // Sender will set condition_not_met flag and pass it to next make_bundle call
         // (tested implicitly via state transition to Building with retry)
 
@@ -2654,7 +2725,7 @@ mod tests {
         // Mock the proposer's process_revert to return empty (no ops to remove)
         mock_proposer_t
             .expect_process_revert()
-            .returning(|_| Box::pin(async { Ok(vec![]) }));
+            .returning(|_| Box::pin(async { Ok(RevertOutcome::default()) }));
 
         mock_pool.expect_remove_ops().returning(|_, _| Ok(()));
 
@@ -2695,6 +2766,191 @@ mod tests {
                 underpriced_info: None,
             })
         ));
+    }
+
+    async fn run_send_error_reports_outcome(error: TxSenderError, outcome: BundleOutcome) {
+        let Mocks {
+            mut mock_proposer_t,
+            mut mock_tracker,
+            mut mock_trigger,
+            mut mock_pool,
+        } = new_mocks();
+
+        let mut seq = Sequence::new();
+        add_trigger_no_update_last_block(&mut mock_trigger, &mut seq, 1);
+
+        setup_tracker_default(&mut mock_tracker);
+        mock_tracker.expect_reset().returning(|| Box::pin(async {}));
+
+        mock_pool
+            .expect_get_ops_summaries()
+            .times(1)
+            .returning(|_, _, _, _| {
+                Ok(vec![pool_op_summary(
+                    ENTRY_POINT_ADDRESS_V0_6,
+                    Address::ZERO,
+                )])
+            });
+        mock_pool
+            .expect_get_ops_by_hashes()
+            .times(1)
+            .returning(|_, _| Ok(vec![demo_pool_op()]));
+        mock_pool
+            .expect_report_bundle_outcome()
+            .withf(move |_, ops, reported, provider_event_active| {
+                ops == &[B256::ZERO] && *reported == outcome && !provider_event_active
+            })
+            .times(1)
+            .returning(|_, _, _, _| Ok(()));
+
+        mock_make_bundle(&mut mock_proposer_t, 1, vec![(Address::ZERO, B256::ZERO)]);
+
+        let error = std::sync::Mutex::new(Some(error));
+        mock_tracker
+            .expect_send_transaction()
+            .returning(move |_, _, _| {
+                let error = error.lock().unwrap().take().unwrap();
+                Box::pin(async move { Err(TransactionTrackerError::Sender(error)) })
+            });
+
+        let mut state = new_state_with(
+            mock_trigger,
+            mock_tracker,
+            InnerState::Building(BuildingState {
+                wait_for_trigger: true,
+                fee_increase_count: 0,
+                underpriced_info: None,
+            }),
+        );
+
+        let mut sender = new_sender(mock_proposer_t, mock_pool);
+
+        let update = state.wait_for_trigger().await.unwrap();
+        sender.step_after_trigger(&mut state, update).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_terminal_error_reports_terminal_failure() {
+        run_send_error_reports_outcome(
+            TxSenderError::TerminalRpcError {
+                code: -32000,
+                message: "internal error".to_string(),
+            },
+            BundleOutcome::TerminalFailure,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_non_terminal_error_reports_non_terminal_failure() {
+        run_send_error_reports_outcome(
+            TxSenderError::SenderUnavailable(anyhow::anyhow!("provider outage")),
+            BundleOutcome::NonTerminalFailure,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_revert_reports_suspects_and_removes() {
+        let Mocks {
+            mut mock_proposer_t,
+            mut mock_tracker,
+            mut mock_trigger,
+            mut mock_pool,
+        } = new_mocks();
+
+        let mut seq = Sequence::new();
+        add_trigger_wait_for_block_last_block(&mut mock_trigger, &mut seq, 1);
+
+        let mined = new_head_mined(2);
+        let mined_clone = mined.clone();
+
+        mock_trigger
+            .expect_wait_for_block()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move || {
+                Box::pin({
+                    let mined = mined_clone.clone();
+                    async move { Ok(mined) }
+                })
+            });
+        mock_trigger
+            .expect_last_block()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(mined);
+
+        mock_tracker.expect_address().return_const(Address::ZERO);
+
+        mock_tracker.expect_process_update().once().returning(|_| {
+            Box::pin(async {
+                Ok(Some(TrackerUpdate::Mined {
+                    block_number: 2,
+                    nonce: 0,
+                    gas_limit: None,
+                    gas_used: None,
+                    gas_price: None,
+                    tx_hash: B256::ZERO,
+                    attempt_number: 0,
+                    is_success: false, // revert
+                }))
+            })
+        });
+
+        let removed = B256::repeat_byte(1);
+        let suspect_a = B256::repeat_byte(2);
+        let suspect_b = B256::repeat_byte(3);
+
+        mock_proposer_t.expect_process_revert().returning(move |_| {
+            Box::pin(async move {
+                Ok(RevertOutcome {
+                    to_remove: vec![removed],
+                    to_mark_suspect: vec![suspect_a, suspect_b],
+                })
+            })
+        });
+
+        mock_pool
+            .expect_report_bundle_outcome()
+            .withf(move |_, ops, outcome, provider_event_active| {
+                ops == &[suspect_a, suspect_b]
+                    && *outcome == BundleOutcome::MarkSuspect
+                    && !provider_event_active
+            })
+            .times(1)
+            .returning(|_, _, _, _| Ok(()));
+        mock_pool
+            .expect_remove_ops()
+            .withf(move |_, ops| ops == &[removed])
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let mut sender = new_sender(mock_proposer_t, mock_pool);
+
+        // Establish pin so process_revert can find the proposer
+        sender.assigner.test_establish_pin(
+            Address::default(),
+            &[Address::ZERO],
+            (ENTRY_POINT_ADDRESS_V0_6, None),
+        );
+
+        let mut state = new_state_with(
+            mock_trigger,
+            mock_tracker,
+            InnerState::Pending(PendingState {
+                until: 3,
+                fee_increase_count: 0,
+            }),
+        );
+
+        // first step has no update
+        let update = state.wait_for_trigger().await.unwrap();
+        sender.step_after_trigger(&mut state, update).await.unwrap();
+
+        // second step is mined as a revert: suspects reported, removals removed
+        let update = state.wait_for_trigger().await.unwrap();
+        sender.step_after_trigger(&mut state, update).await.unwrap();
     }
 
     struct Mocks {

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -662,7 +662,11 @@ where
                 self.assigner.release_all(self.sender_eoa);
                 state.reset();
             }
-            Err(TransactionTrackerError::Other(e)) => {
+            Err(
+                e @ (TransactionTrackerError::SenderUnavailable(_)
+                | TransactionTrackerError::UnrecognizedRpc { .. }
+                | TransactionTrackerError::Other(_)),
+            ) => {
                 error!("Failed to cancel transaction, moving back to building state: {e:#?}");
                 self.increment_counter("builder_cancellation_txns_failed", &pinned, 1);
                 self.assigner.release_all(self.sender_eoa);
@@ -998,9 +1002,13 @@ where
                 error!("Bundle attempt insufficient funds");
                 Ok(SendBundleAttemptResult::InsufficientFunds)
             }
-            Err(TransactionTrackerError::Other(e)) => {
-                error!("Failed to send bundle with unexpected error: {e:?}");
-                if Self::is_intrinsic_gas_too_low_error(&e) {
+            Err(TransactionTrackerError::SenderUnavailable(e)) => {
+                error!("Failed to send bundle, sender unavailable: {e:?}");
+                Err(e)
+            }
+            Err(TransactionTrackerError::UnrecognizedRpc { code, message }) => {
+                error!("Failed to send bundle with unrecognized RPC error {code}: {message}");
+                if Self::is_intrinsic_gas_too_low_error(&message) {
                     let tx_bytes = tx.input.input().map_or_else(
                         || String::from("0x"),
                         |data| format!("0x{}", hex::encode(data)),
@@ -1009,15 +1017,17 @@ where
                         "Bundle transaction bytes for intrinsic gas too low: tx_bytes={tx_bytes}"
                     );
                 }
+                Err(anyhow::anyhow!("unrecognized RPC error {code}: {message}"))
+            }
+            Err(TransactionTrackerError::Other(e)) => {
+                error!("Failed to send bundle with unexpected error: {e:?}");
                 Err(e)
             }
         }
     }
 
-    fn is_intrinsic_gas_too_low_error(error: &anyhow::Error) -> bool {
-        format!("{error:#}")
-            .to_lowercase()
-            .contains("intrinsic gas too low")
+    fn is_intrinsic_gas_too_low_error(message: &str) -> bool {
+        message.to_lowercase().contains("intrinsic gas too low")
     }
 
     /// Emits an event for a specific entrypoint (used for shared signer support)

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -664,6 +664,7 @@ where
             }
             Err(
                 e @ (TransactionTrackerError::IntrinsicGasTooLow
+                | TransactionTrackerError::TerminalRpcError { .. }
                 | TransactionTrackerError::SenderUnavailable(_)
                 | TransactionTrackerError::UnrecognizedRpc { .. }
                 | TransactionTrackerError::Other(_)),
@@ -1014,6 +1015,10 @@ where
                 );
                 error!("Bundle transaction intrinsic gas too low: tx_bytes={tx_bytes}");
                 Err(anyhow::anyhow!("intrinsic gas too low"))
+            }
+            Err(TransactionTrackerError::TerminalRpcError { code, message }) => {
+                error!("Failed to send bundle with terminal RPC error {code}: {message}");
+                Err(anyhow::anyhow!("terminal RPC error {code}: {message}"))
             }
             Err(TransactionTrackerError::UnrecognizedRpc { code, message }) => {
                 error!("Failed to send bundle with unrecognized RPC error {code}: {message}");

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -663,7 +663,8 @@ where
                 state.reset();
             }
             Err(
-                e @ (TransactionTrackerError::SenderUnavailable(_)
+                e @ (TransactionTrackerError::IntrinsicGasTooLow
+                | TransactionTrackerError::SenderUnavailable(_)
                 | TransactionTrackerError::UnrecognizedRpc { .. }
                 | TransactionTrackerError::Other(_)),
             ) => {
@@ -1006,17 +1007,16 @@ where
                 error!("Failed to send bundle, sender unavailable: {e:?}");
                 Err(e)
             }
+            Err(TransactionTrackerError::IntrinsicGasTooLow) => {
+                let tx_bytes = tx.input.input().map_or_else(
+                    || String::from("0x"),
+                    |data| format!("0x{}", hex::encode(data)),
+                );
+                error!("Bundle transaction intrinsic gas too low: tx_bytes={tx_bytes}");
+                Err(anyhow::anyhow!("intrinsic gas too low"))
+            }
             Err(TransactionTrackerError::UnrecognizedRpc { code, message }) => {
                 error!("Failed to send bundle with unrecognized RPC error {code}: {message}");
-                if Self::is_intrinsic_gas_too_low_error(&message) {
-                    let tx_bytes = tx.input.input().map_or_else(
-                        || String::from("0x"),
-                        |data| format!("0x{}", hex::encode(data)),
-                    );
-                    error!(
-                        "Bundle transaction bytes for intrinsic gas too low: tx_bytes={tx_bytes}"
-                    );
-                }
                 Err(anyhow::anyhow!("unrecognized RPC error {code}: {message}"))
             }
             Err(TransactionTrackerError::Other(e)) => {
@@ -1024,10 +1024,6 @@ where
                 Err(e)
             }
         }
-    }
-
-    fn is_intrinsic_gas_too_low_error(message: &str) -> bool {
-        message.to_lowercase().contains("intrinsic gas too low")
     }
 
     /// Emits an event for a specific entrypoint (used for shared signer support)

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -893,15 +893,28 @@ where
             }
         };
 
-        join!(remove_ops_future, update_entities_future);
+        let mark_suspect_future = self.report_bundle_outcome(
+            entry_point,
+            bundle_data.suspect_op_hashes.clone(),
+            BundleOutcome::MarkSuspect,
+        );
+
+        join!(
+            remove_ops_future,
+            update_entities_future,
+            mark_suspect_future
+        );
 
         // Check if bundle is empty
         if bundle_data.is_empty() {
-            if !bundle_data.rejected_op_hashes.is_empty() || !bundle_data.entity_updates.is_empty()
+            if !bundle_data.rejected_op_hashes.is_empty()
+                || !bundle_data.suspect_op_hashes.is_empty()
+                || !bundle_data.entity_updates.is_empty()
             {
                 info!(
-                    "Empty bundle with {} rejected ops and {} rejected entities. Removed from pool.",
+                    "Empty bundle with {} rejected ops, {} suspect ops, and {} rejected entities.",
                     bundle_data.rejected_op_hashes.len(),
+                    bundle_data.suspect_op_hashes.len(),
                     bundle_data.entity_updates.len()
                 );
             }
@@ -923,9 +936,10 @@ where
         let ops = bundle_data.ops;
 
         let num_rejected = bundle_data.rejected_op_hashes.len();
+        let num_suspect = bundle_data.suspect_op_hashes.len();
         let num_updated_entities = bundle_data.entity_updates.len();
         info!(
-            "Selected bundle for {entry_point:?}: nonce: {nonce:?}. Ops: {ops:?}. Num rejected: {num_rejected}. Num updated entities: {num_updated_entities}"
+            "Selected bundle for {entry_point:?}: nonce: {nonce:?}. Ops: {ops:?}. Num rejected: {num_rejected}. Num suspect: {num_suspect}. Num updated entities: {num_updated_entities}"
         );
 
         // Send the transaction
@@ -3192,6 +3206,7 @@ mod tests {
             gas_fees: GasFees::default(),
             ops,
             rejected_op_hashes: vec![],
+            suspect_op_hashes: vec![],
             entity_updates: vec![],
         }
     }

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -1118,6 +1118,15 @@ where
         if ops.is_empty() {
             return;
         }
+
+        let outcome_metric = match outcome {
+            BundleOutcome::Success => "builder_bundle_outcome_success",
+            BundleOutcome::NonTerminalFailure => "builder_bundle_outcome_non_terminal_failure",
+            BundleOutcome::TerminalFailure => "builder_bundle_outcome_terminal_failure",
+            BundleOutcome::MarkSuspect => "builder_bundle_outcome_mark_suspect",
+        };
+        self.increment_counter_ep(outcome_metric, entry_point, 1);
+
         if let Err(error) = self
             .pool
             .report_bundle_outcome(
@@ -1128,6 +1137,7 @@ where
             )
             .await
         {
+            self.increment_counter_ep("builder_bundle_outcome_report_failed", entry_point, 1);
             warn!("Failed to report bundle outcome to pool: {error}");
         }
     }

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -42,6 +42,7 @@ use crate::{
     assigner::{Assigner, AssignmentResult},
     bundle_proposer::{BundleData, BundleProposalRequest, BundleProposerError, BundleProposerT},
     emit::{BuilderEvent, BundleTxDetails},
+    sender::TxSenderError,
     transaction_tracker::{
         TrackerState, TrackerUpdate, TransactionTracker, TransactionTrackerError,
     },
@@ -618,9 +619,11 @@ where
                 self.increment_counter("builder_soft_cancellations", &pinned, 1);
                 state.reset();
             }
-            Err(TransactionTrackerError::Rejected)
-            | Err(TransactionTrackerError::Underpriced)
-            | Err(TransactionTrackerError::ReplacementUnderpriced) => {
+            Err(TransactionTrackerError::Sender(
+                TxSenderError::Rejected
+                | TxSenderError::Underpriced
+                | TxSenderError::ReplacementUnderpriced,
+            )) => {
                 info!(
                     "Transaction underpriced/rejected during cancellation, trying again. {cancel_res:?}"
                 );
@@ -642,19 +645,19 @@ where
                     state.update(InnerState::Cancelling(inner.to_self()));
                 }
             }
-            Err(TransactionTrackerError::NonceTooLow) => {
+            Err(TransactionTrackerError::Sender(TxSenderError::NonceTooLow)) => {
                 // reset the transaction tracker and try again
                 info!("Nonce too low during cancellation, starting new bundle attempt");
                 self.assigner.release_all(self.sender_eoa);
                 state.reset();
             }
-            Err(TransactionTrackerError::InsufficientFunds) => {
+            Err(TransactionTrackerError::Sender(TxSenderError::InsufficientFunds)) => {
                 error!("Insufficient funds during cancellation, starting new bundle attempt");
                 self.increment_counter("builder_cancellation_txns_failed", &pinned, 1);
                 self.assigner.release_all(self.sender_eoa);
                 state.reset();
             }
-            Err(TransactionTrackerError::ConditionNotMet) => {
+            Err(TransactionTrackerError::Sender(TxSenderError::ConditionNotMet)) => {
                 error!(
                     "Unexpected condition not met during cancellation, starting new bundle attempt"
                 );
@@ -662,13 +665,7 @@ where
                 self.assigner.release_all(self.sender_eoa);
                 state.reset();
             }
-            Err(
-                e @ (TransactionTrackerError::IntrinsicGasTooLow
-                | TransactionTrackerError::TerminalRpcError { .. }
-                | TransactionTrackerError::SenderUnavailable(_)
-                | TransactionTrackerError::UnrecognizedRpc { .. }
-                | TransactionTrackerError::Other(_)),
-            ) => {
+            Err(e) => {
                 error!("Failed to cancel transaction, moving back to building state: {e:#?}");
                 self.increment_counter("builder_cancellation_txns_failed", &pinned, 1);
                 self.assigner.release_all(self.sender_eoa);
@@ -974,58 +971,68 @@ where
 
                 Ok(SendBundleAttemptResult::Success(ops))
             }
-            Err(TransactionTrackerError::NonceTooLow) => {
-                self.increment_counter_ep("builder_bundle_txn_nonce_too_low", entry_point, 1);
-                warn!("Bundle attempt nonce too low");
-                Ok(SendBundleAttemptResult::NonceTooLow)
-            }
-            Err(TransactionTrackerError::Underpriced) => {
-                self.increment_counter_ep("builder_bundle_txn_underpriced", entry_point, 1);
-                warn!("Bundle attempt underpriced");
-                Ok(SendBundleAttemptResult::Underpriced)
-            }
-            Err(TransactionTrackerError::ReplacementUnderpriced) => {
-                self.increment_counter_ep("builder_bundle_replacement_underpriced", entry_point, 1);
-                warn!("Bundle attempt replacement transaction underpriced");
-                Ok(SendBundleAttemptResult::ReplacementUnderpriced)
-            }
-            Err(TransactionTrackerError::ConditionNotMet) => {
-                self.increment_counter_ep("builder_bundle_txn_condition_not_met", entry_point, 1);
-                warn!("Bundle attempt condition not met");
-                Ok(SendBundleAttemptResult::ConditionNotMet)
-            }
-            Err(TransactionTrackerError::Rejected) => {
-                self.increment_counter_ep("builder_bundle_txn_rejected", entry_point, 1);
-                warn!("Bundle attempt rejected");
-                Ok(SendBundleAttemptResult::Rejected)
-            }
-            Err(TransactionTrackerError::InsufficientFunds) => {
-                self.increment_counter_ep("builder_bundle_txn_insufficient_funds", entry_point, 1);
-                error!("Bundle attempt insufficient funds");
-                Ok(SendBundleAttemptResult::InsufficientFunds)
-            }
-            Err(TransactionTrackerError::SenderUnavailable(e)) => {
-                error!("Failed to send bundle, sender unavailable: {e:?}");
-                Err(e)
-            }
-            Err(TransactionTrackerError::IntrinsicGasTooLow) => {
-                let tx_bytes = tx.input.input().map_or_else(
-                    || String::from("0x"),
-                    |data| format!("0x{}", hex::encode(data)),
-                );
-                error!("Bundle transaction intrinsic gas too low: tx_bytes={tx_bytes}");
-                Err(anyhow::anyhow!("intrinsic gas too low"))
-            }
-            Err(TransactionTrackerError::TerminalRpcError { code, message }) => {
-                error!("Failed to send bundle with terminal RPC error {code}: {message}");
-                Err(anyhow::anyhow!("terminal RPC error {code}: {message}"))
-            }
-            Err(TransactionTrackerError::UnrecognizedRpc { code, message }) => {
-                error!("Failed to send bundle with unrecognized RPC error {code}: {message}");
-                Err(anyhow::anyhow!("unrecognized RPC error {code}: {message}"))
-            }
+            Err(TransactionTrackerError::Sender(error)) => match error {
+                TxSenderError::NonceTooLow => {
+                    self.increment_counter_ep("builder_bundle_txn_nonce_too_low", entry_point, 1);
+                    warn!("Bundle attempt nonce too low");
+                    Ok(SendBundleAttemptResult::NonceTooLow)
+                }
+                TxSenderError::Underpriced => {
+                    self.increment_counter_ep("builder_bundle_txn_underpriced", entry_point, 1);
+                    warn!("Bundle attempt underpriced");
+                    Ok(SendBundleAttemptResult::Underpriced)
+                }
+                TxSenderError::ReplacementUnderpriced => {
+                    self.increment_counter_ep(
+                        "builder_bundle_replacement_underpriced",
+                        entry_point,
+                        1,
+                    );
+                    warn!("Bundle attempt replacement transaction underpriced");
+                    Ok(SendBundleAttemptResult::ReplacementUnderpriced)
+                }
+                TxSenderError::ConditionNotMet => {
+                    self.increment_counter_ep(
+                        "builder_bundle_txn_condition_not_met",
+                        entry_point,
+                        1,
+                    );
+                    warn!("Bundle attempt condition not met");
+                    Ok(SendBundleAttemptResult::ConditionNotMet)
+                }
+                TxSenderError::Rejected => {
+                    self.increment_counter_ep("builder_bundle_txn_rejected", entry_point, 1);
+                    warn!("Bundle attempt rejected");
+                    Ok(SendBundleAttemptResult::Rejected)
+                }
+                TxSenderError::InsufficientFunds => {
+                    self.increment_counter_ep(
+                        "builder_bundle_txn_insufficient_funds",
+                        entry_point,
+                        1,
+                    );
+                    error!("Bundle attempt insufficient funds");
+                    Ok(SendBundleAttemptResult::InsufficientFunds)
+                }
+                TxSenderError::IntrinsicGasTooLow => {
+                    let tx_bytes = tx.input.input().map_or_else(
+                        || String::from("0x"),
+                        |data| format!("0x{}", hex::encode(data)),
+                    );
+                    error!("Bundle transaction intrinsic gas too low: tx_bytes={tx_bytes}");
+                    Err(anyhow::anyhow!("intrinsic gas too low"))
+                }
+                error @ (TxSenderError::TerminalRpcError { .. }
+                | TxSenderError::UnrecognizedRpc { .. }
+                | TxSenderError::SenderUnavailable(_)
+                | TxSenderError::SoftCancelFailed
+                | TxSenderError::Other(_)) => {
+                    error!("Failed to send bundle: {error}");
+                    Err(error.into())
+                }
+            },
             Err(TransactionTrackerError::Other(e)) => {
-                error!("Failed to send bundle with unexpected error: {e:?}");
+                error!("Failed to send bundle with unexpected tracker error: {e:?}");
                 Err(e)
             }
         }
@@ -2543,9 +2550,13 @@ mod tests {
         mock_make_bundle(&mut mock_proposer_t, 1, vec![(Address::ZERO, B256::ZERO)]);
 
         // should send the bundle txn, returns condition not met
-        mock_tracker
-            .expect_send_transaction()
-            .returning(|_, _, _| Box::pin(async { Err(TransactionTrackerError::ConditionNotMet) }));
+        mock_tracker.expect_send_transaction().returning(|_, _, _| {
+            Box::pin(async {
+                Err(TransactionTrackerError::Sender(
+                    TxSenderError::ConditionNotMet,
+                ))
+            })
+        });
 
         // Sender will set condition_not_met flag and pass it to next make_bundle call
         // (tested implicitly via state transition to Building with retry)

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -22,6 +22,7 @@ use rand::Rng;
 use rundler_provider::FeeEstimator;
 use rundler_task::TaskSpawner;
 use rundler_types::{
+    UserOperation,
     builder::BundlingMode,
     chain::ChainSpec,
     pool::{AddressUpdate, BundleOutcome, NewHead, Pool},
@@ -776,6 +777,11 @@ where
                 let entry_point = assignment.entry_point;
                 let filter_id = assignment.filter_id;
                 let ops = assignment.operations;
+
+                if assignment.is_isolation {
+                    let hashes: Vec<B256> = ops.iter().map(|op| op.uo.hash()).collect();
+                    info!("Sending isolation bundle for suspect ops {hashes:?}");
+                }
 
                 // Build and send bundle. Keep this as a single result path so assigner
                 // cleanup runs for all outcomes, including hard errors.

--- a/crates/builder/src/sender/fallback.rs
+++ b/crates/builder/src/sender/fallback.rs
@@ -320,6 +320,32 @@ mod tests {
         }
     }
 
+    struct ErrSender {
+        make: fn() -> TxSenderError,
+    }
+
+    #[async_trait::async_trait]
+    impl TransactionSender for ErrSender {
+        async fn send_transaction(
+            &self,
+            _tx: TransactionRequest,
+            _expected_storage: &ExpectedStorage,
+            _signer: &SignerLease,
+        ) -> super::Result<B256> {
+            Err((self.make)())
+        }
+
+        async fn cancel_transaction(
+            &self,
+            _tx_hash: B256,
+            _nonce: u64,
+            _gas_fees: GasFees,
+            _signer: &SignerLease,
+        ) -> super::Result<CancelTxInfo> {
+            unimplemented!()
+        }
+    }
+
     fn make_sender(
         primary: impl TransactionSender + 'static,
         fallback: impl TransactionSender + 'static,
@@ -427,6 +453,64 @@ mod tests {
             .unwrap();
         assert_eq!(hash, fallback_hash);
         assert!(sender.last_tx_used_fallback.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn unrecognized_rpc_activates_fallback_at_threshold() {
+        let fallback_hash = B256::repeat_byte(0x02);
+        let sender = make_sender(
+            ErrSender {
+                make: || TxSenderError::UnrecognizedRpc {
+                    code: -32000,
+                    message: "internal error".to_string(),
+                },
+            },
+            AlwaysOkSender {
+                hash: fallback_hash,
+            },
+            60,
+            1,
+        );
+
+        let hash = sender
+            .send_transaction(
+                TransactionRequest::default(),
+                &ExpectedStorage::default(),
+                &test_signer(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(hash, fallback_hash);
+    }
+
+    #[tokio::test]
+    async fn terminal_error_does_not_activate_fallback() {
+        let sender = make_sender(
+            ErrSender {
+                make: || TxSenderError::TerminalRpcError {
+                    code: -32000,
+                    message: "internal error".to_string(),
+                },
+            },
+            AlwaysOkSender {
+                hash: B256::repeat_byte(0x02),
+            },
+            60,
+            1,
+        );
+
+        let result = sender
+            .send_transaction(
+                TransactionRequest::default(),
+                &ExpectedStorage::default(),
+                &test_signer(),
+            )
+            .await;
+        assert!(matches!(
+            result,
+            Err(TxSenderError::TerminalRpcError { .. })
+        ));
+        assert!(matches!(sender.current_sender(), ActiveSender::Primary));
     }
 
     #[tokio::test]

--- a/crates/builder/src/sender/fallback.rs
+++ b/crates/builder/src/sender/fallback.rs
@@ -39,7 +39,7 @@ struct FallbackSenderMetrics {
     #[metric(describe = "total successful sends via the fallback")]
     fallback_sends: Counter,
     #[metric(
-        describe = "total SenderUnavailable errors from the primary, including those below the failover threshold"
+        describe = "total failover-eligible errors from the primary, including those below the failover threshold"
     )]
     primary_unavailable: Counter,
 }
@@ -51,7 +51,8 @@ enum ActiveSender {
 }
 
 /// A transaction sender that transparently fails over to a fallback sender when
-/// the primary returns [`TxSenderError::SenderUnavailable`].
+/// the primary returns [`TxSenderError::SenderUnavailable`] or
+/// [`TxSenderError::UnrecognizedRpc`].
 ///
 /// Recovery is passive: after `recovery_interval` has elapsed the next send
 /// attempt re-tries the primary. On success the primary is reinstated; on
@@ -168,7 +169,9 @@ impl TransactionSender for FallbackTransactionSender {
                 self.metrics.primary_sends.increment(1);
                 Ok(hash)
             }
-            Err(TxSenderError::SenderUnavailable(e)) => {
+            Err(
+                e @ (TxSenderError::SenderUnavailable(_) | TxSenderError::UnrecognizedRpc { .. }),
+            ) => {
                 self.metrics.primary_unavailable.increment(1);
                 let failures = self.consecutive_failures.fetch_add(1, Ordering::AcqRel) + 1;
                 if failures >= self.failure_threshold {
@@ -188,7 +191,7 @@ impl TransactionSender for FallbackTransactionSender {
                         error = %e,
                         "Primary sender unavailable, will activate fallback after threshold"
                     );
-                    Err(TxSenderError::SenderUnavailable(e))
+                    Err(e)
                 }
             }
             Err(e) => Err(e),

--- a/crates/builder/src/sender/flashbots.rs
+++ b/crates/builder/src/sender/flashbots.rs
@@ -33,12 +33,44 @@ use serde_json::{Value, json};
 use super::{ExpectedStorage, Result, TransactionSender, TxSenderError};
 use crate::sender::CancelTxInfo;
 
-fn map_flashbots_error(err: anyhow::Error) -> TxSenderError {
-    tracing::warn!(
-        error = %err,
-        "Flashbots request failed, treating as sender unavailable"
-    );
-    TxSenderError::SenderUnavailable(err)
+/// Errors from the Flashbots relay's raw HTTP JSON-RPC interface.
+#[derive(Debug, thiserror::Error)]
+enum FlashbotsError {
+    /// The relay responded with a well-formed JSON-RPC error object - a
+    /// verdict on this specific request, not evidence the relay is down.
+    #[error("Flashbots RPC error {code}: {message}")]
+    Rpc { code: i64, message: String },
+    /// Network failure, non-2xx status with no JSON-RPC error body, or any
+    /// other response that isn't a recognizable JSON-RPC envelope.
+    #[error(transparent)]
+    Transport(#[from] anyhow::Error),
+}
+
+impl From<FlashbotsError> for TxSenderError {
+    fn from(value: FlashbotsError) -> Self {
+        match value {
+            FlashbotsError::Rpc { code, message } => {
+                if let Some(known) = super::parse_known_call_execution_failed(&message, code) {
+                    return known;
+                }
+                tracing::warn!(
+                    rpc_error_code = code,
+                    rpc_error_message = %message,
+                    "Unrecognized Flashbots RPC error, treating as sender unavailable"
+                );
+                TxSenderError::SenderUnavailable(anyhow::anyhow!(
+                    "unrecognized Flashbots RPC error {code}: {message}"
+                ))
+            }
+            FlashbotsError::Transport(err) => {
+                tracing::warn!(
+                    error = %err,
+                    "Flashbots request failed, treating as sender unavailable"
+                );
+                TxSenderError::SenderUnavailable(err)
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -62,8 +94,7 @@ impl TransactionSender for FlashbotsTransactionSender {
         let tx_hash = self
             .flashbots_client
             .send_private_transaction(raw_tx)
-            .await
-            .map_err(map_flashbots_error)?;
+            .await?;
 
         Ok(tx_hash)
     }
@@ -78,8 +109,7 @@ impl TransactionSender for FlashbotsTransactionSender {
         let success = self
             .flashbots_client
             .cancel_private_transaction(tx_hash)
-            .await
-            .map_err(map_flashbots_error)?;
+            .await?;
 
         if !success {
             return Err(TxSenderError::SoftCancelFailed);
@@ -142,22 +172,31 @@ struct FlashbotsSendPrivateTransactionRequest {
     preferences: Preferences,
 }
 
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-struct FlashbotsSendPrivateTransactionResponse {
-    result: B256,
-}
-
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct FlashbotsCancelPrivateTransactionRequest {
     tx_hash: B256,
 }
 
+/// A JSON-RPC 2.0 response envelope that may carry either a `result` or an
+/// `error` object, so a well-formed RPC-level rejection from the relay can be
+/// told apart from a transport failure or a garbled response.
 #[derive(Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-struct FlashbotsCancelPrivateTransactionResponse {
-    result: bool,
+struct JsonRpcEnvelope<T> {
+    // Named default fns (rather than bare `#[serde(default)]`) avoid serde
+    // deriving a spurious `T: Default` bound on the whole impl - Option<T> is
+    // Default for any T, but serde's derive can't see that through a bare
+    // `Default::default()` call.
+    #[serde(default = "Option::default")]
+    result: Option<T>,
+    #[serde(default = "Option::default")]
+    error: Option<JsonRpcErrorObject>,
+}
+
+#[derive(Deserialize, Debug)]
+struct JsonRpcErrorObject {
+    code: i64,
+    message: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -223,7 +262,10 @@ impl FlashbotsClient {
         }
     }
 
-    async fn send_private_transaction(&self, raw_tx: Bytes) -> anyhow::Result<B256> {
+    async fn send_private_transaction(
+        &self,
+        raw_tx: Bytes,
+    ) -> std::result::Result<B256, FlashbotsError> {
         let preferences = Preferences {
             fast: false,
             privacy: Some(Privacy {
@@ -245,17 +287,13 @@ impl FlashbotsClient {
             "id": 1
         });
 
-        let response = self.sign_send_request(body).await?;
-
-        let parsed_response = response
-            .json::<FlashbotsSendPrivateTransactionResponse>()
-            .await
-            .map_err(|e| anyhow!("failed to deserialize Flashbots response: {:?}", e))?;
-
-        Ok(parsed_response.result)
+        self.send_and_parse(body).await
     }
 
-    async fn cancel_private_transaction(&self, tx_hash: B256) -> anyhow::Result<bool> {
+    async fn cancel_private_transaction(
+        &self,
+        tx_hash: B256,
+    ) -> std::result::Result<bool, FlashbotsError> {
         let body = json!({
             "jsonrpc": "2.0",
             "method": "eth_cancelPrivateTransaction",
@@ -265,17 +303,48 @@ impl FlashbotsClient {
             "id": 1
         });
 
-        let response = self.sign_send_request(body).await?;
-
-        let parsed_response = response
-            .json::<FlashbotsCancelPrivateTransactionResponse>()
-            .await
-            .map_err(|e| anyhow!("failed to deserialize Flashbots response: {:?}", e))?;
-
-        Ok(parsed_response.result)
+        self.send_and_parse(body).await
     }
 
-    async fn sign_send_request(&self, body: Value) -> anyhow::Result<Response> {
+    /// Sends a signed JSON-RPC request and parses the response as a
+    /// [`JsonRpcEnvelope`], so a well-formed RPC-level rejection from the
+    /// relay - which can arrive on a 200 or a non-2xx status - is classified
+    /// via `FlashbotsError::Rpc` instead of being lumped in with genuine
+    /// transport failures.
+    async fn send_and_parse<T>(&self, body: Value) -> std::result::Result<T, FlashbotsError>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let response = self.sign_send_request(body).await?;
+        let status = response.status();
+        let text = response.text().await.map_err(|e| {
+            FlashbotsError::Transport(anyhow!("failed to read Flashbots response body: {e:?}"))
+        })?;
+
+        let envelope: JsonRpcEnvelope<T> = serde_json::from_str(&text).map_err(|e| {
+            FlashbotsError::Transport(anyhow!(
+                "failed to parse Flashbots response (status {status}): {e:?}, body: {text}"
+            ))
+        })?;
+
+        if let Some(error) = envelope.error {
+            return Err(FlashbotsError::Rpc {
+                code: error.code,
+                message: error.message,
+            });
+        }
+
+        envelope.result.ok_or_else(|| {
+            FlashbotsError::Transport(anyhow!(
+                "Flashbots response missing both result and error (status {status}): {text}"
+            ))
+        })
+    }
+
+    async fn sign_send_request(
+        &self,
+        body: Value,
+    ) -> std::result::Result<Response, FlashbotsError> {
         let to_sign = format!("0x{:x}", utils::keccak256(body.to_string()));
 
         let signature = self
@@ -293,19 +362,19 @@ impl FlashbotsClient {
         headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
         headers.insert("x-flashbots-signature", header_val);
 
-        // Send the request
-        let response = self
-            .http_client
+        // Send the request. Deliberately not checking status here: a
+        // well-formed JSON-RPC error can arrive on a non-2xx status just as
+        // easily as on a 200, and send_and_parse needs the body either way
+        // to tell an RPC-level rejection apart from a transport failure.
+        self.http_client
             .post(&self.relay_url)
             .headers(headers)
             .body(body.to_string())
             .send()
             .await
-            .map_err(|e| anyhow!("failed to send request to Flashbots: {:?}", e))?;
-
-        response
-            .error_for_status()
-            .map_err(|e| anyhow!("Flashbots request failed: {:?}", e))
+            .map_err(|e| {
+                FlashbotsError::Transport(anyhow!("failed to send request to Flashbots: {e:?}"))
+            })
     }
 }
 
@@ -373,4 +442,58 @@ where
         Value::Null => None,
         _ => return Err(de::Error::custom("expected a hexadecimal string")),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sender::RpcOutcomeClass;
+
+    #[test]
+    fn recognized_rpc_error_is_classified_not_sender_unavailable() {
+        let error = FlashbotsError::Rpc {
+            code: -32000,
+            message: "nonce too low".to_string(),
+        };
+        let sender_error: TxSenderError = error.into();
+        assert!(matches!(sender_error, TxSenderError::NonceTooLow));
+        assert_eq!(sender_error.classify(), RpcOutcomeClass::Neutral);
+    }
+
+    #[test]
+    fn unrecognized_rpc_error_falls_back_to_sender_unavailable() {
+        let error = FlashbotsError::Rpc {
+            code: -32099,
+            message: "some new relay-specific rejection".to_string(),
+        };
+        let sender_error: TxSenderError = error.into();
+        assert!(matches!(sender_error, TxSenderError::SenderUnavailable(_)));
+        assert_eq!(sender_error.classify(), RpcOutcomeClass::NonTerminal);
+    }
+
+    #[test]
+    fn transport_failure_is_sender_unavailable() {
+        let error = FlashbotsError::Transport(anyhow!("connection reset"));
+        let sender_error: TxSenderError = error.into();
+        assert!(matches!(sender_error, TxSenderError::SenderUnavailable(_)));
+        assert_eq!(sender_error.classify(), RpcOutcomeClass::NonTerminal);
+    }
+
+    #[test]
+    fn envelope_parses_rpc_error_alongside_missing_result() {
+        let body = r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"nonce too low"}}"#;
+        let envelope: JsonRpcEnvelope<B256> = serde_json::from_str(body).unwrap();
+        assert!(envelope.result.is_none());
+        let error = envelope.error.expect("should parse error object");
+        assert_eq!(error.code, -32000);
+        assert_eq!(error.message, "nonce too low");
+    }
+
+    #[test]
+    fn envelope_parses_result_alongside_missing_error() {
+        let body = r#"{"jsonrpc":"2.0","id":1,"result":"0x0000000000000000000000000000000000000000000000000000000000000001"}"#;
+        let envelope: JsonRpcEnvelope<B256> = serde_json::from_str(body).unwrap();
+        assert!(envelope.error.is_none());
+        assert!(envelope.result.is_some());
+    }
 }

--- a/crates/builder/src/sender/health.rs
+++ b/crates/builder/src/sender/health.rs
@@ -1,0 +1,209 @@
+// This file is part of Rundler.
+//
+// Rundler is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version.
+//
+// Rundler is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with Rundler.
+// If not, see https://www.gnu.org/licenses/.
+
+use std::{
+    collections::VecDeque,
+    sync::{
+        Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use metrics::Gauge;
+use metrics_derive::Metrics;
+
+/// Number of most recent non-neutral final submission outcomes considered.
+const WINDOW_SIZE: usize = 20;
+/// Minimum observations in the window before an event can be entered.
+const MIN_OBSERVATIONS: usize = 10;
+/// Failure ratio at or above which an event is entered.
+const ENTER_FAILURE_RATIO: f64 = 0.30;
+/// Failure ratio below which an active event is exited.
+const EXIT_FAILURE_RATIO: f64 = 0.10;
+
+/// Rolling-window detector for provider-health events, per the provider-event
+/// signal in `docs/designs/poison-user-operations.md`.
+///
+/// One signal exists per submission route and is shared by its builders. Only
+/// final submission outcomes — after provider retries and fallbacks are
+/// exhausted — are recorded: successes and non-terminal provider failures.
+/// Neutral operational errors and terminal RPC errors are excluded from the
+/// window by the caller.
+///
+/// Entering requires at least `MIN_OBSERVATIONS` with at least
+/// `ENTER_FAILURE_RATIO` failures; exiting requires the failure ratio to drop
+/// below `EXIT_FAILURE_RATIO`. The different thresholds prevent flapping.
+pub(crate) struct ProviderEventSignal {
+    /// Recent outcomes, `true` for a failure.
+    window: Mutex<VecDeque<bool>>,
+    active: AtomicBool,
+    metrics: ProviderEventMetrics,
+}
+
+impl Default for ProviderEventSignal {
+    fn default() -> Self {
+        Self {
+            window: Mutex::new(VecDeque::with_capacity(WINDOW_SIZE)),
+            active: AtomicBool::new(false),
+            metrics: ProviderEventMetrics::default(),
+        }
+    }
+}
+
+impl ProviderEventSignal {
+    /// Records a final successful submission.
+    pub(crate) fn record_success(&self) {
+        self.record(false);
+    }
+
+    /// Records a final non-terminal provider failure.
+    pub(crate) fn record_failure(&self) {
+        self.record(true);
+    }
+
+    /// Returns true while a provider event is active.
+    pub(crate) fn is_active(&self) -> bool {
+        self.active.load(Ordering::Relaxed)
+    }
+
+    /// Number of outcomes currently in the window, for tests.
+    #[cfg(test)]
+    pub(crate) fn observations(&self) -> usize {
+        self.window.lock().unwrap().len()
+    }
+
+    fn record(&self, failure: bool) {
+        let mut window = self.window.lock().unwrap();
+        if window.len() == WINDOW_SIZE {
+            window.pop_front();
+        }
+        window.push_back(failure);
+
+        let failures = window.iter().filter(|f| **f).count();
+        let ratio = failures as f64 / window.len() as f64;
+
+        if self.active.load(Ordering::Relaxed) {
+            if ratio < EXIT_FAILURE_RATIO {
+                self.active.store(false, Ordering::Relaxed);
+                self.metrics.provider_event_active.set(0.0);
+                tracing::info!(
+                    "Provider event ended: {failures} failures in last {} submissions",
+                    window.len()
+                );
+            }
+        } else if window.len() >= MIN_OBSERVATIONS && ratio >= ENTER_FAILURE_RATIO {
+            self.active.store(true, Ordering::Relaxed);
+            self.metrics.provider_event_active.set(1.0);
+            tracing::warn!(
+                "Provider event detected: {failures} failures in last {} submissions, pausing poison user operation evidence",
+                window.len()
+            );
+        }
+    }
+}
+
+#[derive(Metrics)]
+#[metrics(scope = "builder_sender")]
+struct ProviderEventMetrics {
+    #[metric(describe = "whether a provider-health event is currently active.")]
+    provider_event_active: Gauge,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stays_inactive_below_min_observations() {
+        let signal = ProviderEventSignal::default();
+        // 100% failures, but fewer than MIN_OBSERVATIONS
+        for _ in 0..MIN_OBSERVATIONS - 1 {
+            signal.record_failure();
+        }
+        assert!(!signal.is_active());
+    }
+
+    #[test]
+    fn enters_event_at_failure_ratio() {
+        let signal = ProviderEventSignal::default();
+        for _ in 0..7 {
+            signal.record_success();
+        }
+        for _ in 0..2 {
+            signal.record_failure();
+        }
+        // 9 observations: below the minimum even at the enter ratio
+        assert!(!signal.is_active());
+        signal.record_failure();
+        // 3 failures in 10 observations reaches the 30% enter threshold
+        assert!(signal.is_active());
+    }
+
+    #[test]
+    fn stays_below_enter_ratio() {
+        let signal = ProviderEventSignal::default();
+        for _ in 0..8 {
+            signal.record_success();
+        }
+        for _ in 0..2 {
+            signal.record_failure();
+        }
+        // 2 failures in 10 observations is below the 30% enter threshold
+        assert!(!signal.is_active());
+    }
+
+    #[test]
+    fn exits_event_below_exit_ratio() {
+        let signal = ProviderEventSignal::default();
+        for _ in 0..7 {
+            signal.record_success();
+        }
+        for _ in 0..3 {
+            signal.record_failure();
+        }
+        assert!(signal.is_active());
+
+        // successes push the failures out of the window; the event ends only
+        // once fewer than 10% of the window are failures
+        for _ in 0..18 {
+            signal.record_success();
+        }
+        // two of the failures are still within the last 20 outcomes:
+        // 2/20 = 10%, not yet below the exit ratio (hysteresis)
+        assert!(signal.is_active());
+        signal.record_success();
+        // 1 failure in 20 = 5%, below the 10% exit ratio
+        assert!(!signal.is_active());
+    }
+
+    #[test]
+    fn old_outcomes_roll_off_the_window() {
+        let signal = ProviderEventSignal::default();
+        for _ in 0..6 {
+            signal.record_failure();
+        }
+        for _ in 0..WINDOW_SIZE {
+            signal.record_success();
+        }
+        // the failures have been fully evicted
+        assert!(!signal.is_active());
+        for _ in 0..5 {
+            signal.record_failure();
+        }
+        // 5 failures in the last 20 = 25%, below the enter threshold
+        assert!(!signal.is_active());
+        signal.record_failure();
+        // 6 in 20 = 30%
+        assert!(signal.is_active());
+    }
+}

--- a/crates/builder/src/sender/health.rs
+++ b/crates/builder/src/sender/health.rs
@@ -19,7 +19,7 @@ use std::{
     },
 };
 
-use metrics::Gauge;
+use metrics::{Counter, Gauge};
 use metrics_derive::Metrics;
 
 /// Number of most recent non-neutral final submission outcomes considered.
@@ -104,6 +104,7 @@ impl ProviderEventSignal {
         } else if window.len() >= MIN_OBSERVATIONS && ratio >= ENTER_FAILURE_RATIO {
             self.active.store(true, Ordering::Relaxed);
             self.metrics.provider_event_active.set(1.0);
+            self.metrics.provider_events_total.increment(1);
             tracing::warn!(
                 "Provider event detected: {failures} failures in last {} submissions, pausing poison user operation evidence",
                 window.len()
@@ -117,6 +118,8 @@ impl ProviderEventSignal {
 struct ProviderEventMetrics {
     #[metric(describe = "whether a provider-health event is currently active.")]
     provider_event_active: Gauge,
+    #[metric(describe = "the total number of times a provider-health event was entered.")]
+    provider_events_total: Counter,
 }
 
 #[cfg(test)]

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -71,6 +71,9 @@ pub(crate) enum TxSenderError {
     /// Insufficient funds for transaction
     #[error("insufficient funds for transaction")]
     InsufficientFunds,
+    /// Transaction gas limit is below its intrinsic gas cost
+    #[error("intrinsic gas too low")]
+    IntrinsicGasTooLow,
     /// Sender is unavailable due to an outage or transport error.
     ///
     /// When a fallback sender is configured this triggers failover.
@@ -112,6 +115,7 @@ impl TxSenderError {
     #[allow(dead_code)] // consumed once the bundle sender reports outcomes to the pool
     pub(crate) fn classify(&self) -> RpcOutcomeClass {
         match self {
+            TxSenderError::IntrinsicGasTooLow => RpcOutcomeClass::Terminal,
             TxSenderError::SenderUnavailable(_) | TxSenderError::UnrecognizedRpc { .. } => {
                 RpcOutcomeClass::NonTerminal
             }
@@ -355,6 +359,7 @@ impl From<TransactionSubmissionError> for TxSenderError {
             TransactionSubmissionError::ConditionNotMet => Self::ConditionNotMet,
             TransactionSubmissionError::Rejected => Self::Rejected,
             TransactionSubmissionError::InsufficientFunds => Self::InsufficientFunds,
+            TransactionSubmissionError::IntrinsicGasTooLow => Self::IntrinsicGasTooLow,
         }
     }
 }

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -14,6 +14,7 @@
 mod bloxroute;
 mod fallback;
 mod flashbots;
+mod health;
 mod polygon_private;
 mod raw;
 
@@ -25,6 +26,7 @@ pub(crate) use bloxroute::PolygonBloxrouteTransactionSender;
 use enum_dispatch::enum_dispatch;
 pub(crate) use fallback::FallbackTransactionSender;
 pub(crate) use flashbots::FlashbotsTransactionSender;
+pub(crate) use health::ProviderEventSignal;
 #[cfg(test)]
 use mockall::automock;
 pub(crate) use raw::RawTransactionSender;

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -112,7 +112,6 @@ pub(crate) enum TxSenderError {
 /// Classification of a submission failure for poison user operation handling.
 ///
 /// See `docs/designs/poison-user-operations.md`.
-#[allow(dead_code)] // consumed once the bundle sender reports outcomes to the pool
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum RpcOutcomeClass {
     /// Final rejection; retrying the identical transaction cannot succeed.
@@ -126,7 +125,6 @@ pub(crate) enum RpcOutcomeClass {
 
 impl TxSenderError {
     /// Classifies this error for poison user operation handling.
-    #[allow(dead_code)] // consumed once the bundle sender reports outcomes to the pool
     pub(crate) fn classify(&self) -> RpcOutcomeClass {
         match self {
             TxSenderError::IntrinsicGasTooLow | TxSenderError::TerminalRpcError { .. } => {

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -35,7 +35,7 @@ use rundler_provider::{
     transaction::{self, TransactionSubmissionError},
 };
 use rundler_signer::SignerLease;
-use rundler_types::{ExpectedStorage, GasFees};
+use rundler_types::{ExpectedStorage, GasFees, chain::ChainSpec};
 use secrecy::SecretString;
 
 use crate::sender::polygon_private::PolygonPrivateSender;
@@ -81,8 +81,11 @@ pub(crate) enum TxSenderError {
     /// The provider rejected the transaction with an error response known to be
     /// terminal for this chain: retrying the identical transaction cannot succeed.
     ///
-    /// Currently produced for `-32000: internal error` on chains with
-    /// `ChainSpec::internal_rpc_error_is_terminal`.
+    /// Produced by [`TxSenderError::promote_terminal_error`] for `-32000: internal
+    /// error` on chains with `ChainSpec::internal_rpc_error_is_terminal`, and
+    /// unconditionally for `-32000: Transaction rejected by chain policy`
+    /// (Robinhood's unambiguous wording for the same rejection, unlike the
+    /// generic "internal error").
     #[error("terminal RPC error {code}: {message}")]
     TerminalRpcError {
         /// RPC error code.
@@ -155,15 +158,31 @@ impl TxSenderError {
         }
     }
 
-    /// On chains where the node emits `-32000: internal error` as a terminal
-    /// per-transaction rejection (`ChainSpec::internal_rpc_error_is_terminal`),
-    /// promotes that response from ambiguous to terminal.
-    pub(crate) fn promote_terminal_internal_error(self) -> Self {
+    /// Promotes an ambiguous `-32000: UnrecognizedRpc` response to
+    /// `TerminalRpcError` when its message is known to be a terminal,
+    /// per-transaction rejection rather than a transient or provider-health
+    /// condition.
+    ///
+    /// Two message shapes are recognized:
+    /// - `"internal error"` — only promoted on chains with
+    ///   `ChainSpec::internal_rpc_error_is_terminal`, since some providers also use
+    ///   this generic wording for transient outages.
+    /// - `"Transaction rejected by chain policy"` — Robinhood's unambiguous wording
+    ///   for the same rejection; promoted unconditionally, since no chain
+    ///   legitimately emits this phrase for a transient condition.
+    pub(crate) fn promote_terminal_error(self, chain_spec: &ChainSpec) -> Self {
         match self {
-            TxSenderError::UnrecognizedRpc { code, message }
-                if code == -32000 && message.trim().eq_ignore_ascii_case("internal error") =>
-            {
-                TxSenderError::TerminalRpcError { code, message }
+            TxSenderError::UnrecognizedRpc { code, message } if code == -32000 => {
+                let trimmed = message.trim();
+                let is_terminal = trimmed
+                    .eq_ignore_ascii_case("Transaction rejected by chain policy")
+                    || (chain_spec.internal_rpc_error_is_terminal
+                        && trimmed.eq_ignore_ascii_case("internal error"));
+                if is_terminal {
+                    TxSenderError::TerminalRpcError { code, message }
+                } else {
+                    TxSenderError::UnrecognizedRpc { code, message }
+                }
             }
             other => other,
         }
@@ -218,6 +237,7 @@ pub enum TransactionSenderKind {
 
 /// Transaction sender types
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum TransactionSenderArgs {
     /// Raw transaction sender
     Raw(RawSenderArgs),
@@ -238,8 +258,9 @@ pub struct RawSenderArgs {
     pub submit_url: String,
     /// If the sender should use the conditional endpoint
     pub use_conditional_rpc: bool,
-    /// If the chain emits `-32000: internal error` as a terminal rejection
-    pub internal_rpc_error_is_terminal: bool,
+    /// Chain spec, used to classify terminal RPC errors
+    /// (see `TxSenderError::promote_terminal_error`)
+    pub chain_spec: ChainSpec,
 }
 
 /// Bloxroute sender arguments
@@ -301,7 +322,7 @@ impl TransactionSenderArgs {
                 TransactionSenderEnum::Raw(RawTransactionSender::new(
                     submitter,
                     args.use_conditional_rpc,
-                    args.internal_rpc_error_is_terminal,
+                    args.chain_spec,
                 ))
             }
             Self::Flashbots(args) => TransactionSenderEnum::Flashbots(
@@ -420,6 +441,7 @@ impl From<TransactionSubmissionError> for TxSenderError {
 mod tests {
     use alloy_transport::TransportErrorKind;
     use rundler_provider::ProviderError;
+    use rundler_types::chain::ChainSpec;
 
     use super::{RpcOutcomeClass, TxSenderError};
 
@@ -483,12 +505,26 @@ mod tests {
             code: -32000,
             message: " Internal Error ".to_string(),
         }
-        .promote_terminal_internal_error();
+        .promote_terminal_error(&ChainSpec {
+            internal_rpc_error_is_terminal: true,
+            ..Default::default()
+        });
 
         assert!(matches!(
             error,
             TxSenderError::TerminalRpcError { code: -32000, .. }
         ));
+    }
+
+    #[test]
+    fn does_not_promote_internal_error_when_flag_unset() {
+        let error = TxSenderError::UnrecognizedRpc {
+            code: -32000,
+            message: "internal error".to_string(),
+        }
+        .promote_terminal_error(&ChainSpec::default());
+
+        assert!(matches!(error, TxSenderError::UnrecognizedRpc { .. }));
     }
 
     #[test]
@@ -504,10 +540,55 @@ mod tests {
             },
             TxSenderError::SenderUnavailable(anyhow::anyhow!("internal error")),
         ];
+        // Flagged as terminal-eligible so these cases fail on their own
+        // shape (wrong code, extra suffix, wrong variant), not the flag.
+        let chain_spec = ChainSpec {
+            internal_rpc_error_is_terminal: true,
+            ..Default::default()
+        };
 
         for error in cases {
             assert!(!matches!(
-                error.promote_terminal_internal_error(),
+                error.promote_terminal_error(&chain_spec),
+                TxSenderError::TerminalRpcError { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn promotes_chain_policy_rejection_to_terminal() {
+        let error = TxSenderError::UnrecognizedRpc {
+            code: -32000,
+            message: " transaction rejected by chain policy ".to_string(),
+        }
+        .promote_terminal_error(&ChainSpec::default());
+
+        assert!(matches!(
+            error,
+            TxSenderError::TerminalRpcError { code: -32000, .. }
+        ));
+    }
+
+    #[test]
+    fn does_not_promote_other_errors_as_chain_policy_rejection() {
+        let cases = [
+            TxSenderError::UnrecognizedRpc {
+                code: -32603,
+                message: "Transaction rejected by chain policy".to_string(),
+            },
+            TxSenderError::UnrecognizedRpc {
+                code: -32000,
+                message: "internal error".to_string(),
+            },
+            TxSenderError::SenderUnavailable(anyhow::anyhow!(
+                "Transaction rejected by chain policy"
+            )),
+        ];
+        let chain_spec = ChainSpec::default();
+
+        for error in cases {
+            assert!(!matches!(
+                error.promote_terminal_error(&chain_spec),
                 TxSenderError::TerminalRpcError { .. }
             ));
         }

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -129,6 +129,15 @@ impl TxSenderError {
     /// Classifies this error for poison user operation handling.
     pub(crate) fn classify(&self) -> RpcOutcomeClass {
         match self {
+            // Gas is estimated per-bundle from the included ops, so a low
+            // intrinsic gas limit is provably a function of what's in the
+            // bundle right now. Reclassifying this as Neutral wouldn't make
+            // it disappear: the same ops would be re-selected next round and
+            // reproduce the identical failure, livelocking the entrypoint.
+            // Terminal removal/suspicion of the offending op(s) is what
+            // breaks that loop - the exact case poison-op handling exists
+            // for - even though the failure surfaces on the bundle as a
+            // whole rather than a single attributable op.
             TxSenderError::IntrinsicGasTooLow | TxSenderError::TerminalRpcError { .. } => {
                 RpcOutcomeClass::Terminal
             }

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -71,14 +71,60 @@ pub(crate) enum TxSenderError {
     /// Insufficient funds for transaction
     #[error("insufficient funds for transaction")]
     InsufficientFunds,
-    /// Sender is unavailable due to an outage or unrecognized error.
+    /// Sender is unavailable due to an outage or transport error.
     ///
     /// When a fallback sender is configured this triggers failover.
     #[error("sender unavailable: {0}")]
     SenderUnavailable(anyhow::Error),
+    /// The provider returned an RPC error response that Rundler does not recognize.
+    ///
+    /// The node judged the transaction but the meaning is unknown, so acceptance is
+    /// ambiguous. When a fallback sender is configured this triggers failover.
+    #[error("unrecognized RPC error {code}: {message}")]
+    UnrecognizedRpc {
+        /// RPC error code.
+        code: i64,
+        /// RPC error message.
+        message: String,
+    },
     /// All other errors
     #[error(transparent)]
     Other(#[from] anyhow::Error),
+}
+
+/// Classification of a submission failure for poison user operation handling.
+///
+/// See `docs/designs/poison-user-operations.md`.
+#[allow(dead_code)] // consumed once the bundle sender reports outcomes to the pool
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RpcOutcomeClass {
+    /// Final rejection; retrying the identical transaction cannot succeed.
+    Terminal,
+    /// Transport failure, timeout, outage, or ambiguous rejection; acceptance unknown.
+    NonTerminal,
+    /// Known operational error with dedicated handling; evidence of neither user
+    /// operation poison nor provider health.
+    Neutral,
+}
+
+impl TxSenderError {
+    /// Classifies this error for poison user operation handling.
+    #[allow(dead_code)] // consumed once the bundle sender reports outcomes to the pool
+    pub(crate) fn classify(&self) -> RpcOutcomeClass {
+        match self {
+            TxSenderError::SenderUnavailable(_) | TxSenderError::UnrecognizedRpc { .. } => {
+                RpcOutcomeClass::NonTerminal
+            }
+            TxSenderError::Underpriced
+            | TxSenderError::ReplacementUnderpriced
+            | TxSenderError::NonceTooLow
+            | TxSenderError::ConditionNotMet
+            | TxSenderError::Rejected
+            | TxSenderError::SoftCancelFailed
+            | TxSenderError::InsufficientFunds
+            | TxSenderError::Other(_) => RpcOutcomeClass::Neutral,
+        }
+    }
 }
 
 pub(crate) type Result<T> = std::result::Result<T, TxSenderError>;
@@ -274,18 +320,15 @@ impl From<ProviderError> for TxSenderError {
                     if let Some(known) = parse_known_call_execution_failed(&e.message, e.code) {
                         return known;
                     }
-                    // Unrecognized RPC error: -32000s from us should be rare, so treat
-                    // as a provider outage and log for debugging.
                     tracing::warn!(
                         rpc_error_code = e.code,
                         rpc_error_message = %e.message,
-                        "Unrecognized RPC error from provider, treating as sender unavailable"
+                        "Unrecognized RPC error response from provider"
                     );
-                    TxSenderError::SenderUnavailable(anyhow::anyhow!(
-                        "unrecognized RPC error {}: {}",
-                        e.code,
-                        e.message
-                    ))
+                    TxSenderError::UnrecognizedRpc {
+                        code: e.code,
+                        message: e.message.to_string(),
+                    }
                 } else {
                     tracing::warn!(
                         error = ?value,

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -17,6 +17,8 @@ mod flashbots;
 mod polygon_private;
 mod raw;
 
+#[cfg(test)]
+use alloy_json_rpc::{ErrorPayload, RpcError};
 use alloy_primitives::{Address, B256};
 use anyhow::Context;
 pub(crate) use bloxroute::PolygonBloxrouteTransactionSender;
@@ -337,6 +339,16 @@ pub(crate) enum SenderConstructorErrors {
     Other(#[from] anyhow::Error),
 }
 
+/// Builds the `ProviderError` for a JSON-RPC error response, for tests.
+#[cfg(test)]
+pub(crate) fn rpc_error_response(code: i64, message: &str) -> ProviderError {
+    ProviderError::RPC(RpcError::ErrorResp(ErrorPayload {
+        code,
+        message: message.to_string().into(),
+        data: None,
+    }))
+}
+
 fn create_hard_cancel_tx(to: Address, nonce: u64, gas_fees: GasFees) -> TransactionRequest {
     TransactionRequest::default()
         .to(to)
@@ -397,7 +409,100 @@ impl From<TransactionSubmissionError> for TxSenderError {
 
 #[cfg(test)]
 mod tests {
-    use super::TxSenderError;
+    use alloy_transport::TransportErrorKind;
+    use rundler_provider::ProviderError;
+
+    use super::{RpcOutcomeClass, TxSenderError};
+
+    #[test]
+    fn classifies_rpc_outcomes() {
+        let cases = [
+            (TxSenderError::IntrinsicGasTooLow, RpcOutcomeClass::Terminal),
+            (
+                TxSenderError::TerminalRpcError {
+                    code: -32000,
+                    message: "internal error".to_string(),
+                },
+                RpcOutcomeClass::Terminal,
+            ),
+            (
+                TxSenderError::SenderUnavailable(anyhow::anyhow!("connection refused")),
+                RpcOutcomeClass::NonTerminal,
+            ),
+            (
+                TxSenderError::UnrecognizedRpc {
+                    code: -32000,
+                    message: "internal error".to_string(),
+                },
+                RpcOutcomeClass::NonTerminal,
+            ),
+            (TxSenderError::Underpriced, RpcOutcomeClass::Neutral),
+            (TxSenderError::NonceTooLow, RpcOutcomeClass::Neutral),
+            (
+                TxSenderError::Other(anyhow::anyhow!("signing failed")),
+                RpcOutcomeClass::Neutral,
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.classify(), expected, "error: {error}");
+        }
+    }
+
+    #[test]
+    fn maps_unrecognized_rpc_response_to_unrecognized_rpc() {
+        let error = TxSenderError::from(super::rpc_error_response(-32000, "internal error"));
+
+        assert!(matches!(
+            error,
+            TxSenderError::UnrecognizedRpc { code: -32000, ref message } if message == "internal error"
+        ));
+    }
+
+    #[test]
+    fn maps_transport_failure_to_sender_unavailable() {
+        let error = TxSenderError::from(ProviderError::RPC(TransportErrorKind::custom_str(
+            "connection refused",
+        )));
+
+        assert!(matches!(error, TxSenderError::SenderUnavailable(_)));
+    }
+
+    #[test]
+    fn promotes_internal_error_to_terminal() {
+        let error = TxSenderError::UnrecognizedRpc {
+            code: -32000,
+            message: " Internal Error ".to_string(),
+        }
+        .promote_terminal_internal_error();
+
+        assert!(matches!(
+            error,
+            TxSenderError::TerminalRpcError { code: -32000, .. }
+        ));
+    }
+
+    #[test]
+    fn does_not_promote_other_errors() {
+        let cases = [
+            TxSenderError::UnrecognizedRpc {
+                code: -32603,
+                message: "internal error".to_string(),
+            },
+            TxSenderError::UnrecognizedRpc {
+                code: -32000,
+                message: "internal error: tx pool full".to_string(),
+            },
+            TxSenderError::SenderUnavailable(anyhow::anyhow!("internal error")),
+        ];
+
+        for error in cases {
+            assert!(!matches!(
+                error.promote_terminal_internal_error(),
+                TxSenderError::TerminalRpcError { .. }
+            ));
+        }
+    }
 
     #[test]
     fn parses_cronos_invalid_sequence_as_nonce_too_low() {

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -74,6 +74,18 @@ pub(crate) enum TxSenderError {
     /// Transaction gas limit is below its intrinsic gas cost
     #[error("intrinsic gas too low")]
     IntrinsicGasTooLow,
+    /// The provider rejected the transaction with an error response known to be
+    /// terminal for this chain: retrying the identical transaction cannot succeed.
+    ///
+    /// Currently produced for `-32000: internal error` on chains with
+    /// `ChainSpec::internal_rpc_error_is_terminal`.
+    #[error("terminal RPC error {code}: {message}")]
+    TerminalRpcError {
+        /// RPC error code.
+        code: i64,
+        /// RPC error message.
+        message: String,
+    },
     /// Sender is unavailable due to an outage or transport error.
     ///
     /// When a fallback sender is configured this triggers failover.
@@ -115,7 +127,9 @@ impl TxSenderError {
     #[allow(dead_code)] // consumed once the bundle sender reports outcomes to the pool
     pub(crate) fn classify(&self) -> RpcOutcomeClass {
         match self {
-            TxSenderError::IntrinsicGasTooLow => RpcOutcomeClass::Terminal,
+            TxSenderError::IntrinsicGasTooLow | TxSenderError::TerminalRpcError { .. } => {
+                RpcOutcomeClass::Terminal
+            }
             TxSenderError::SenderUnavailable(_) | TxSenderError::UnrecognizedRpc { .. } => {
                 RpcOutcomeClass::NonTerminal
             }
@@ -127,6 +141,20 @@ impl TxSenderError {
             | TxSenderError::SoftCancelFailed
             | TxSenderError::InsufficientFunds
             | TxSenderError::Other(_) => RpcOutcomeClass::Neutral,
+        }
+    }
+
+    /// On chains where the node emits `-32000: internal error` as a terminal
+    /// per-transaction rejection (`ChainSpec::internal_rpc_error_is_terminal`),
+    /// promotes that response from ambiguous to terminal.
+    pub(crate) fn promote_terminal_internal_error(self) -> Self {
+        match self {
+            TxSenderError::UnrecognizedRpc { code, message }
+                if code == -32000 && message.trim().eq_ignore_ascii_case("internal error") =>
+            {
+                TxSenderError::TerminalRpcError { code, message }
+            }
+            other => other,
         }
     }
 }
@@ -199,6 +227,8 @@ pub struct RawSenderArgs {
     pub submit_url: String,
     /// If the sender should use the conditional endpoint
     pub use_conditional_rpc: bool,
+    /// If the chain emits `-32000: internal error` as a terminal rejection
+    pub internal_rpc_error_is_terminal: bool,
 }
 
 /// Bloxroute sender arguments
@@ -260,6 +290,7 @@ impl TransactionSenderArgs {
                 TransactionSenderEnum::Raw(RawTransactionSender::new(
                     submitter,
                     args.use_conditional_rpc,
+                    args.internal_rpc_error_is_terminal,
                 ))
             }
             Self::Flashbots(args) => TransactionSenderEnum::Flashbots(

--- a/crates/builder/src/sender/raw.rs
+++ b/crates/builder/src/sender/raw.rs
@@ -14,18 +14,19 @@
 use alloy_primitives::B256;
 use anyhow::Context;
 use async_trait::async_trait;
-use rundler_provider::{EvmProvider, TransactionRequest};
+use rundler_provider::{EvmProvider, ProviderError, TransactionRequest};
 use rundler_signer::SignerLease;
 use rundler_types::{ExpectedStorage, GasFees};
 use serde_json::json;
 
 use super::{CancelTxInfo, Result};
-use crate::sender::{TransactionSender, create_hard_cancel_tx};
+use crate::sender::{TransactionSender, TxSenderError, create_hard_cancel_tx};
 
 #[derive(Debug)]
 pub(crate) struct RawTransactionSender<P> {
     submit_provider: P,
     use_conditional_rpc: bool,
+    internal_rpc_error_is_terminal: bool,
 }
 
 #[async_trait]
@@ -44,18 +45,18 @@ where
             .await
             .context("failed to sign transaction")?;
 
-        let tx_hash = if self.use_conditional_rpc {
+        let result = if self.use_conditional_rpc {
             self.submit_provider
                 .request(
                     "eth_sendRawTransactionConditional",
                     (raw_tx, json!({ "knownAccounts": expected_storage })),
                 )
-                .await?
+                .await
         } else {
-            self.submit_provider.send_raw_transaction(raw_tx).await?
+            self.submit_provider.send_raw_transaction(raw_tx).await
         };
 
-        Ok(tx_hash)
+        result.map_err(|e| self.map_provider_error(e))
     }
 
     async fn cancel_transaction(
@@ -72,7 +73,11 @@ where
             .await
             .context("failed to sign transaction")?;
 
-        let tx_hash = self.submit_provider.send_raw_transaction(raw_tx).await?;
+        let tx_hash = self
+            .submit_provider
+            .send_raw_transaction(raw_tx)
+            .await
+            .map_err(|e| self.map_provider_error(e))?;
 
         Ok(CancelTxInfo {
             tx_hash,
@@ -82,10 +87,24 @@ where
 }
 
 impl<P> RawTransactionSender<P> {
-    pub(crate) fn new(submit_provider: P, use_conditional_rpc: bool) -> Self {
+    pub(crate) fn new(
+        submit_provider: P,
+        use_conditional_rpc: bool,
+        internal_rpc_error_is_terminal: bool,
+    ) -> Self {
         Self {
             submit_provider,
             use_conditional_rpc,
+            internal_rpc_error_is_terminal,
+        }
+    }
+
+    fn map_provider_error(&self, error: ProviderError) -> TxSenderError {
+        let error = TxSenderError::from(error);
+        if self.internal_rpc_error_is_terminal {
+            error.promote_terminal_internal_error()
+        } else {
+            error
         }
     }
 }

--- a/crates/builder/src/sender/raw.rs
+++ b/crates/builder/src/sender/raw.rs
@@ -16,7 +16,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use rundler_provider::{EvmProvider, ProviderError, TransactionRequest};
 use rundler_signer::SignerLease;
-use rundler_types::{ExpectedStorage, GasFees};
+use rundler_types::{ExpectedStorage, GasFees, chain::ChainSpec};
 use serde_json::json;
 
 use super::{CancelTxInfo, Result};
@@ -26,7 +26,7 @@ use crate::sender::{TransactionSender, TxSenderError, create_hard_cancel_tx};
 pub(crate) struct RawTransactionSender<P> {
     submit_provider: P,
     use_conditional_rpc: bool,
-    internal_rpc_error_is_terminal: bool,
+    chain_spec: ChainSpec,
 }
 
 #[async_trait]
@@ -90,22 +90,17 @@ impl<P> RawTransactionSender<P> {
     pub(crate) fn new(
         submit_provider: P,
         use_conditional_rpc: bool,
-        internal_rpc_error_is_terminal: bool,
+        chain_spec: ChainSpec,
     ) -> Self {
         Self {
             submit_provider,
             use_conditional_rpc,
-            internal_rpc_error_is_terminal,
+            chain_spec,
         }
     }
 
     fn map_provider_error(&self, error: ProviderError) -> TxSenderError {
-        let error = TxSenderError::from(error);
-        if self.internal_rpc_error_is_terminal {
-            error.promote_terminal_internal_error()
-        } else {
-            error
-        }
+        TxSenderError::from(error).promote_terminal_error(&self.chain_spec)
     }
 }
 
@@ -116,18 +111,51 @@ mod tests {
     use super::*;
     use crate::sender::rpc_error_response;
 
+    fn chain_spec_with_internal_error_terminal(internal_rpc_error_is_terminal: bool) -> ChainSpec {
+        ChainSpec {
+            internal_rpc_error_is_terminal,
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn promotes_internal_error_only_when_flagged() {
-        let flagged = RawTransactionSender::new(MockEvmProvider::new(), false, true);
+        let flagged = RawTransactionSender::new(
+            MockEvmProvider::new(),
+            false,
+            chain_spec_with_internal_error_terminal(true),
+        );
         assert!(matches!(
             flagged.map_provider_error(rpc_error_response(-32000, "internal error")),
             TxSenderError::TerminalRpcError { .. }
         ));
 
-        let unflagged = RawTransactionSender::new(MockEvmProvider::new(), false, false);
+        let unflagged = RawTransactionSender::new(
+            MockEvmProvider::new(),
+            false,
+            chain_spec_with_internal_error_terminal(false),
+        );
         assert!(matches!(
             unflagged.map_provider_error(rpc_error_response(-32000, "internal error")),
             TxSenderError::UnrecognizedRpc { .. }
         ));
+    }
+
+    #[test]
+    fn promotes_chain_policy_rejection_regardless_of_flag() {
+        for internal_rpc_error_is_terminal in [false, true] {
+            let sender = RawTransactionSender::new(
+                MockEvmProvider::new(),
+                false,
+                chain_spec_with_internal_error_terminal(internal_rpc_error_is_terminal),
+            );
+            assert!(matches!(
+                sender.map_provider_error(rpc_error_response(
+                    -32000,
+                    "Transaction rejected by chain policy"
+                )),
+                TxSenderError::TerminalRpcError { .. }
+            ));
+        }
     }
 }

--- a/crates/builder/src/sender/raw.rs
+++ b/crates/builder/src/sender/raw.rs
@@ -108,3 +108,26 @@ impl<P> RawTransactionSender<P> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rundler_provider::MockEvmProvider;
+
+    use super::*;
+    use crate::sender::rpc_error_response;
+
+    #[test]
+    fn promotes_internal_error_only_when_flagged() {
+        let flagged = RawTransactionSender::new(MockEvmProvider::new(), false, true);
+        assert!(matches!(
+            flagged.map_provider_error(rpc_error_response(-32000, "internal error")),
+            TxSenderError::TerminalRpcError { .. }
+        ));
+
+        let unflagged = RawTransactionSender::new(MockEvmProvider::new(), false, false);
+        assert!(matches!(
+            unflagged.map_provider_error(rpc_error_response(-32000, "internal error")),
+            TxSenderError::UnrecognizedRpc { .. }
+        ));
+    }
+}

--- a/crates/builder/src/task.rs
+++ b/crates/builder/src/task.rs
@@ -47,7 +47,7 @@ use crate::{
     bundle_sender::{self, BundleSender, BundleSenderAction, BundleSenderImpl},
     delegation_sender::{DelegationSenderTask, Settings as DelegationSettings},
     emit::BuilderEvent,
-    sender::TransactionSenderArgs,
+    sender::{ProviderEventSignal, TransactionSenderArgs},
     server::{self, LocalBuilderBuilder},
     transaction_tracker::{self, TransactionTrackerImpl},
 };
@@ -487,6 +487,10 @@ where
             }),
         );
 
+        // All builders submit through the same route (sender_args), so they
+        // share one provider-health signal.
+        let provider_event_signal = Arc::new(ProviderEventSignal::default());
+
         let mut bundle_sender_actions = vec![];
         for i in 0..self.args.num_signers {
             let bundle_sender_action = self
@@ -497,6 +501,7 @@ where
                     proposers.clone(),
                     i as usize,
                     heads_tx.subscribe(),
+                    provider_event_signal.clone(),
                 )
                 .await?;
             bundle_sender_actions.push(bundle_sender_action);
@@ -504,6 +509,7 @@ where
         Ok((bundle_sender_actions, heads_tx))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn create_bundle_builder<T>(
         &self,
         task_spawner: &T,
@@ -512,6 +518,7 @@ where
         proposers: Arc<HashMap<ProposerKey, Box<dyn BundleProposerT>>>,
         index: usize,
         heads_rx: broadcast::Receiver<Arc<NewHead>>,
+        provider_event_signal: Arc<ProviderEventSignal>,
     ) -> anyhow::Result<mpsc::Sender<BundleSenderAction>>
     where
         T: TaskSpawnerExt,
@@ -559,6 +566,7 @@ where
             self.pool.clone(),
             sender_settings,
             self.event_sender.clone(),
+            provider_event_signal,
         );
 
         // Spawn each sender as its own independent task

--- a/crates/builder/src/transaction_tracker.rs
+++ b/crates/builder/src/transaction_tracker.rs
@@ -117,6 +117,9 @@ pub(crate) enum TransactionTrackerError {
     Rejected,
     #[error("insufficient funds")]
     InsufficientFunds,
+    /// The transaction's gas limit is below its intrinsic gas cost.
+    #[error("intrinsic gas too low")]
+    IntrinsicGasTooLow,
     /// The sender is unavailable due to an outage or transport error; acceptance
     /// of the transaction is unknown.
     #[error("sender unavailable: {0}")]
@@ -703,6 +706,7 @@ impl From<TxSenderError> for TransactionTrackerError {
             TxSenderError::ConditionNotMet => TransactionTrackerError::ConditionNotMet,
             TxSenderError::Rejected => TransactionTrackerError::Rejected,
             TxSenderError::InsufficientFunds => TransactionTrackerError::InsufficientFunds,
+            TxSenderError::IntrinsicGasTooLow => TransactionTrackerError::IntrinsicGasTooLow,
             TxSenderError::SoftCancelFailed => {
                 TransactionTrackerError::Other(anyhow::anyhow!("soft cancel failed"))
             }

--- a/crates/builder/src/transaction_tracker.rs
+++ b/crates/builder/src/transaction_tracker.rs
@@ -105,44 +105,10 @@ pub(crate) trait TransactionTracker: Send + Sync {
 /// Errors that can occur while using a `TransactionTracker`.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum TransactionTrackerError {
-    #[error("nonce too low")]
-    NonceTooLow,
-    #[error("transaction underpriced")]
-    Underpriced,
-    #[error("replacement transaction underpriced")]
-    ReplacementUnderpriced,
-    #[error("storage slot value condition not met")]
-    ConditionNotMet,
-    #[error("rejected")]
-    Rejected,
-    #[error("insufficient funds")]
-    InsufficientFunds,
-    /// The transaction's gas limit is below its intrinsic gas cost.
-    #[error("intrinsic gas too low")]
-    IntrinsicGasTooLow,
-    /// The provider rejected the transaction with an error response known to be
-    /// terminal for this chain: retrying the identical transaction cannot succeed.
-    #[error("terminal RPC error {code}: {message}")]
-    TerminalRpcError {
-        /// RPC error code.
-        code: i64,
-        /// RPC error message.
-        message: String,
-    },
-    /// The sender is unavailable due to an outage or transport error; acceptance
-    /// of the transaction is unknown.
-    #[error("sender unavailable: {0}")]
-    SenderUnavailable(anyhow::Error),
-    /// The provider returned an RPC error response that Rundler does not recognize;
-    /// acceptance of the transaction is unknown.
-    #[error("unrecognized RPC error {code}: {message}")]
-    UnrecognizedRpc {
-        /// RPC error code.
-        code: i64,
-        /// RPC error message.
-        message: String,
-    },
-    /// All other errors
+    /// The sender failed to submit or rejected the transaction.
+    #[error(transparent)]
+    Sender(#[from] TxSenderError),
+    /// Tracker-local failures (validation, signer acquisition, chain reads).
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -544,7 +510,9 @@ where
                     });
                 };
 
-                Err(TransactionTrackerError::ReplacementUnderpriced)
+                Err(TransactionTrackerError::Sender(
+                    TxSenderError::ReplacementUnderpriced,
+                ))
             }
             Err(e) => Err(e.into()),
         }
@@ -701,33 +669,6 @@ where
             return true;
         }
         false
-    }
-}
-
-impl From<TxSenderError> for TransactionTrackerError {
-    fn from(value: TxSenderError) -> Self {
-        match value {
-            TxSenderError::NonceTooLow => TransactionTrackerError::NonceTooLow,
-            TxSenderError::Underpriced => TransactionTrackerError::Underpriced,
-            TxSenderError::ReplacementUnderpriced => {
-                TransactionTrackerError::ReplacementUnderpriced
-            }
-            TxSenderError::ConditionNotMet => TransactionTrackerError::ConditionNotMet,
-            TxSenderError::Rejected => TransactionTrackerError::Rejected,
-            TxSenderError::InsufficientFunds => TransactionTrackerError::InsufficientFunds,
-            TxSenderError::IntrinsicGasTooLow => TransactionTrackerError::IntrinsicGasTooLow,
-            TxSenderError::TerminalRpcError { code, message } => {
-                TransactionTrackerError::TerminalRpcError { code, message }
-            }
-            TxSenderError::SoftCancelFailed => {
-                TransactionTrackerError::Other(anyhow::anyhow!("soft cancel failed"))
-            }
-            TxSenderError::SenderUnavailable(e) => TransactionTrackerError::SenderUnavailable(e),
-            TxSenderError::UnrecognizedRpc { code, message } => {
-                TransactionTrackerError::UnrecognizedRpc { code, message }
-            }
-            TxSenderError::Other(e) => TransactionTrackerError::Other(e),
-        }
     }
 }
 
@@ -1093,7 +1034,7 @@ mod tests {
 
         assert!(matches!(
             sent_transaction,
-            Err(TransactionTrackerError::Underpriced)
+            Err(TransactionTrackerError::Sender(TxSenderError::Underpriced))
         ));
         assert_eq!(tracker.num_pending_transactions(), 0);
         assert_eq!(
@@ -1124,7 +1065,9 @@ mod tests {
 
         assert!(matches!(
             sent_transaction,
-            Err(TransactionTrackerError::ReplacementUnderpriced)
+            Err(TransactionTrackerError::Sender(
+                TxSenderError::ReplacementUnderpriced
+            ))
         ));
         assert_eq!(tracker.num_pending_transactions(), 0);
         assert_eq!(

--- a/crates/builder/src/transaction_tracker.rs
+++ b/crates/builder/src/transaction_tracker.rs
@@ -117,6 +117,19 @@ pub(crate) enum TransactionTrackerError {
     Rejected,
     #[error("insufficient funds")]
     InsufficientFunds,
+    /// The sender is unavailable due to an outage or transport error; acceptance
+    /// of the transaction is unknown.
+    #[error("sender unavailable: {0}")]
+    SenderUnavailable(anyhow::Error),
+    /// The provider returned an RPC error response that Rundler does not recognize;
+    /// acceptance of the transaction is unknown.
+    #[error("unrecognized RPC error {code}: {message}")]
+    UnrecognizedRpc {
+        /// RPC error code.
+        code: i64,
+        /// RPC error message.
+        message: String,
+    },
     /// All other errors
     #[error(transparent)]
     Other(#[from] anyhow::Error),
@@ -693,9 +706,10 @@ impl From<TxSenderError> for TransactionTrackerError {
             TxSenderError::SoftCancelFailed => {
                 TransactionTrackerError::Other(anyhow::anyhow!("soft cancel failed"))
             }
-            // SenderUnavailable reaching here means no fallback is configured; treat
-            // it as a transient error so the bundle sender retries next cycle.
-            TxSenderError::SenderUnavailable(e) => TransactionTrackerError::Other(e),
+            TxSenderError::SenderUnavailable(e) => TransactionTrackerError::SenderUnavailable(e),
+            TxSenderError::UnrecognizedRpc { code, message } => {
+                TransactionTrackerError::UnrecognizedRpc { code, message }
+            }
             TxSenderError::Other(e) => TransactionTrackerError::Other(e),
         }
     }

--- a/crates/builder/src/transaction_tracker.rs
+++ b/crates/builder/src/transaction_tracker.rs
@@ -120,6 +120,15 @@ pub(crate) enum TransactionTrackerError {
     /// The transaction's gas limit is below its intrinsic gas cost.
     #[error("intrinsic gas too low")]
     IntrinsicGasTooLow,
+    /// The provider rejected the transaction with an error response known to be
+    /// terminal for this chain: retrying the identical transaction cannot succeed.
+    #[error("terminal RPC error {code}: {message}")]
+    TerminalRpcError {
+        /// RPC error code.
+        code: i64,
+        /// RPC error message.
+        message: String,
+    },
     /// The sender is unavailable due to an outage or transport error; acceptance
     /// of the transaction is unknown.
     #[error("sender unavailable: {0}")]
@@ -707,6 +716,9 @@ impl From<TxSenderError> for TransactionTrackerError {
             TxSenderError::Rejected => TransactionTrackerError::Rejected,
             TxSenderError::InsufficientFunds => TransactionTrackerError::InsufficientFunds,
             TxSenderError::IntrinsicGasTooLow => TransactionTrackerError::IntrinsicGasTooLow,
+            TxSenderError::TerminalRpcError { code, message } => {
+                TransactionTrackerError::TerminalRpcError { code, message }
+            }
             TxSenderError::SoftCancelFailed => {
                 TransactionTrackerError::Other(anyhow::anyhow!("soft cancel failed"))
             }

--- a/crates/pool/Cargo.toml
+++ b/crates/pool/Cargo.toml
@@ -24,6 +24,7 @@ metrics.workspace = true
 metrics-derive.workspace = true
 parking_lot.workspace = true
 prost.workspace = true
+rand.workspace = true
 rundler-contracts.workspace = true
 rundler-provider.workspace = true
 rundler-sim.workspace = true

--- a/crates/pool/proto/op_pool/op_pool.proto
+++ b/crates/pool/proto/op_pool/op_pool.proto
@@ -228,6 +228,9 @@ message PoolOperationSummary {
   bytes gas_limit = 7;
   // Maximum WEI the bundler will pay (empty if not sponsored)
   bytes bundler_sponsorship_max_cost = 8;
+  // Whether the operation is suspected of poisoning bundles and must only be
+  // submitted alone
+  bool suspect = 9;
 }
 
 // Data associated with a user operation for DA gas calculations
@@ -318,6 +321,10 @@ service OpPool {
   // Notify the pool about a pending bundle transaction
   rpc NotifyPendingBundle(NotifyPendingBundleRequest) returns (NotifyPendingBundleResponse);
 
+  // Report the final outcome of a bundle submission attempt, for poison
+  // user operation tracking
+  rpc ReportBundleOutcome(ReportBundleOutcomeRequest) returns (ReportBundleOutcomeResponse);
+
   // Get extended status for a user operation
   rpc GetOpStatus(GetOpStatusRequest) returns (GetOpStatusResponse);
 }
@@ -366,13 +373,16 @@ message GetOpsSuccess {
   repeated MempoolOp ops = 1;
 }
 
-message GetOpsSummariesRequest {  
+message GetOpsSummariesRequest {
   // The serialized entry point address
   bytes entry_point = 1;
-  // The maximum number of UserOperations to return
+  // The maximum number of non-suspect UserOperations to return
   uint64 max_ops = 2;
-  // The filter ID to apply to the UserOperations 
+  // The filter ID to apply to the UserOperations
   string filter_id = 3;
+  // The maximum number of due suspect UserOperations to return, in addition
+  // to `max_ops`
+  uint64 max_suspects = 4;
 }
 message GetOpsSummariesResponse {
   oneof result {
@@ -644,6 +654,38 @@ message NotifyPendingBundleResponse {
   }
 }
 message NotifyPendingBundleSuccess {}
+
+// Final outcome of a bundle submission attempt, for poison user operation
+// tracking
+enum BundleOutcome {
+  BUNDLE_OUTCOME_UNSPECIFIED = 0;
+  // The bundle transaction was accepted by the provider
+  BUNDLE_OUTCOME_SUCCESS = 1;
+  // Transport failure, timeout, or ambiguous rejection; acceptance unknown
+  BUNDLE_OUTCOME_NON_TERMINAL_FAILURE = 2;
+  // Final rejection; retrying the identical transaction cannot succeed
+  BUNDLE_OUTCOME_TERMINAL_FAILURE = 3;
+  // Mark every operation in the bundle as suspect
+  BUNDLE_OUTCOME_MARK_SUSPECT = 4;
+}
+
+message ReportBundleOutcomeRequest {
+  // The serialized entry point address
+  bytes entry_point = 1;
+  // The serialized UserOperation hashes in the bundle
+  repeated bytes hashes = 2;
+  // The outcome of the bundle submission attempt
+  BundleOutcome outcome = 3;
+  // Whether a provider health event was active at submission time
+  bool provider_event_active = 4;
+}
+message ReportBundleOutcomeResponse {
+  oneof result {
+    ReportBundleOutcomeSuccess success = 1;
+    MempoolError failure = 2;
+  }
+}
+message ReportBundleOutcomeSuccess {}
 
 message GetOpStatusRequest {
   bytes hash = 1;

--- a/crates/pool/src/emit.rs
+++ b/crates/pool/src/emit.rs
@@ -103,7 +103,7 @@ pub enum EntityReputation {
 }
 
 /// Reason an operation was removed from the pool
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum OpRemovalReason {
     /// Removal was requested
     Requested,

--- a/crates/pool/src/emit.rs
+++ b/crates/pool/src/emit.rs
@@ -47,6 +47,18 @@ pub enum OpPoolEvent {
         /// Removal reason
         reason: OpRemovalReason,
     },
+    /// An operation was marked as a poison-UO suspect
+    MarkedSuspect {
+        /// Operation hash
+        op_hash: B256,
+        /// What triggered the suspicion
+        trigger: SuspectTrigger,
+    },
+    /// A suspect operation was cleared by a successful submission
+    SuspectCleared {
+        /// Operation hash
+        op_hash: B256,
+    },
     /// All operations for an entity were removed from the pool
     RemovedEntity {
         /// The removed entity
@@ -154,6 +166,18 @@ pub enum OpRemovalReason {
     RepeatedNonTerminalRpcFailure,
 }
 
+/// What triggered a UO being marked suspect. See
+/// `docs/designs/poison-user-operations.md`.
+#[derive(Clone, Copy, Debug)]
+pub enum SuspectTrigger {
+    /// An ambiguous multi-UO failure (unattributed mined revert or terminal
+    /// RPC error on a bundle of more than one op) forced suspicion
+    /// immediately.
+    MultiOpFailure,
+    /// The non-terminal RPC failure counter reached the suspect threshold.
+    Threshold,
+}
+
 impl EntitySummary {
     pub fn set_status(&mut self, kind: EntityType, status: EntityStatus) {
         match kind {
@@ -207,6 +231,20 @@ impl Display for OpPoolEvent {
                     }
                     _ => write!(f, "    Reason: {:?}", reason),
                 }
+            }
+            OpPoolEvent::MarkedSuspect { op_hash, trigger } => {
+                write!(
+                    f,
+                    "Marked op as poison UO suspect.    Op hash: {:?}    Trigger: {:?}",
+                    op_hash, trigger
+                )
+            }
+            OpPoolEvent::SuspectCleared { op_hash } => {
+                write!(
+                    f,
+                    "Cleared poison UO suspect status.    Op hash: {:?}",
+                    op_hash
+                )
             }
             OpPoolEvent::RemovedEntity { entity } => {
                 write!(

--- a/crates/pool/src/emit.rs
+++ b/crates/pool/src/emit.rs
@@ -146,6 +146,12 @@ pub enum OpRemovalReason {
         /// Hash of the new operation that replaced this one
         replaced_by: B256,
     },
+    /// Op was removed because the provider terminally rejected its
+    /// single-operation bundle
+    TerminalRpcError,
+    /// Op was removed because, while isolated as a suspect, it repeatedly
+    /// failed submission with non-terminal RPC errors
+    RepeatedNonTerminalRpcFailure,
 }
 
 impl EntitySummary {

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -108,8 +108,10 @@ pub(crate) trait Mempool: Send + Sync {
     /// Reports the final outcome of a bundle submission attempt for the given
     /// operations, for poison user operation tracking.
     ///
-    /// While `provider_event_active` is true, a non-terminal failure is not
-    /// evidence against its operations and changes no operation state.
+    /// While `provider_event_active` is true, suspect analysis continues but
+    /// removal progress pauses: non-terminal failures still count toward
+    /// suspicion, while suspects only refresh their isolation backoff and
+    /// never advance toward removal.
     fn report_bundle_outcome(
         &self,
         ops: &[B256],

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -108,8 +108,8 @@ pub(crate) trait Mempool: Send + Sync {
     /// Reports the final outcome of a bundle submission attempt for the given
     /// operations, for poison user operation tracking.
     ///
-    /// While `provider_event_active` is true, non-terminal failures do not
-    /// advance the failure counts of non-suspect operations.
+    /// While `provider_event_active` is true, a non-terminal failure is not
+    /// evidence against its operations and changes no operation state.
     fn report_bundle_outcome(
         &self,
         ops: &[B256],

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -38,8 +38,8 @@ use rundler_types::{
     UserOperationVariant,
     chain::ChainSpec,
     pool::{
-        MempoolError, PaymasterMetadata, PoolOperation, PoolOperationStatus, Reputation,
-        ReputationStatus, StakeStatus,
+        BundleOutcome, MempoolError, PaymasterMetadata, PoolOperation, PoolOperationStatus,
+        Reputation, ReputationStatus, StakeStatus,
     },
 };
 use tonic::async_trait;
@@ -92,6 +92,30 @@ pub(crate) trait Mempool: Send + Sync {
         max: usize,
         filter_id: Option<String>,
     ) -> MempoolResult<Vec<Arc<PoolOperation>>>;
+
+    /// Returns suspect operations whose isolation retry delay has elapsed,
+    /// best first, up to `max` operations.
+    ///
+    /// Suspects are excluded from `best_operations` and must only be submitted
+    /// in single-operation bundles. See
+    /// `docs/designs/poison-user-operations.md`.
+    fn due_suspect_operations(
+        &self,
+        max: usize,
+        filter_id: Option<String>,
+    ) -> MempoolResult<Vec<Arc<PoolOperation>>>;
+
+    /// Reports the final outcome of a bundle submission attempt for the given
+    /// operations, for poison user operation tracking.
+    ///
+    /// While `provider_event_active` is true, non-terminal failures do not
+    /// advance the failure counts of non-suspect operations.
+    fn report_bundle_outcome(
+        &self,
+        ops: &[B256],
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+    );
 
     /// Returns the all operations from the pool up to a max size
     fn all_operations(&self, max: usize) -> Vec<Arc<PoolOperation>>;
@@ -192,6 +216,15 @@ pub struct PoolConfig {
     pub max_time_in_pool: Option<Duration>,
     /// The maximum number of storage slots that can be expected to be used by a user operation during validation
     pub max_expected_storage_slots: usize,
+    /// Number of non-terminal RPC submission failures before a user operation becomes a suspect
+    pub rpc_failures_before_suspect: u32,
+    /// Number of non-terminal RPC submission failures a suspect is allowed before removal.
+    /// 0 disables removal.
+    pub max_suspect_rpc_failures: u32,
+    /// Initial backoff delay between suspect isolation attempts
+    pub suspect_rpc_backoff_initial: Duration,
+    /// Maximum backoff delay between suspect isolation attempts
+    pub suspect_rpc_backoff_max: Duration,
 }
 
 /// Origin of an operation.

--- a/crates/pool/src/mempool/mod.rs
+++ b/crates/pool/src/mempool/mod.rs
@@ -218,6 +218,10 @@ pub struct PoolConfig {
     pub max_time_in_pool: Option<Duration>,
     /// The maximum number of storage slots that can be expected to be used by a user operation during validation
     pub max_expected_storage_slots: usize,
+    /// Master switch for poison user operation handling. When disabled, bundle
+    /// outcomes change no operation state and no operation is ever suspected or
+    /// removed by that flow.
+    pub suspect_tracking_enabled: bool,
     /// Number of non-terminal RPC submission failures before a user operation becomes a suspect
     pub rpc_failures_before_suspect: u32,
     /// Number of non-terminal RPC submission failures a suspect is allowed before removal.

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -286,10 +286,11 @@ where
                     let Some(op) = self.by_hash.get(hash) else {
                         continue;
                     };
-                    // While a provider event is active only suspects accrue
-                    // failures: suspect removal is protected by backoff-spaced
-                    // evidence rather than by outage detection.
-                    if !op.is_suspect(suspect_threshold) && provider_event_active {
+                    // A failure during a provider event is not evidence against
+                    // the op: treat the submission as if it never happened.
+                    // Retry pacing during an event is left to normal submission
+                    // cadence and provider rate limiting.
+                    if provider_event_active {
                         continue;
                     }
                     let failures = op.record_failure(
@@ -2172,8 +2173,11 @@ mod tests {
     }
 
     #[test]
-    fn provider_event_pauses_pre_suspect_counting_only() {
-        let mut pool = pool();
+    fn provider_event_pauses_failure_counting() {
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_rpc_backoff_initial: Duration::from_secs(10),
+            ..conf()
+        });
         let non_suspect = pool
             .add_operation(create_op(Address::random(), 0, 1), 0, 0)
             .unwrap();
@@ -2182,21 +2186,15 @@ mod tests {
             .unwrap();
         pool.by_hash[&suspect].mark_suspect(3);
 
-        pool.apply_bundle_outcome(
-            &[non_suspect],
-            BundleOutcome::NonTerminalFailure,
-            true,
-            Instant::now(),
-        );
-        pool.apply_bundle_outcome(
-            &[suspect],
-            BundleOutcome::NonTerminalFailure,
-            true,
-            Instant::now(),
-        );
+        let now = Instant::now();
+        pool.apply_bundle_outcome(&[non_suspect], BundleOutcome::NonTerminalFailure, true, now);
+        pool.apply_bundle_outcome(&[suspect], BundleOutcome::NonTerminalFailure, true, now);
 
+        // a failure during a provider event changes no UO state
         assert_eq!(pool.by_hash[&non_suspect].failures(), 0);
-        assert_eq!(pool.by_hash[&suspect].failures(), 4);
+        assert_eq!(pool.by_hash[&suspect].failures(), 3);
+        assert!(pool.by_hash[&non_suspect].retry_due(now));
+        assert!(pool.by_hash[&suspect].retry_due(now));
     }
 
     #[test]

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -796,6 +796,12 @@ where
         self.count_by_address.clear();
         self.pool_size = SizeTracker::default();
         self.cache_size = SizeTracker::default();
+        // Every op (suspect or not) is gone, so the suspect gauge is
+        // unconditionally 0 - unlike the removal path, which decrements by
+        // one because it knows exactly one op with a known suspect status
+        // left, a bulk clear doesn't track how many of the cleared ops were
+        // suspects, so set rather than decrement.
+        self.metrics.num_suspect_ops.set(0.0);
         self.update_metrics();
     }
 

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -52,6 +52,7 @@ pub(crate) struct PoolInnerConfig {
     da_gas_tracking_enabled: bool,
     max_time_in_pool: Option<Duration>,
     verification_gas_limit_efficiency_reject_threshold: f64,
+    suspect_tracking_enabled: bool,
     rpc_failures_before_suspect: u32,
     max_suspect_rpc_failures: u32,
     suspect_rpc_backoff_initial: Duration,
@@ -71,6 +72,7 @@ impl From<PoolConfig> for PoolInnerConfig {
             max_time_in_pool: config.max_time_in_pool,
             verification_gas_limit_efficiency_reject_threshold: config
                 .verification_gas_limit_efficiency_reject_threshold,
+            suspect_tracking_enabled: config.suspect_tracking_enabled,
             rpc_failures_before_suspect: config.rpc_failures_before_suspect,
             max_suspect_rpc_failures: config.max_suspect_rpc_failures,
             suspect_rpc_backoff_initial: config.suspect_rpc_backoff_initial,
@@ -270,6 +272,13 @@ where
         provider_event_active: bool,
         now: Instant,
     ) -> Vec<(B256, OpRemovalReason)> {
+        // Master switch for poison UO handling: when disabled, bundle
+        // outcomes change no UO state and no operation is ever suspected
+        // or removed by this flow.
+        if !self.config.suspect_tracking_enabled {
+            return Vec::new();
+        }
+
         let suspect_threshold = self.config.rpc_failures_before_suspect;
         let mut to_remove = Vec::new();
 
@@ -2411,6 +2420,40 @@ mod tests {
     }
 
     #[test]
+    fn disabled_suspect_tracking_ignores_bundle_outcomes() {
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_tracking_enabled: false,
+            suspect_rpc_backoff_initial: Duration::ZERO,
+            ..conf()
+        });
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+
+        for _ in 0..10 {
+            let to_remove = pool.apply_bundle_outcome(
+                &[hash],
+                BundleOutcome::NonTerminalFailure,
+                false,
+                Instant::now(),
+            );
+            assert!(to_remove.is_empty());
+        }
+        let terminal = pool.apply_bundle_outcome(
+            &[hash],
+            BundleOutcome::TerminalFailure,
+            false,
+            Instant::now(),
+        );
+        assert!(terminal.is_empty());
+        pool.apply_bundle_outcome(&[hash], BundleOutcome::MarkSuspect, false, Instant::now());
+
+        assert_eq!(pool.by_hash[&hash].failures(), 0);
+        assert_eq!(pool.best_operations().count(), 1);
+        assert_eq!(pool.due_suspect_operations(Instant::now()).count(), 0);
+    }
+
+    #[test]
     fn bundle_outcome_ignores_unknown_hashes() {
         let pool = pool();
         let to_remove = pool.apply_bundle_outcome(
@@ -2435,6 +2478,7 @@ mod tests {
             da_gas_tracking_enabled: false,
             max_time_in_pool: None,
             verification_gas_limit_efficiency_reject_threshold: 0.5,
+            suspect_tracking_enabled: true,
             rpc_failures_before_suspect: 3,
             max_suspect_rpc_failures: 3,
             suspect_rpc_backoff_initial: Duration::from_secs(1),

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -23,12 +23,16 @@ use anyhow::Context;
 use metrics::{Counter, Gauge, Histogram};
 use metrics_derive::Metrics;
 use parking_lot::RwLock;
+use rand::Rng;
 use rundler_provider::DAGasOracleSync;
 use rundler_types::{
     Entity, EntityType, GasFees, Timestamp, UserOperation, UserOperationId, UserOperationVariant,
     chain::ChainSpec,
     da::DAGasBlockData,
-    pool::{MempoolError, PendingBundleInfo, PoolOperation, PoolOperationStatus, PreconfInfo},
+    pool::{
+        BundleOutcome, MempoolError, PendingBundleInfo, PoolOperation, PoolOperationStatus,
+        PreconfInfo,
+    },
 };
 use rundler_utils::{emit::WithEntryPoint, math};
 use tokio::sync::broadcast;
@@ -48,6 +52,10 @@ pub(crate) struct PoolInnerConfig {
     da_gas_tracking_enabled: bool,
     max_time_in_pool: Option<Duration>,
     verification_gas_limit_efficiency_reject_threshold: f64,
+    rpc_failures_before_suspect: u32,
+    max_suspect_rpc_failures: u32,
+    suspect_rpc_backoff_initial: Duration,
+    suspect_rpc_backoff_max: Duration,
 }
 
 impl From<PoolConfig> for PoolInnerConfig {
@@ -63,6 +71,10 @@ impl From<PoolConfig> for PoolInnerConfig {
             max_time_in_pool: config.max_time_in_pool,
             verification_gas_limit_efficiency_reject_threshold: config
                 .verification_gas_limit_efficiency_reject_threshold,
+            rpc_failures_before_suspect: config.rpc_failures_before_suspect,
+            max_suspect_rpc_failures: config.max_suspect_rpc_failures,
+            suspect_rpc_backoff_initial: config.suspect_rpc_backoff_initial,
+            suspect_rpc_backoff_max: config.suspect_rpc_backoff_max,
         }
     }
 }
@@ -224,7 +236,98 @@ where
     }
 
     pub(crate) fn best_operations(&self) -> impl Iterator<Item = Arc<PoolOperation>> + '_ {
-        self.best.iter().map(|o| o.po.clone())
+        self.best
+            .iter()
+            .filter(|o| !o.is_suspect(self.config.rpc_failures_before_suspect))
+            .map(|o| o.po.clone())
+    }
+
+    /// Returns suspect operations whose isolation retry delay has elapsed,
+    /// best first.
+    pub(crate) fn due_suspect_operations(
+        &self,
+        now: Instant,
+    ) -> impl Iterator<Item = Arc<PoolOperation>> + '_ {
+        self.best
+            .iter()
+            .filter(move |o| {
+                o.is_suspect(self.config.rpc_failures_before_suspect) && o.retry_due(now)
+            })
+            .map(|o| o.po.clone())
+    }
+
+    /// Applies the final outcome of a bundle submission attempt to the given
+    /// operations, per the failure flow in
+    /// `docs/designs/poison-user-operations.md`.
+    ///
+    /// Operations no longer in the pool are skipped. Returns the operations
+    /// that must be removed, with their removal reasons; removal itself is the
+    /// caller's responsibility.
+    pub(crate) fn apply_bundle_outcome(
+        &self,
+        ops: &[B256],
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+        now: Instant,
+    ) -> Vec<(B256, OpRemovalReason)> {
+        let suspect_threshold = self.config.rpc_failures_before_suspect;
+        let mut to_remove = Vec::new();
+
+        match outcome {
+            BundleOutcome::Success => {
+                for hash in ops {
+                    if let Some(op) = self.by_hash.get(hash) {
+                        op.reset_failures();
+                    }
+                }
+            }
+            BundleOutcome::NonTerminalFailure => {
+                for hash in ops {
+                    let Some(op) = self.by_hash.get(hash) else {
+                        continue;
+                    };
+                    // While a provider event is active only suspects accrue
+                    // failures: suspect removal is protected by backoff-spaced
+                    // evidence rather than by outage detection.
+                    if !op.is_suspect(suspect_threshold) && provider_event_active {
+                        continue;
+                    }
+                    let failures = op.record_failure(
+                        now,
+                        suspect_threshold,
+                        self.config.suspect_rpc_backoff_initial,
+                        self.config.suspect_rpc_backoff_max,
+                    );
+                    if self.config.max_suspect_rpc_failures > 0
+                        && failures >= suspect_threshold + self.config.max_suspect_rpc_failures
+                    {
+                        to_remove.push((*hash, OpRemovalReason::RepeatedNonTerminalRpcFailure));
+                    }
+                }
+            }
+            BundleOutcome::TerminalFailure => {
+                if let [hash] = ops {
+                    if self.by_hash.contains_key(hash) {
+                        to_remove.push((*hash, OpRemovalReason::TerminalRpcError));
+                    }
+                } else {
+                    for hash in ops {
+                        if let Some(op) = self.by_hash.get(hash) {
+                            op.mark_suspect(suspect_threshold);
+                        }
+                    }
+                }
+            }
+            BundleOutcome::MarkSuspect => {
+                for hash in ops {
+                    if let Some(op) = self.by_hash.get(hash) {
+                        op.mark_suspect(suspect_threshold);
+                    }
+                }
+            }
+        }
+
+        to_remove
     }
 
     pub(crate) fn all_operations(&self) -> impl Iterator<Item = Arc<PoolOperation>> + '_ {
@@ -828,6 +931,18 @@ where
     }
 }
 
+/// Submission failure tracking for poison user operation handling.
+///
+/// A single counter measured against two thresholds: an operation becomes a
+/// suspect at `rpc_failures_before_suspect` failures and is removed
+/// `max_suspect_rpc_failures` failures later. Any successful submission resets
+/// the counter. See `docs/designs/poison-user-operations.md`.
+#[derive(Debug, Default)]
+struct SuspectState {
+    failures: u32,
+    retry_after: Option<Instant>,
+}
+
 /// Wrapper around PoolOperation that adds a submission ID to implement
 /// a custom ordering for the best operations
 #[derive(Debug)]
@@ -840,6 +955,7 @@ struct OrderedPoolOperation {
     time_to_mine: RwLock<Option<TimeToMineInfo>>,
     /// The block number at which the operation was added to the pool
     added_at_block: u64,
+    suspect_state: RwLock<SuspectState>,
 }
 
 impl OrderedPoolOperation {
@@ -858,6 +974,7 @@ impl OrderedPoolOperation {
             insertion_time: Instant::now(),
             time_to_mine: RwLock::new(Some(TimeToMineInfo::new(current_block_number))),
             added_at_block: current_block_number,
+            suspect_state: RwLock::new(SuspectState::default()),
         }
     }
 
@@ -905,6 +1022,60 @@ impl OrderedPoolOperation {
 
     fn gas_price(&self) -> u128 {
         *self.gas_price.read()
+    }
+
+    fn is_suspect(&self, suspect_threshold: u32) -> bool {
+        self.suspect_state.read().failures >= suspect_threshold
+    }
+
+    /// Records a submission failure, scheduling the next isolation retry with
+    /// exponential backoff once the operation is past the suspect threshold.
+    /// Returns the new failure count.
+    fn record_failure(
+        &self,
+        now: Instant,
+        suspect_threshold: u32,
+        backoff_initial: Duration,
+        backoff_max: Duration,
+    ) -> u32 {
+        let mut state = self.suspect_state.write();
+        state.failures += 1;
+        if state.failures > suspect_threshold {
+            let exponent = state.failures - suspect_threshold - 1;
+            state.retry_after =
+                Some(now + Self::suspect_backoff(backoff_initial, backoff_max, exponent));
+        }
+        state.failures
+    }
+
+    /// Backoff delay doubling from `initial` with ±20% jitter, capped at `max`.
+    fn suspect_backoff(initial: Duration, max: Duration, exponent: u32) -> Duration {
+        let base = initial
+            .saturating_mul(2u32.saturating_pow(exponent))
+            .min(max);
+        base.mul_f64(rand::thread_rng().gen_range(0.8..=1.2))
+            .min(max)
+    }
+
+    fn reset_failures(&self) {
+        *self.suspect_state.write() = SuspectState::default();
+    }
+
+    fn mark_suspect(&self, suspect_threshold: u32) {
+        let mut state = self.suspect_state.write();
+        state.failures = state.failures.max(suspect_threshold);
+    }
+
+    #[cfg(test)]
+    fn failures(&self) -> u32 {
+        self.suspect_state.read().failures
+    }
+
+    fn retry_due(&self, now: Instant) -> bool {
+        self.suspect_state
+            .read()
+            .retry_after
+            .is_none_or(|retry_after| retry_after <= now)
     }
 }
 
@@ -1950,6 +2121,272 @@ mod tests {
         assert!(!pool.pending_bundles_by_uo.contains_key(&hash1));
     }
 
+    #[test]
+    fn success_resets_failures() {
+        let mut pool = pool();
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+
+        pool.apply_bundle_outcome(
+            &[hash],
+            BundleOutcome::NonTerminalFailure,
+            false,
+            Instant::now(),
+        );
+        pool.apply_bundle_outcome(
+            &[hash],
+            BundleOutcome::NonTerminalFailure,
+            false,
+            Instant::now(),
+        );
+        assert_eq!(pool.by_hash[&hash].failures(), 2);
+
+        pool.apply_bundle_outcome(&[hash], BundleOutcome::Success, false, Instant::now());
+        assert_eq!(pool.by_hash[&hash].failures(), 0);
+        assert_eq!(pool.best_operations().count(), 1);
+    }
+
+    #[test]
+    fn non_terminal_failures_promote_to_suspect() {
+        let mut pool = pool();
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+
+        for _ in 0..3 {
+            let to_remove = pool.apply_bundle_outcome(
+                &[hash],
+                BundleOutcome::NonTerminalFailure,
+                false,
+                Instant::now(),
+            );
+            assert!(to_remove.is_empty());
+        }
+
+        // suspect: hidden from best operations, due for isolation immediately
+        assert_eq!(pool.best_operations().count(), 0);
+        let due: Vec<_> = pool.due_suspect_operations(Instant::now()).collect();
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].uo.hash(), hash);
+    }
+
+    #[test]
+    fn provider_event_pauses_pre_suspect_counting_only() {
+        let mut pool = pool();
+        let non_suspect = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+        let suspect = pool
+            .add_operation(create_op(Address::random(), 0, 2), 0, 0)
+            .unwrap();
+        pool.by_hash[&suspect].mark_suspect(3);
+
+        pool.apply_bundle_outcome(
+            &[non_suspect],
+            BundleOutcome::NonTerminalFailure,
+            true,
+            Instant::now(),
+        );
+        pool.apply_bundle_outcome(
+            &[suspect],
+            BundleOutcome::NonTerminalFailure,
+            true,
+            Instant::now(),
+        );
+
+        assert_eq!(pool.by_hash[&non_suspect].failures(), 0);
+        assert_eq!(pool.by_hash[&suspect].failures(), 4);
+    }
+
+    #[test]
+    fn suspect_failure_schedules_backoff() {
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_rpc_backoff_initial: Duration::from_secs(10),
+            suspect_rpc_backoff_max: Duration::from_secs(600),
+            max_suspect_rpc_failures: 0,
+            ..conf()
+        });
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+        pool.by_hash[&hash].mark_suspect(3);
+
+        let now = Instant::now();
+        pool.apply_bundle_outcome(&[hash], BundleOutcome::NonTerminalFailure, false, now);
+
+        // first delay is 10s with ±20% jitter
+        let op = &pool.by_hash[&hash];
+        assert!(!op.retry_due(now + Duration::from_millis(7_900)));
+        assert!(op.retry_due(now + Duration::from_millis(12_100)));
+        assert_eq!(pool.due_suspect_operations(now).count(), 0);
+
+        // second delay doubles to 20s with ±20% jitter
+        pool.apply_bundle_outcome(&[hash], BundleOutcome::NonTerminalFailure, false, now);
+        let op = &pool.by_hash[&hash];
+        assert!(!op.retry_due(now + Duration::from_millis(15_900)));
+        assert!(op.retry_due(now + Duration::from_millis(24_100)));
+    }
+
+    #[test]
+    fn suspect_backoff_caps_at_max() {
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_rpc_backoff_initial: Duration::from_secs(10),
+            suspect_rpc_backoff_max: Duration::from_secs(15),
+            max_suspect_rpc_failures: 0,
+            ..conf()
+        });
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+        pool.by_hash[&hash].mark_suspect(3);
+
+        let now = Instant::now();
+        for _ in 0..8 {
+            pool.apply_bundle_outcome(&[hash], BundleOutcome::NonTerminalFailure, false, now);
+        }
+        assert!(pool.by_hash[&hash].retry_due(now + Duration::from_secs(15)));
+    }
+
+    #[test]
+    fn repeated_suspect_failures_remove_at_threshold() {
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_rpc_backoff_initial: Duration::ZERO,
+            ..conf()
+        });
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+
+        // suspect threshold 3 + removal allowance 3 = removal at the 6th failure
+        for _ in 0..5 {
+            let to_remove = pool.apply_bundle_outcome(
+                &[hash],
+                BundleOutcome::NonTerminalFailure,
+                false,
+                Instant::now(),
+            );
+            assert!(to_remove.is_empty());
+        }
+        let to_remove = pool.apply_bundle_outcome(
+            &[hash],
+            BundleOutcome::NonTerminalFailure,
+            false,
+            Instant::now(),
+        );
+        assert_eq!(to_remove.len(), 1);
+        assert_eq!(to_remove[0].0, hash);
+        assert!(matches!(
+            to_remove[0].1,
+            OpRemovalReason::RepeatedNonTerminalRpcFailure
+        ));
+    }
+
+    #[test]
+    fn zero_max_suspect_failures_disables_removal() {
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            max_suspect_rpc_failures: 0,
+            suspect_rpc_backoff_initial: Duration::ZERO,
+            ..conf()
+        });
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+
+        for _ in 0..20 {
+            let to_remove = pool.apply_bundle_outcome(
+                &[hash],
+                BundleOutcome::NonTerminalFailure,
+                false,
+                Instant::now(),
+            );
+            assert!(to_remove.is_empty());
+        }
+    }
+
+    #[test]
+    fn terminal_failure_single_op_removes() {
+        let mut pool = pool();
+        let hash = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+
+        let to_remove = pool.apply_bundle_outcome(
+            &[hash],
+            BundleOutcome::TerminalFailure,
+            false,
+            Instant::now(),
+        );
+        assert_eq!(to_remove.len(), 1);
+        assert_eq!(to_remove[0].0, hash);
+        assert!(matches!(to_remove[0].1, OpRemovalReason::TerminalRpcError));
+    }
+
+    #[test]
+    fn terminal_failure_multi_op_marks_all_suspect() {
+        let mut pool = pool();
+        let hashes: Vec<B256> = (0..3)
+            .map(|i| {
+                pool.add_operation(create_op(Address::random(), 0, i + 1), 0, 0)
+                    .unwrap()
+            })
+            .collect();
+
+        let to_remove = pool.apply_bundle_outcome(
+            &hashes,
+            BundleOutcome::TerminalFailure,
+            false,
+            Instant::now(),
+        );
+        assert!(to_remove.is_empty());
+        assert_eq!(pool.best_operations().count(), 0);
+        assert_eq!(pool.due_suspect_operations(Instant::now()).count(), 3);
+    }
+
+    #[test]
+    fn mark_suspect_does_not_reset_progress() {
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_rpc_backoff_initial: Duration::ZERO,
+            ..conf()
+        });
+        let fresh = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+        let seasoned = pool
+            .add_operation(create_op(Address::random(), 0, 2), 0, 0)
+            .unwrap();
+        for _ in 0..5 {
+            pool.apply_bundle_outcome(
+                &[seasoned],
+                BundleOutcome::NonTerminalFailure,
+                false,
+                Instant::now(),
+            );
+        }
+
+        pool.apply_bundle_outcome(
+            &[fresh, seasoned],
+            BundleOutcome::MarkSuspect,
+            false,
+            Instant::now(),
+        );
+
+        assert_eq!(pool.by_hash[&fresh].failures(), 3);
+        assert_eq!(pool.by_hash[&seasoned].failures(), 5);
+    }
+
+    #[test]
+    fn bundle_outcome_ignores_unknown_hashes() {
+        let pool = pool();
+        let to_remove = pool.apply_bundle_outcome(
+            &[B256::random()],
+            BundleOutcome::TerminalFailure,
+            false,
+            Instant::now(),
+        );
+        assert!(to_remove.is_empty());
+    }
+
     const MAX_POOL_SIZE_OPS: usize = 20;
 
     fn conf() -> PoolInnerConfig {
@@ -1963,6 +2400,10 @@ mod tests {
             da_gas_tracking_enabled: false,
             max_time_in_pool: None,
             verification_gas_limit_efficiency_reject_threshold: 0.5,
+            rpc_failures_before_suspect: 3,
+            max_suspect_rpc_failures: 3,
+            suspect_rpc_backoff_initial: Duration::from_secs(1),
+            suspect_rpc_backoff_max: Duration::from_secs(600),
         }
     }
 

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -280,11 +280,21 @@ where
         provider_event_active: bool,
         now: Instant,
     ) -> Vec<(B256, OpRemovalReason)> {
-        // Master switch for poison UO handling: when disabled, bundle
-        // outcomes change no UO state and no operation is ever suspected
-        // or removed by this flow.
+        // Master switch for poison UO handling: when disabled, no suspect
+        // state is tracked, so `MarkSuspect` has nothing to fall back on and
+        // reverts to the behavior it replaced — removing every op in an
+        // unattributed multi-op revert — so those ops are not left live with
+        // no path to eviction. Every other outcome is genuinely new
+        // functionality with no pre-existing behavior, so it stays a no-op.
         if !self.config.suspect_tracking_enabled {
-            return Vec::new();
+            return match outcome {
+                BundleOutcome::MarkSuspect => ops
+                    .iter()
+                    .filter(|hash| self.by_hash.contains_key(*hash))
+                    .map(|hash| (*hash, OpRemovalReason::Requested))
+                    .collect(),
+                _ => Vec::new(),
+            };
         }
 
         let suspect_threshold = self.config.rpc_failures_before_suspect;
@@ -2513,7 +2523,14 @@ mod tests {
             Instant::now(),
         );
         assert!(terminal.is_empty());
-        pool.apply_bundle_outcome(&[hash], BundleOutcome::MarkSuspect, false, Instant::now());
+
+        // MarkSuspect is the one exception: with tracking off there is no
+        // suspect state to fall back on, so it reverts to the pre-feature
+        // behavior it replaced and removes the op outright, rather than
+        // silently leaving an unattributed-revert op live forever.
+        let mark_suspect =
+            pool.apply_bundle_outcome(&[hash], BundleOutcome::MarkSuspect, false, Instant::now());
+        assert_eq!(mark_suspect, vec![(hash, OpRemovalReason::Requested)]);
 
         assert_eq!(pool.by_hash[&hash].failures(), 0);
         assert_eq!(pool.best_operations().count(), 1);

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -39,7 +39,11 @@ use tokio::sync::broadcast;
 use tracing::info;
 
 use super::{MempoolResult, PoolConfig, entity_tracker::EntityCounter, size::SizeTracker};
-use crate::{PoolEvent, chain::MinedOp, emit::OpRemovalReason};
+use crate::{
+    PoolEvent,
+    chain::MinedOp,
+    emit::{OpRemovalReason, SuspectTrigger},
+};
 
 #[derive(Debug, Clone)]
 pub(crate) struct PoolInnerConfig {
@@ -137,6 +141,14 @@ where
         event_sender: broadcast::Sender<WithEntryPoint<PoolEvent>>,
     ) -> Self {
         let entry_point = config.entry_point.to_string();
+        let metrics = PoolMetrics::new_with_labels(&[("entry_point", entry_point)]);
+        metrics
+            .suspect_tracking_enabled
+            .set(if config.suspect_tracking_enabled {
+                1.0
+            } else {
+                0.0
+            });
         Self {
             config,
             da_gas_oracle,
@@ -155,7 +167,7 @@ where
             pool_size: SizeTracker::default(),
             cache_size: SizeTracker::default(),
             prev_block_number: 0,
-            metrics: PoolMetrics::new_with_labels(&[("entry_point", entry_point)]),
+            metrics,
             event_sender,
         }
     }
@@ -304,7 +316,13 @@ where
             BundleOutcome::Success => {
                 for hash in ops {
                     if let Some(op) = self.by_hash.get(hash) {
+                        let was_suspect = op.is_suspect(suspect_threshold);
                         op.reset_failures();
+                        if was_suspect {
+                            self.metrics.num_suspect_ops.decrement(1.0);
+                            self.metrics.num_suspects_cleared.increment(1);
+                            self.emit(PoolEvent::SuspectCleared { op_hash: *hash });
+                        }
                     }
                 }
             }
@@ -327,18 +345,28 @@ where
                         );
                         continue;
                     }
+                    let was_suspect = op.is_suspect(suspect_threshold);
                     let failures = op.record_failure(
                         now,
                         suspect_threshold,
                         self.config.suspect_rpc_backoff_initial,
                         self.config.suspect_rpc_backoff_max,
                     );
+                    if !was_suspect && failures >= suspect_threshold {
+                        self.metrics.num_suspect_ops.increment(1.0);
+                        self.metrics.num_marked_suspect_threshold.increment(1);
+                        self.emit(PoolEvent::MarkedSuspect {
+                            op_hash: *hash,
+                            trigger: SuspectTrigger::Threshold,
+                        });
+                    }
                     if self.config.max_suspect_rpc_failures > 0
                         && failures
                             >= suspect_threshold
                                 .saturating_add(self.config.max_suspect_rpc_failures)
                     {
                         to_remove.push((*hash, OpRemovalReason::RepeatedNonTerminalRpcFailure));
+                        self.metrics.num_suspects_removed.increment(1);
                     }
                 }
             }
@@ -346,11 +374,12 @@ where
                 if let [hash] = ops {
                     if self.by_hash.contains_key(hash) {
                         to_remove.push((*hash, OpRemovalReason::TerminalRpcError));
+                        self.metrics.num_suspects_removed.increment(1);
                     }
                 } else {
                     for hash in ops {
                         if let Some(op) = self.by_hash.get(hash) {
-                            op.mark_suspect(suspect_threshold);
+                            self.mark_suspect_and_record(*hash, op, suspect_threshold);
                         }
                     }
                 }
@@ -358,13 +387,37 @@ where
             BundleOutcome::MarkSuspect => {
                 for hash in ops {
                     if let Some(op) = self.by_hash.get(hash) {
-                        op.mark_suspect(suspect_threshold);
+                        self.mark_suspect_and_record(*hash, op, suspect_threshold);
                     }
                 }
             }
         }
 
         to_remove
+    }
+
+    /// Marks an operation suspect and records the transition (suspect gauge,
+    /// multi-op-failure counter, `MarkedSuspect` event) unless it was already
+    /// a suspect, per the ambiguous multi-UO failure paths in the failure
+    /// flow table.
+    fn mark_suspect_and_record(
+        &self,
+        hash: B256,
+        op: &OrderedPoolOperation,
+        suspect_threshold: u32,
+    ) {
+        let was_suspect = op.is_suspect(suspect_threshold);
+        op.mark_suspect(suspect_threshold);
+        if !was_suspect {
+            self.metrics.num_suspect_ops.increment(1.0);
+            self.metrics
+                .num_marked_suspect_multi_op_failure
+                .increment(1);
+            self.emit(PoolEvent::MarkedSuspect {
+                op_hash: hash,
+                trigger: SuspectTrigger::MultiOpFailure,
+            });
+        }
     }
 
     pub(crate) fn all_operations(&self) -> impl Iterator<Item = Arc<PoolOperation>> + '_ {
@@ -905,6 +958,13 @@ where
         block_number: Option<u64>,
     ) -> Option<Arc<PoolOperation>> {
         let op = self.by_hash.remove(&hash)?;
+        // Recompute the current suspect population on every removal path
+        // (mined, expired, replaced, entity-removed, poison-ops removal,
+        // etc.) so the gauge never leaks regardless of why a suspect left
+        // the pool.
+        if op.is_suspect(self.config.rpc_failures_before_suspect) {
+            self.metrics.num_suspect_ops.decrement(1.0);
+        }
         let id = &op.po.uo.id();
         self.by_id.remove(id);
         self.best.remove(&op);
@@ -1205,6 +1265,24 @@ struct PoolMetrics {
     num_7702_ops_added: Counter,
     #[metric(describe = "the number of ops added")]
     num_ops_added: Counter,
+    #[metric(describe = "the number of suspect ops currently in the pool.")]
+    num_suspect_ops: Gauge,
+    #[metric(describe = "the number of ops marked suspect by an ambiguous multi-op failure.")]
+    num_marked_suspect_multi_op_failure: Counter,
+    #[metric(
+        describe = "the number of ops marked suspect by reaching the non-terminal RPC failure threshold."
+    )]
+    num_marked_suspect_threshold: Counter,
+    #[metric(describe = "the number of suspects cleared by a successful submission.")]
+    num_suspects_cleared: Counter,
+    #[metric(
+        describe = "the number of suspects removed after a terminal RPC error or repeated non-terminal RPC failures."
+    )]
+    num_suspects_removed: Counter,
+    #[metric(
+        describe = "whether poison user operation suspect tracking is enabled (1) or disabled (0)."
+    )]
+    suspect_tracking_enabled: Gauge,
 }
 
 #[cfg(test)]

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -238,9 +238,15 @@ where
     }
 
     pub(crate) fn best_operations(&self) -> impl Iterator<Item = Arc<PoolOperation>> + '_ {
+        // Master switch: when disabled, no operation is ever treated as a
+        // suspect, regardless of `rpc_failures_before_suspect` (a threshold of
+        // 0 would otherwise mark every fresh operation suspect and empty this
+        // iterator).
+        let suspect_tracking_enabled = self.config.suspect_tracking_enabled;
+        let suspect_threshold = self.config.rpc_failures_before_suspect;
         self.best
             .iter()
-            .filter(|o| !o.is_suspect(self.config.rpc_failures_before_suspect))
+            .filter(move |o| !suspect_tracking_enabled || !o.is_suspect(suspect_threshold))
             .map(|o| o.po.clone())
     }
 
@@ -250,10 +256,12 @@ where
         &self,
         now: Instant,
     ) -> impl Iterator<Item = Arc<PoolOperation>> + '_ {
+        let suspect_tracking_enabled = self.config.suspect_tracking_enabled;
+        let suspect_threshold = self.config.rpc_failures_before_suspect;
         self.best
             .iter()
             .filter(move |o| {
-                o.is_suspect(self.config.rpc_failures_before_suspect) && o.retry_due(now)
+                suspect_tracking_enabled && o.is_suspect(suspect_threshold) && o.retry_due(now)
             })
             .map(|o| o.po.clone())
     }
@@ -316,7 +324,9 @@ where
                         self.config.suspect_rpc_backoff_max,
                     );
                     if self.config.max_suspect_rpc_failures > 0
-                        && failures >= suspect_threshold + self.config.max_suspect_rpc_failures
+                        && failures
+                            >= suspect_threshold
+                                .saturating_add(self.config.max_suspect_rpc_failures)
                     {
                         to_remove.push((*hash, OpRemovalReason::RepeatedNonTerminalRpcFailure));
                     }
@@ -1056,7 +1066,7 @@ impl OrderedPoolOperation {
         backoff_max: Duration,
     ) -> u32 {
         let mut state = self.suspect_state.write();
-        state.failures += 1;
+        state.failures = state.failures.saturating_add(1);
         if state.failures > suspect_threshold {
             let exponent = state.failures - suspect_threshold - 1;
             state.retry_after =
@@ -2244,6 +2254,45 @@ mod tests {
     }
 
     #[test]
+    fn provider_event_resumes_removal_progress_after_clearing() {
+        // threshold 3, max_suspect_rpc_failures 3: removal at 6 total failures
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_rpc_backoff_initial: Duration::ZERO,
+            ..conf()
+        });
+        let suspect = pool
+            .add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+        pool.by_hash[&suspect].mark_suspect(3);
+
+        let now = Instant::now();
+        for _ in 0..5 {
+            let to_remove =
+                pool.apply_bundle_outcome(&[suspect], BundleOutcome::NonTerminalFailure, true, now);
+            // failures during the event never contribute to a later removal
+            assert!(to_remove.is_empty());
+        }
+        assert_eq!(pool.by_hash[&suspect].failures(), 3);
+
+        // event clears: removal progress resumes from the frozen count, not from 0
+        pool.apply_bundle_outcome(&[suspect], BundleOutcome::NonTerminalFailure, false, now);
+        assert_eq!(pool.by_hash[&suspect].failures(), 4);
+        let to_remove =
+            pool.apply_bundle_outcome(&[suspect], BundleOutcome::NonTerminalFailure, false, now);
+        assert_eq!(pool.by_hash[&suspect].failures(), 5);
+        assert!(to_remove.is_empty());
+
+        let to_remove =
+            pool.apply_bundle_outcome(&[suspect], BundleOutcome::NonTerminalFailure, false, now);
+        assert_eq!(to_remove.len(), 1);
+        assert_eq!(to_remove[0].0, suspect);
+        assert!(matches!(
+            to_remove[0].1,
+            OpRemovalReason::RepeatedNonTerminalRpcFailure
+        ));
+    }
+
+    #[test]
     fn suspect_failure_schedules_backoff() {
         let mut pool = pool_with_conf(PoolInnerConfig {
             suspect_rpc_backoff_initial: Duration::from_secs(10),
@@ -2417,6 +2466,24 @@ mod tests {
 
         assert_eq!(pool.by_hash[&fresh].failures(), 3);
         assert_eq!(pool.by_hash[&seasoned].failures(), 5);
+    }
+
+    #[test]
+    fn disabled_suspect_tracking_ignores_zero_threshold() {
+        // A threshold of 0 would make every fresh op appear suspect
+        // (`failures >= 0`); the master switch must still guarantee that
+        // disabling suspect tracking never removes operations from
+        // `best_operations`.
+        let mut pool = pool_with_conf(PoolInnerConfig {
+            suspect_tracking_enabled: false,
+            rpc_failures_before_suspect: 0,
+            ..conf()
+        });
+        pool.add_operation(create_op(Address::random(), 0, 1), 0, 0)
+            .unwrap();
+
+        assert_eq!(pool.best_operations().count(), 1);
+        assert_eq!(pool.due_suspect_operations(Instant::now()).count(), 0);
     }
 
     #[test]

--- a/crates/pool/src/mempool/pool.rs
+++ b/crates/pool/src/mempool/pool.rs
@@ -286,11 +286,18 @@ where
                     let Some(op) = self.by_hash.get(hash) else {
                         continue;
                     };
-                    // A failure during a provider event is not evidence against
-                    // the op: treat the submission as if it never happened.
-                    // Retry pacing during an event is left to normal submission
-                    // cadence and provider rate limiting.
-                    if provider_event_active {
+                    // Removal progress pauses during a provider event so that
+                    // provider issues cannot remove operations, but suspect
+                    // analysis continues: gating suspicion too would let a
+                    // poison herd large enough to trip the event keep riding
+                    // in normal bundles for as long as it sustains the event.
+                    if provider_event_active && op.is_suspect(suspect_threshold) {
+                        op.reschedule_retry(
+                            now,
+                            suspect_threshold,
+                            self.config.suspect_rpc_backoff_initial,
+                            self.config.suspect_rpc_backoff_max,
+                        );
                         continue;
                     }
                     let failures = op.record_failure(
@@ -1047,6 +1054,24 @@ impl OrderedPoolOperation {
                 Some(now + Self::suspect_backoff(backoff_initial, backoff_max, exponent));
         }
         state.failures
+    }
+
+    /// Schedules the next isolation retry without recording a failure, for
+    /// suspect failures that are not evidence against the operation (during a
+    /// provider event). No-op unless the operation is a suspect.
+    fn reschedule_retry(
+        &self,
+        now: Instant,
+        suspect_threshold: u32,
+        backoff_initial: Duration,
+        backoff_max: Duration,
+    ) {
+        let mut state = self.suspect_state.write();
+        if state.failures >= suspect_threshold {
+            let exponent = state.failures - suspect_threshold;
+            state.retry_after =
+                Some(now + Self::suspect_backoff(backoff_initial, backoff_max, exponent));
+        }
     }
 
     /// Backoff delay doubling from `initial` with ±20% jitter, capped at `max`.
@@ -2173,7 +2198,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_event_pauses_failure_counting() {
+    fn provider_event_pauses_removal_progress_only() {
         let mut pool = pool_with_conf(PoolInnerConfig {
             suspect_rpc_backoff_initial: Duration::from_secs(10),
             ..conf()
@@ -2187,14 +2212,26 @@ mod tests {
         pool.by_hash[&suspect].mark_suspect(3);
 
         let now = Instant::now();
-        pool.apply_bundle_outcome(&[non_suspect], BundleOutcome::NonTerminalFailure, true, now);
-        pool.apply_bundle_outcome(&[suspect], BundleOutcome::NonTerminalFailure, true, now);
+        for _ in 0..10 {
+            let to_remove = pool.apply_bundle_outcome(
+                &[non_suspect, suspect],
+                BundleOutcome::NonTerminalFailure,
+                true,
+                now,
+            );
+            // no removal ever fires during a provider event
+            assert!(to_remove.is_empty());
+        }
 
-        // a failure during a provider event changes no UO state
-        assert_eq!(pool.by_hash[&non_suspect].failures(), 0);
+        // suspect analysis continues during the event: the non-suspect accrues
+        // failures, is promoted at the threshold, and then freezes
+        assert_eq!(pool.by_hash[&non_suspect].failures(), 3);
+        // an existing suspect makes no removal progress
         assert_eq!(pool.by_hash[&suspect].failures(), 3);
-        assert!(pool.by_hash[&non_suspect].retry_due(now));
-        assert!(pool.by_hash[&suspect].retry_due(now));
+        // but its isolation retries stay spaced: 10s initial with ±20% jitter
+        let suspect_op = &pool.by_hash[&suspect];
+        assert!(!suspect_op.retry_due(now + Duration::from_millis(7_900)));
+        assert!(suspect_op.retry_due(now + Duration::from_millis(12_100)));
     }
 
     #[test]

--- a/crates/pool/src/mempool/uo_pool.rs
+++ b/crates/pool/src/mempool/uo_pool.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, sync::Arc, time::Instant};
 
 use alloy_primitives::{Address, B256, Bytes, U256, utils::format_units};
 use anyhow::Context;
@@ -29,8 +29,8 @@ use rundler_types::{
     Entity, EntityUpdate, EntityUpdateType, EntryPointVersion, GasFees, UserOperation,
     UserOperationId, UserOperationPermissions, UserOperationVariant,
     pool::{
-        MempoolError, PaymasterMetadata, PoolOperation, PoolOperationStatus, Reputation,
-        ReputationStatus, StakeStatus,
+        BundleOutcome, MempoolError, PaymasterMetadata, PoolOperation, PoolOperationStatus,
+        Reputation, ReputationStatus, StakeStatus,
     },
 };
 use rundler_utils::{emit::WithEntryPoint, guard_timer::CustomTimerGuard};
@@ -120,6 +120,29 @@ where
             entry_point: self.config.entry_point,
             event,
         });
+    }
+
+    fn remove_operations_with_reason(&self, hashes: &[B256], reason: OpRemovalReason) {
+        let mut count: u64 = 0;
+        let mut removed_hashes = vec![];
+        {
+            let mut state = self.state.write();
+            for hash in hashes {
+                if let Some(op) = state.pool.remove_operation_by_hash(*hash) {
+                    self.paymaster.remove_operation(&op.uo.id());
+                    count += 1;
+                    removed_hashes.push(*hash);
+                }
+            }
+        }
+
+        for hash in removed_hashes {
+            self.emit(OpPoolEvent::RemovedOp {
+                op_hash: hash,
+                reason: reason.clone(),
+            })
+        }
+        self.ep_specific_metrics.removed_operations.increment(count);
     }
 
     fn throttle_entity(&self, entity: Entity) {
@@ -790,26 +813,7 @@ where
     }
 
     fn remove_operations(&self, hashes: &[B256]) {
-        let mut count: u64 = 0;
-        let mut removed_hashes = vec![];
-        {
-            let mut state = self.state.write();
-            for hash in hashes {
-                if let Some(op) = state.pool.remove_operation_by_hash(*hash) {
-                    self.paymaster.remove_operation(&op.uo.id());
-                    count += 1;
-                    removed_hashes.push(*hash);
-                }
-            }
-        }
-
-        for hash in removed_hashes {
-            self.emit(OpPoolEvent::RemovedOp {
-                op_hash: hash,
-                reason: OpRemovalReason::Requested,
-            })
-        }
-        self.ep_specific_metrics.removed_operations.increment(count);
+        self.remove_operations_with_reason(hashes, OpRemovalReason::Requested);
     }
 
     fn get_op_by_id(&self, id: &UserOperationId) -> Option<Arc<PoolOperation>> {
@@ -899,6 +903,39 @@ where
             .filter(|op| filter_id == op.filter_id)
             .take(max)
             .collect())
+    }
+
+    fn due_suspect_operations(
+        &self,
+        max: usize,
+        filter_id: Option<String>,
+    ) -> MempoolResult<Vec<Arc<PoolOperation>>> {
+        let state = self.state.read();
+
+        Ok(state
+            .pool
+            .due_suspect_operations(Instant::now())
+            .filter(|op| filter_id == op.filter_id)
+            .take(max)
+            .collect())
+    }
+
+    fn report_bundle_outcome(
+        &self,
+        ops: &[B256],
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+    ) {
+        let to_remove = {
+            let state = self.state.read();
+            state
+                .pool
+                .apply_bundle_outcome(ops, outcome, provider_event_active, Instant::now())
+        };
+
+        for (hash, reason) in to_remove {
+            self.remove_operations_with_reason(&[hash], reason);
+        }
     }
 
     fn all_operations(&self, max: usize) -> Vec<Arc<PoolOperation>> {
@@ -1049,7 +1086,7 @@ struct UoPoolMetrics {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, str::FromStr, vec};
+    use std::{collections::HashMap, str::FromStr, time::Duration, vec};
 
     use alloy_primitives::{Address, Bytes, Log as PrimitiveLog, LogData, address, bytes, uint};
     use alloy_rpc_types_eth::TransactionReceipt as AlloyTransactionReceipt;
@@ -1123,6 +1160,58 @@ mod tests {
         check_ops(pool.best_operations(3, None).unwrap(), uos);
         pool.remove_operations(&hashes);
         assert_eq!(pool.best_operations(3, None).unwrap(), vec![]);
+    }
+
+    #[tokio::test]
+    async fn report_bundle_outcome_removes_after_repeated_failures() {
+        let op = create_op(Address::random(), 0, 0, None);
+        let pool = create_pool(vec![op.clone()]);
+        let hash = pool
+            .add_operation(OperationOrigin::Local, op.op, default_perms())
+            .await
+            .unwrap();
+
+        // suspect threshold 3 + removal allowance 3 = removal at the 6th failure
+        for _ in 0..5 {
+            pool.report_bundle_outcome(&[hash], BundleOutcome::NonTerminalFailure, false);
+            assert!(pool.get_user_operation_by_hash(hash).is_some());
+        }
+        pool.report_bundle_outcome(&[hash], BundleOutcome::NonTerminalFailure, false);
+        assert!(pool.get_user_operation_by_hash(hash).is_none());
+    }
+
+    #[tokio::test]
+    async fn report_bundle_outcome_success_clears_suspect() {
+        let op = create_op(Address::random(), 0, 0, None);
+        let uos = vec![op.op.clone()];
+        let pool = create_pool(vec![op.clone()]);
+        let hash = pool
+            .add_operation(OperationOrigin::Local, op.op, default_perms())
+            .await
+            .unwrap();
+
+        for _ in 0..3 {
+            pool.report_bundle_outcome(&[hash], BundleOutcome::NonTerminalFailure, false);
+        }
+        assert_eq!(pool.best_operations(1, None).unwrap(), vec![]);
+        check_ops(pool.due_suspect_operations(1, None).unwrap(), uos.clone());
+
+        pool.report_bundle_outcome(&[hash], BundleOutcome::Success, false);
+        check_ops(pool.best_operations(1, None).unwrap(), uos);
+        assert_eq!(pool.due_suspect_operations(1, None).unwrap(), vec![]);
+    }
+
+    #[tokio::test]
+    async fn report_bundle_outcome_terminal_removes_single() {
+        let op = create_op(Address::random(), 0, 0, None);
+        let pool = create_pool(vec![op.clone()]);
+        let hash = pool
+            .add_operation(OperationOrigin::Local, op.op, default_perms())
+            .await
+            .unwrap();
+
+        pool.report_bundle_outcome(&[hash], BundleOutcome::TerminalFailure, false);
+        assert!(pool.get_user_operation_by_hash(hash).is_none());
     }
 
     #[tokio::test]
@@ -2424,6 +2513,10 @@ mod tests {
             verification_gas_limit_efficiency_reject_threshold: 0.0,
             max_time_in_pool: None,
             max_expected_storage_slots: usize::MAX,
+            rpc_failures_before_suspect: 3,
+            max_suspect_rpc_failures: 3,
+            suspect_rpc_backoff_initial: Duration::from_secs(1),
+            suspect_rpc_backoff_max: Duration::from_secs(600),
         }
     }
 

--- a/crates/pool/src/mempool/uo_pool.rs
+++ b/crates/pool/src/mempool/uo_pool.rs
@@ -2513,6 +2513,7 @@ mod tests {
             verification_gas_limit_efficiency_reject_threshold: 0.0,
             max_time_in_pool: None,
             max_expected_storage_slots: usize::MAX,
+            suspect_tracking_enabled: true,
             rpc_failures_before_suspect: 3,
             max_suspect_rpc_failures: 3,
             suspect_rpc_backoff_initial: Duration::from_secs(1),

--- a/crates/pool/src/mempool/uo_pool.rs
+++ b/crates/pool/src/mempool/uo_pool.rs
@@ -1215,6 +1215,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn report_bundle_outcome_mark_suspect_removes_when_tracking_disabled() {
+        // With the master switch off there is no suspect state to mark, so an
+        // unattributed multi-op revert (MarkSuspect) must fall back to the
+        // pre-feature behavior of removing the op outright, rather than
+        // silently leaving it live with no path to eviction.
+        let op = create_op(Address::random(), 0, 0, None);
+        let config = PoolConfig {
+            suspect_tracking_enabled: false,
+            ..default_config()
+        };
+        let pool = create_pool_with_config(config, vec![op.clone()]);
+        let hash = pool
+            .add_operation(OperationOrigin::Local, op.op, default_perms())
+            .await
+            .unwrap();
+
+        pool.report_bundle_outcome(&[hash], BundleOutcome::MarkSuspect, false);
+        assert!(pool.get_user_operation_by_hash(hash).is_none());
+    }
+
+    #[tokio::test]
     async fn clear() {
         let ops = vec![
             create_op(Address::random(), 0, 3, None),

--- a/crates/pool/src/server/local.rs
+++ b/crates/pool/src/server/local.rs
@@ -34,7 +34,7 @@ use rundler_types::{
     EntityUpdate, EntryPointAbiVersion, UserOperation, UserOperationId, UserOperationPermissions,
     UserOperationVariant,
     pool::{
-        MempoolError, NewHead, PaymasterMetadata, Pool, PoolError, PoolOperation,
+        BundleOutcome, MempoolError, NewHead, PaymasterMetadata, Pool, PoolError, PoolOperation,
         PoolOperationStatus, PoolOperationSummary, PoolResult, Reputation, ReputationStatus,
         StakeStatus,
     },
@@ -202,11 +202,13 @@ impl Pool for LocalPoolHandle {
         &self,
         entry_point: Address,
         max_ops: u64,
+        max_suspects: u64,
         filter_id: Option<String>,
     ) -> PoolResult<Vec<PoolOperationSummary>> {
         let req = ServerRequestKind::GetOpsSummaries {
             entry_point,
             max_ops,
+            max_suspects,
             filter_id,
         };
         let resp = self.send(req).await?;
@@ -268,6 +270,26 @@ impl Pool for LocalPoolHandle {
         let resp = self.send(req).await?;
         match resp {
             ServerResponse::RemoveOpById { hash } => Ok(hash),
+            _ => Err(PoolError::UnexpectedResponse),
+        }
+    }
+
+    async fn report_bundle_outcome(
+        &self,
+        entry_point: Address,
+        ops: Vec<B256>,
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+    ) -> PoolResult<()> {
+        let req = ServerRequestKind::ReportBundleOutcome {
+            entry_point,
+            ops,
+            outcome,
+            provider_event_active,
+        };
+        let resp = self.send(req).await?;
+        match resp {
+            ServerResponse::ReportBundleOutcome => Ok(()),
             _ => Err(PoolError::UnexpectedResponse),
         }
     }
@@ -522,14 +544,26 @@ impl LocalPoolServerRunner {
         &self,
         entry_point: Address,
         max_ops: u64,
+        max_suspects: u64,
         filter_id: Option<String>,
     ) -> PoolResult<Vec<PoolOperationSummary>> {
         let mempool = self.get_pool(entry_point)?;
-        Ok(mempool
-            .best_operations(max_ops as usize, filter_id)?
+        let mut summaries: Vec<PoolOperationSummary> = mempool
+            .best_operations(max_ops as usize, filter_id.clone())?
             .iter()
             .map(|op| op.as_ref().into())
-            .collect())
+            .collect();
+        summaries.extend(
+            mempool
+                .due_suspect_operations(max_suspects as usize, filter_id)?
+                .iter()
+                .map(|op| {
+                    let mut summary: PoolOperationSummary = op.as_ref().into();
+                    summary.suspect = true;
+                    summary
+                }),
+        );
+        Ok(summaries)
     }
 
     fn get_ops_by_hashes(
@@ -579,6 +613,18 @@ impl LocalPoolServerRunner {
     ) -> PoolResult<Option<B256>> {
         let mempool = self.get_pool(entry_point)?;
         mempool.remove_op_by_id(id).map_err(|e| e.into())
+    }
+
+    fn report_bundle_outcome(
+        &self,
+        entry_point: Address,
+        ops: &[B256],
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+    ) -> PoolResult<()> {
+        let mempool = self.get_pool(entry_point)?;
+        mempool.report_bundle_outcome(ops, outcome, provider_event_active);
+        Ok(())
     }
 
     fn update_entities<'a>(
@@ -801,8 +847,8 @@ impl LocalPoolServerRunner {
                                 Err(e) => Err(e),
                             }
                         },
-                        ServerRequestKind::GetOpsSummaries { entry_point, max_ops, filter_id } => {
-                            match self.get_ops_summaries(entry_point, max_ops, filter_id) {
+                        ServerRequestKind::GetOpsSummaries { entry_point, max_ops, max_suspects, filter_id } => {
+                            match self.get_ops_summaries(entry_point, max_ops, max_suspects, filter_id) {
                                 Ok(summaries) => Ok(ServerResponse::GetOpsSummaries { summaries }),
                                 Err(e) => Err(e),
                             }
@@ -834,6 +880,12 @@ impl LocalPoolServerRunner {
                         ServerRequestKind::RemoveOpById { entry_point, id } => {
                             match self.remove_op_by_id(entry_point, &id) {
                                 Ok(hash) => Ok(ServerResponse::RemoveOpById{ hash }),
+                                Err(e) => Err(e),
+                            }
+                        },
+                        ServerRequestKind::ReportBundleOutcome { entry_point, ops, outcome, provider_event_active } => {
+                            match self.report_bundle_outcome(entry_point, &ops, outcome, provider_event_active) {
+                                Ok(_) => Ok(ServerResponse::ReportBundleOutcome),
                                 Err(e) => Err(e),
                             }
                         },
@@ -935,6 +987,7 @@ enum ServerRequestKind {
     GetOpsSummaries {
         entry_point: Address,
         max_ops: u64,
+        max_suspects: u64,
         filter_id: Option<String>,
     },
     GetOpsByHashes {
@@ -954,6 +1007,12 @@ enum ServerRequestKind {
     RemoveOpById {
         entry_point: Address,
         id: UserOperationId,
+    },
+    ReportBundleOutcome {
+        entry_point: Address,
+        ops: Vec<B256>,
+        outcome: BundleOutcome,
+        provider_event_active: bool,
     },
     UpdateEntities {
         entry_point: Address,
@@ -1033,6 +1092,7 @@ enum ServerResponse {
     RemoveOpById {
         hash: Option<B256>,
     },
+    ReportBundleOutcome,
     UpdateEntities,
     DebugClearState,
     AdminSetTracking,
@@ -1069,8 +1129,8 @@ mod tests {
     use parking_lot::RwLock;
     use reth_tasks::TaskManager;
     use rundler_types::{
-        EntryPointVersion, chain::ChainSpec, v0_6::UserOperation as UserOperationV0_6,
-        v0_7::UserOperation as UserOperationV0_7,
+        EntityInfos, EntryPointVersion, ValidTimeRange, chain::ChainSpec, da::DAGasData,
+        v0_6::UserOperation as UserOperationV0_6, v0_7::UserOperation as UserOperationV0_7,
     };
 
     use super::*;
@@ -1097,6 +1157,37 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(hash0, hash1);
+    }
+
+    #[tokio::test]
+    async fn test_get_ops_summaries_includes_due_suspects() {
+        let mut mock_pool = MockMempool::new();
+        let normal_op = Arc::new(mock_pool_operation());
+        let suspect_op = Arc::new(mock_pool_operation());
+        mock_pool
+            .expect_entry_point_version()
+            .returning(|| EntryPointVersion::V0_6);
+        mock_pool
+            .expect_best_operations()
+            .withf(|max, filter_id| *max == 10 && filter_id.is_none())
+            .returning(move |_, _| Ok(vec![normal_op.clone()]));
+        mock_pool
+            .expect_due_suspect_operations()
+            .withf(|max, filter_id| *max == 5 && filter_id.is_none())
+            .returning(move |_, _| Ok(vec![suspect_op.clone()]));
+
+        let ep = ChainSpec::default().entry_point_address_v0_6;
+        let pool: Arc<dyn Mempool> = Arc::new(mock_pool);
+        let state = setup(HashMap::from([(ep, pool)]));
+
+        let summaries = state
+            .handle
+            .get_ops_summaries(ep, 10, 5, None)
+            .await
+            .unwrap();
+        assert_eq!(summaries.len(), 2);
+        assert!(!summaries[0].suspect);
+        assert!(summaries[1].suspect);
     }
 
     #[tokio::test]
@@ -1225,6 +1316,24 @@ mod tests {
 
     fn mock_op() -> UserOperationVariant {
         UserOperationVariant::V0_6(UserOperationV0_6::default())
+    }
+
+    fn mock_pool_operation() -> PoolOperation {
+        PoolOperation {
+            uo: mock_op(),
+            entry_point: Address::random(),
+            aggregator: None,
+            valid_time_range: ValidTimeRange::default(),
+            expected_code_hash: B256::random(),
+            sim_block_hash: B256::random(),
+            sim_block_number: 0,
+            account_is_staked: false,
+            entity_infos: EntityInfos::default(),
+            da_gas_data: DAGasData::Empty,
+            filter_id: None,
+            perms: UserOperationPermissions::default(),
+            sender_is_7702: false,
+        }
     }
 
     fn mock_op_v0_7() -> UserOperationVariant {

--- a/crates/pool/src/server/remote/client.rs
+++ b/crates/pool/src/server/remote/client.rs
@@ -25,8 +25,9 @@ use rundler_types::{
     EntityUpdate, UserOperationId, UserOperationPermissions, UserOperationVariant,
     chain::ChainSpec,
     pool::{
-        NewHead, PaymasterMetadata, Pool, PoolError, PoolOperation, PoolOperationStatus,
-        PoolOperationSummary, PoolResult, Reputation, ReputationStatus, StakeStatus,
+        BundleOutcome, NewHead, PaymasterMetadata, Pool, PoolError, PoolOperation,
+        PoolOperationStatus, PoolOperationSummary, PoolResult, Reputation, ReputationStatus,
+        StakeStatus,
     },
 };
 use rundler_utils::retry::{self, UnlimitedRetryOpts};
@@ -52,7 +53,8 @@ use super::protos::{
     debug_set_reputation_response, get_op_by_hash_response, get_op_by_id_response,
     get_ops_by_hashes_response, get_ops_response, get_ops_summaries_response,
     get_reputation_status_response, get_stake_status_response, op_pool_client::OpPoolClient,
-    remove_op_by_id_response, remove_ops_response, update_entities_response,
+    remove_op_by_id_response, remove_ops_response, report_bundle_outcome_response,
+    update_entities_response,
 };
 
 /// Remote pool client
@@ -226,6 +228,7 @@ impl Pool for RemotePoolClient {
         &self,
         entry_point: Address,
         max_ops: u64,
+        max_suspects: u64,
         filter_id: Option<String>,
     ) -> PoolResult<Vec<PoolOperationSummary>> {
         let res = self
@@ -234,6 +237,7 @@ impl Pool for RemotePoolClient {
             .get_ops_summaries(protos::GetOpsSummariesRequest {
                 entry_point: entry_point.to_proto_bytes(),
                 max_ops,
+                max_suspects,
                 filter_id: filter_id.unwrap_or_default(),
             })
             .await
@@ -376,6 +380,36 @@ impl Pool for RemotePoolClient {
         match res {
             Some(remove_ops_response::Result::Success(_)) => Ok(()),
             Some(remove_ops_response::Result::Failure(f)) => Err(f.try_into()?),
+            None => Err(PoolError::Other(anyhow::anyhow!(
+                "should have received result from op pool"
+            )))?,
+        }
+    }
+
+    async fn report_bundle_outcome(
+        &self,
+        entry_point: Address,
+        ops: Vec<B256>,
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+    ) -> PoolResult<()> {
+        let res = self
+            .op_pool_client
+            .clone()
+            .report_bundle_outcome(protos::ReportBundleOutcomeRequest {
+                entry_point: entry_point.to_proto_bytes(),
+                hashes: ops.into_iter().map(|h| h.to_proto_bytes()).collect(),
+                outcome: protos::BundleOutcome::from(outcome) as i32,
+                provider_event_active,
+            })
+            .await
+            .map_err(anyhow::Error::from)?
+            .into_inner()
+            .result;
+
+        match res {
+            Some(report_bundle_outcome_response::Result::Success(_)) => Ok(()),
+            Some(report_bundle_outcome_response::Result::Failure(f)) => Err(f.try_into()?),
             None => Err(PoolError::Other(anyhow::anyhow!(
                 "should have received result from op pool"
             )))?,

--- a/crates/pool/src/server/remote/protos.rs
+++ b/crates/pool/src/server/remote/protos.rs
@@ -29,9 +29,10 @@ use rundler_types::{
         NitroDAGasData as RundlerNitroDAGasData,
     },
     pool::{
-        AddressUpdate as PoolAddressUpdate, NewHead as PoolNewHead,
-        PaymasterMetadata as PoolPaymasterMetadata, PendingBundleInfo as RundlerPendingBundleInfo,
-        PoolOperation, PoolOperationStatus as RundlerPoolOperationStatus,
+        AddressUpdate as PoolAddressUpdate, BundleOutcome as RundlerBundleOutcome,
+        NewHead as PoolNewHead, PaymasterMetadata as PoolPaymasterMetadata,
+        PendingBundleInfo as RundlerPendingBundleInfo, PoolOperation,
+        PoolOperationStatus as RundlerPoolOperationStatus,
         PoolOperationSummary as RundlerPoolOperationSummary, PreconfInfo as RundlerPreconfInfo,
         Reputation as PoolReputation, ReputationStatus as PoolReputationStatus,
         StakeStatus as RundlerStakeStatus,
@@ -723,6 +724,7 @@ impl From<RundlerPoolOperationSummary> for PoolOperationSummary {
                 .bundler_sponsorship_max_cost
                 .map(|c| c.to_proto_bytes())
                 .unwrap_or_default(),
+            suspect: summary.suspect,
         }
     }
 }
@@ -745,7 +747,33 @@ impl TryFrom<PoolOperationSummary> for RundlerPoolOperationSummary {
             max_priority_fee_per_gas: from_bytes(&summary.max_priority_fee_per_gas)?,
             gas_limit: from_bytes(&summary.gas_limit)?,
             bundler_sponsorship_max_cost,
+            suspect: summary.suspect,
         })
+    }
+}
+
+impl From<RundlerBundleOutcome> for BundleOutcome {
+    fn from(outcome: RundlerBundleOutcome) -> Self {
+        match outcome {
+            RundlerBundleOutcome::Success => BundleOutcome::Success,
+            RundlerBundleOutcome::NonTerminalFailure => BundleOutcome::NonTerminalFailure,
+            RundlerBundleOutcome::TerminalFailure => BundleOutcome::TerminalFailure,
+            RundlerBundleOutcome::MarkSuspect => BundleOutcome::MarkSuspect,
+        }
+    }
+}
+
+impl TryFrom<BundleOutcome> for RundlerBundleOutcome {
+    type Error = ConversionError;
+
+    fn try_from(outcome: BundleOutcome) -> Result<Self, Self::Error> {
+        match outcome {
+            BundleOutcome::Success => Ok(RundlerBundleOutcome::Success),
+            BundleOutcome::NonTerminalFailure => Ok(RundlerBundleOutcome::NonTerminalFailure),
+            BundleOutcome::TerminalFailure => Ok(RundlerBundleOutcome::TerminalFailure),
+            BundleOutcome::MarkSuspect => Ok(RundlerBundleOutcome::MarkSuspect),
+            BundleOutcome::Unspecified => Err(ConversionError::InvalidEnumValue(outcome as i32)),
+        }
     }
 }
 
@@ -864,6 +892,7 @@ mod tests {
             max_priority_fee_per_gas: 56,
             gas_limit: 100_000,
             bundler_sponsorship_max_cost: Some(U256::from(500_000)),
+            suspect: true,
         };
 
         let proto = PoolOperationSummary::from(summary.clone());
@@ -883,6 +912,7 @@ mod tests {
             converted.bundler_sponsorship_max_cost,
             summary.bundler_sponsorship_max_cost
         );
+        assert_eq!(converted.suspect, summary.suspect);
     }
 
     #[test]
@@ -896,6 +926,7 @@ mod tests {
             max_priority_fee_per_gas: 56,
             gas_limit: 100_000,
             bundler_sponsorship_max_cost: None,
+            suspect: false,
         };
 
         let proto = PoolOperationSummary::from(summary.clone());

--- a/crates/pool/src/server/remote/server.rs
+++ b/crates/pool/src/server/remote/server.rs
@@ -26,7 +26,10 @@ use async_trait::async_trait;
 use futures_util::StreamExt;
 use rundler_task::{
     GracefulShutdown, TaskSpawner,
-    grpc::{grpc_metrics::GrpcMetricsLayer, protos::from_bytes},
+    grpc::{
+        grpc_metrics::GrpcMetricsLayer,
+        protos::{ConversionError, from_bytes},
+    },
 };
 use rundler_types::{
     EntityUpdate, UserOperationId, UserOperationVariant,
@@ -39,7 +42,7 @@ use tonic::{Request, Response, Result, Status, transport::Server};
 
 use super::protos::{
     AddOpRequest, AddOpResponse, AddOpSuccess, AdminSetTrackingRequest, AdminSetTrackingResponse,
-    AdminSetTrackingSuccess, DebugClearStateRequest, DebugClearStateResponse,
+    AdminSetTrackingSuccess, BundleOutcome, DebugClearStateRequest, DebugClearStateResponse,
     DebugClearStateSuccess, DebugDumpMempoolRequest, DebugDumpMempoolResponse,
     DebugDumpMempoolSuccess, DebugDumpPaymasterBalancesRequest, DebugDumpPaymasterBalancesResponse,
     DebugDumpPaymasterBalancesSuccess, DebugDumpReputationRequest, DebugDumpReputationResponse,
@@ -54,16 +57,19 @@ use super::protos::{
     MempoolOp, NotifyPendingBundleRequest, NotifyPendingBundleResponse, NotifyPendingBundleSuccess,
     OP_POOL_FILE_DESCRIPTOR_SET, PoolOperationStatus, PoolOperationSummary, RemoveOpByIdRequest,
     RemoveOpByIdResponse, RemoveOpByIdSuccess, RemoveOpsRequest, RemoveOpsResponse,
-    RemoveOpsSuccess, ReputationStatus, SubscribeNewHeadsRequest, SubscribeNewHeadsResponse,
-    TryUoFromProto, UpdateEntitiesRequest, UpdateEntitiesResponse, UpdateEntitiesSuccess,
-    add_op_response, admin_set_tracking_response, debug_clear_state_response,
-    debug_dump_mempool_response, debug_dump_paymaster_balances_response,
-    debug_dump_reputation_response, debug_set_reputation_response, get_op_by_hash_response,
-    get_op_by_id_response, get_op_status_response, get_ops_by_hashes_response, get_ops_response,
+    RemoveOpsSuccess, ReportBundleOutcomeRequest, ReportBundleOutcomeResponse,
+    ReportBundleOutcomeSuccess, ReputationStatus, SubscribeNewHeadsRequest,
+    SubscribeNewHeadsResponse, TryUoFromProto, UpdateEntitiesRequest, UpdateEntitiesResponse,
+    UpdateEntitiesSuccess, add_op_response, admin_set_tracking_response,
+    debug_clear_state_response, debug_dump_mempool_response,
+    debug_dump_paymaster_balances_response, debug_dump_reputation_response,
+    debug_set_reputation_response, get_op_by_hash_response, get_op_by_id_response,
+    get_op_status_response, get_ops_by_hashes_response, get_ops_response,
     get_ops_summaries_response, get_reputation_status_response, get_stake_status_response,
     notify_pending_bundle_response,
     op_pool_server::{OpPool, OpPoolServer},
-    remove_op_by_id_response, remove_ops_response, update_entities_response,
+    remove_op_by_id_response, remove_ops_response, report_bundle_outcome_response,
+    update_entities_response,
 };
 use crate::server::local::LocalPoolHandle;
 
@@ -229,7 +235,7 @@ impl OpPool for OpPoolImpl {
 
         let resp = match self
             .local_pool
-            .get_ops_summaries(ep, req.max_ops, filter_id)
+            .get_ops_summaries(ep, req.max_ops, req.max_suspects, filter_id)
             .await
         {
             Ok(summaries) => GetOpsSummariesResponse {
@@ -358,6 +364,49 @@ impl OpPool for OpPoolImpl {
             },
             Err(error) => RemoveOpsResponse {
                 result: Some(remove_ops_response::Result::Failure(error.into())),
+            },
+        };
+
+        Ok(Response::new(resp))
+    }
+
+    async fn report_bundle_outcome(
+        &self,
+        request: Request<ReportBundleOutcomeRequest>,
+    ) -> Result<Response<ReportBundleOutcomeResponse>> {
+        let req = request.into_inner();
+        let ep = self.get_entry_point(&req.entry_point)?;
+
+        let hashes: Vec<B256> = req
+            .hashes
+            .into_iter()
+            .map(|h| {
+                if h.len() != 32 {
+                    return Err(Status::invalid_argument("Hash must be 32 bytes long"));
+                }
+                Ok(B256::from_slice(&h))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let outcome = BundleOutcome::try_from(req.outcome)
+            .map_err(|_| Status::invalid_argument("Invalid bundle outcome"))?
+            .try_into()
+            .map_err(|e: ConversionError| Status::invalid_argument(e.to_string()))?;
+
+        let resp = match self
+            .local_pool
+            .report_bundle_outcome(ep, hashes, outcome, req.provider_event_active)
+            .await
+        {
+            Ok(_) => ReportBundleOutcomeResponse {
+                result: Some(report_bundle_outcome_response::Result::Success(
+                    ReportBundleOutcomeSuccess {},
+                )),
+            },
+            Err(error) => ReportBundleOutcomeResponse {
+                result: Some(report_bundle_outcome_response::Result::Failure(
+                    error.into(),
+                )),
             },
         };
 

--- a/crates/provider/src/transaction.rs
+++ b/crates/provider/src/transaction.rs
@@ -28,6 +28,8 @@ pub enum TransactionSubmissionError {
     Rejected,
     /// The sender account has insufficient funds.
     InsufficientFunds,
+    /// A transaction's gas limit is below its intrinsic gas cost.
+    IntrinsicGasTooLow,
 }
 
 /// Classifies a transaction submission RPC error that Rundler knows how to handle.
@@ -81,6 +83,10 @@ pub fn classify_submission_error(message: &str, code: i64) -> Option<Transaction
     // Geth, Erigon, and Reth.
     if lowercase_message.contains("insufficient funds") {
         return Some(TransactionSubmissionError::InsufficientFunds);
+    }
+    // Geth, Erigon, and Reth.
+    if lowercase_message.contains("intrinsic gas too low") {
+        return Some(TransactionSubmissionError::IntrinsicGasTooLow);
     }
     // Arbitrum sequencer.
     if lowercase_message.contains("condition not met") {

--- a/crates/provider/src/transaction.rs
+++ b/crates/provider/src/transaction.rs
@@ -158,6 +158,11 @@ mod tests {
                 TransactionSubmissionError::InsufficientFunds,
             ),
             (
+                "intrinsic gas too low: gas 20000, minimum needed 21000",
+                -32000,
+                TransactionSubmissionError::IntrinsicGasTooLow,
+            ),
+            (
                 "storage slot value condition not met",
                 -32000,
                 TransactionSubmissionError::ConditionNotMet,

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -20,7 +20,7 @@ use futures_util::StreamExt;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use rundler_types::{
     builder::{Builder, BuilderError, BundlingMode},
-    pool::Pool,
+    pool::{BundleOutcome, Pool},
 };
 
 use crate::{
@@ -51,6 +51,22 @@ pub trait DebugApi {
     /// Note that the bundling mode must be set to `Manual` else this will fail.
     #[method(name = "bundler_sendBundleNow")]
     async fn bundler_send_bundle_now(&self) -> RpcResult<B256>;
+
+    /// Directly reports a bundle outcome to the pool for the given ops,
+    /// bypassing any real RPC submission or on-chain revert. Lets manual
+    /// poison-user-operation testing and incident response drive
+    /// `Pool::report_bundle_outcome` (see
+    /// `docs/designs/poison-user-operations.md`) deterministically -
+    /// e.g. to force-quarantine a suspected op, or to clear a false
+    /// positive. `outcome` is one of "success", "non_terminal_failure",
+    /// "terminal_failure", "mark_suspect".
+    #[method(name = "bundler_forceReportBundleOutcome")]
+    async fn bundler_force_report_bundle_outcome(
+        &self,
+        entry_point: Address,
+        ops: Vec<B256>,
+        outcome: String,
+    ) -> RpcResult<String>;
 
     /// Sets the bundling mode.
     #[method(name = "bundler_setBundlingMode")]
@@ -133,6 +149,19 @@ where
         utils::safe_call_rpc_handler(
             "bundler_sendBundleNow",
             DebugApi::bundler_send_bundle_now(self),
+        )
+        .await
+    }
+
+    async fn bundler_force_report_bundle_outcome(
+        &self,
+        entry_point: Address,
+        ops: Vec<B256>,
+        outcome: String,
+    ) -> RpcResult<String> {
+        utils::safe_call_rpc_handler(
+            "bundler_forceReportBundleOutcome",
+            DebugApi::bundler_force_report_bundle_outcome(self, entry_point, ops, outcome),
         )
         .await
     }
@@ -292,6 +321,33 @@ where
         }
 
         Ok(tx)
+    }
+
+    async fn bundler_force_report_bundle_outcome(
+        &self,
+        entry_point: Address,
+        ops: Vec<B256>,
+        outcome: String,
+    ) -> InternalRpcResult<String> {
+        let outcome = match outcome.as_str() {
+            "success" => BundleOutcome::Success,
+            "non_terminal_failure" => BundleOutcome::NonTerminalFailure,
+            "terminal_failure" => BundleOutcome::TerminalFailure,
+            "mark_suspect" => BundleOutcome::MarkSuspect,
+            other => {
+                return Err(anyhow::anyhow!(
+                    "unknown outcome {other:?}, expected one of: success, non_terminal_failure, terminal_failure, mark_suspect"
+                )
+                .into());
+            }
+        };
+
+        self.pool
+            .report_bundle_outcome(entry_point, ops, outcome, false)
+            .await
+            .context("should report bundle outcome")?;
+
+        Ok("ok".to_string())
     }
 
     async fn bundler_set_bundling_mode(&self, mode: BundlingMode) -> InternalRpcResult<String> {

--- a/crates/types/src/chain.rs
+++ b/crates/types/src/chain.rs
@@ -142,6 +142,9 @@ pub struct ChainSpec {
     pub flashbots_relay_url: Option<String>,
     /// True if the bloxroute sender is enabled on this chain
     pub bloxroute_enabled: bool,
+    /// True if this chain's node rejects transactions with `-32000: internal error`
+    /// as a terminal, per-transaction rejection rather than a provider outage
+    pub internal_rpc_error_is_terminal: bool,
 
     /*
      * Pool
@@ -215,6 +218,7 @@ impl Default for ChainSpec {
             flashbots_enabled: false,
             flashbots_relay_url: None,
             bloxroute_enabled: false,
+            internal_rpc_error_is_terminal: false,
             chain_history_size: 64,
             signature_aggregators: Arc::new(ContractRegistry::default()),
             submission_proxies: Arc::new(ContractRegistry::default()),

--- a/crates/types/src/pool/traits.rs
+++ b/crates/types/src/pool/traits.rs
@@ -96,9 +96,15 @@ pub trait Pool: Send + Sync {
 
     /// Get summaries of operations from the pool
     ///
-    /// Returns up to `max_ops` non-suspect operations, plus up to `max_suspects`
-    /// suspect operations whose isolation retry delay has elapsed, marked with
-    /// `suspect: true`. Suspects do not count against `max_ops`.
+    /// Returns up to `max_ops` non-suspect operations, followed by up to
+    /// `max_suspects` suspect operations whose isolation retry delay has
+    /// elapsed, marked with `suspect: true`. Suspects do not count against
+    /// `max_ops` and are always ordered after non-suspects in the returned
+    /// vec — but that ordering is an implementation detail, not something to
+    /// index into: callers that need to separate the two groups (e.g. the
+    /// builder's assigner) must partition on the `suspect` flag on each
+    /// summary rather than assume position, since the non-suspect share can
+    /// itself be shorter than `max_ops`.
     async fn get_ops_summaries(
         &self,
         entry_point: Address,

--- a/crates/types/src/pool/traits.rs
+++ b/crates/types/src/pool/traits.rs
@@ -49,6 +49,27 @@ pub struct PoolOperationSummary {
     pub gas_limit: u128,
     /// Maximum WEI the bundler will pay for this operation (None if not sponsored)
     pub bundler_sponsorship_max_cost: Option<U256>,
+    /// Whether the operation is suspected of poisoning bundles and must only be
+    /// submitted alone. See `docs/designs/poison-user-operations.md`.
+    pub suspect: bool,
+}
+
+/// Final outcome of a bundle submission attempt, reported to the pool for poison
+/// user operation tracking. See `docs/designs/poison-user-operations.md`.
+///
+/// Neutral outcomes (known operational errors with dedicated handling) are not
+/// reported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BundleOutcome {
+    /// The bundle transaction was accepted by the provider.
+    Success,
+    /// Transport failure, timeout, or ambiguous rejection; acceptance unknown.
+    NonTerminalFailure,
+    /// Final rejection; retrying the identical transaction cannot succeed.
+    TerminalFailure,
+    /// Mark every operation in the bundle as suspect, e.g. after an
+    /// unattributed mined revert of a multi-operation bundle.
+    MarkSuspect,
 }
 
 /// Pool server trait
@@ -74,10 +95,15 @@ pub trait Pool: Send + Sync {
     ) -> PoolResult<Vec<PoolOperation>>;
 
     /// Get summaries of operations from the pool
+    ///
+    /// Returns up to `max_ops` non-suspect operations, plus up to `max_suspects`
+    /// suspect operations whose isolation retry delay has elapsed, marked with
+    /// `suspect: true`. Suspects do not count against `max_ops`.
     async fn get_ops_summaries(
         &self,
         entry_point: Address,
         max_ops: u64,
+        max_suspects: u64,
         filter_id: Option<String>,
     ) -> PoolResult<Vec<PoolOperationSummary>>;
 
@@ -105,6 +131,19 @@ pub trait Pool: Send + Sync {
         entry_point: Address,
         id: UserOperationId,
     ) -> PoolResult<Option<B256>>;
+
+    /// Report the final outcome of a bundle submission attempt for the given
+    /// operations, for poison user operation tracking.
+    ///
+    /// `provider_event_active` gates suspect creation: while true, non-terminal
+    /// failures do not advance the failure counts of non-suspect operations.
+    async fn report_bundle_outcome(
+        &self,
+        entry_point: Address,
+        ops: Vec<B256>,
+        outcome: BundleOutcome,
+        provider_event_active: bool,
+    ) -> PoolResult<()>;
 
     /// Get extended status for a user operation
     async fn get_op_status(&self, hash: B256) -> PoolResult<Option<PoolOperationStatus>>;
@@ -197,6 +236,7 @@ impl From<&PoolOperation> for PoolOperationSummary {
             max_priority_fee_per_gas: op.uo.max_priority_fee_per_gas(),
             gas_limit: op.uo.total_gas_limit(),
             bundler_sponsorship_max_cost: op.perms.bundler_sponsorship.as_ref().map(|s| s.max_cost),
+            suspect: false,
         }
     }
 }
@@ -223,6 +263,7 @@ mockall::mock! {
             &self,
             entry_point: Address,
             max_ops: u64,
+            max_suspects: u64,
             filter_id: Option<String>,
         ) -> PoolResult<Vec<PoolOperationSummary>>;
         async fn get_ops_by_hashes(
@@ -238,6 +279,13 @@ mockall::mock! {
             entry_point: Address,
             id: UserOperationId,
         ) -> PoolResult<Option<B256>>;
+        async fn report_bundle_outcome(
+            &self,
+            entry_point: Address,
+            ops: Vec<B256>,
+            outcome: BundleOutcome,
+            provider_event_active: bool,
+        ) -> PoolResult<()>;
         async fn update_entities(
             &self,
             entry_point: Address,

--- a/crates/types/src/pool/traits.rs
+++ b/crates/types/src/pool/traits.rs
@@ -135,8 +135,8 @@ pub trait Pool: Send + Sync {
     /// Report the final outcome of a bundle submission attempt for the given
     /// operations, for poison user operation tracking.
     ///
-    /// `provider_event_active` gates suspect creation: while true, non-terminal
-    /// failures do not advance the failure counts of non-suspect operations.
+    /// While `provider_event_active` is true, a non-terminal failure is not
+    /// evidence against its operations and changes no operation state.
     async fn report_bundle_outcome(
         &self,
         entry_point: Address,

--- a/crates/types/src/pool/traits.rs
+++ b/crates/types/src/pool/traits.rs
@@ -135,8 +135,10 @@ pub trait Pool: Send + Sync {
     /// Report the final outcome of a bundle submission attempt for the given
     /// operations, for poison user operation tracking.
     ///
-    /// While `provider_event_active` is true, a non-terminal failure is not
-    /// evidence against its operations and changes no operation state.
+    /// While `provider_event_active` is true, suspect analysis continues but
+    /// removal progress pauses: non-terminal failures still count toward
+    /// suspicion, while suspects only refresh their isolation backoff and
+    /// never advance toward removal.
     async fn report_bundle_outcome(
         &self,
         entry_point: Address,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -215,7 +215,7 @@ List of command line options for configuring the Pool.
 - `--pool.rpc_failures_before_suspect`: Number of non-terminal RPC submission failures before a UO becomes a suspect and is only submitted alone (default: `3`)
   - env: _POOL_RPC_FAILURES_BEFORE_SUSPECT_
   - See [poison user operations](./designs/poison-user-operations.md) for details. With a single builder signer, the scheduler cannot guarantee progress for both suspect and normal work when both remain continuously eligible.
-- `--pool.max_suspect_rpc_failures`: Number of non-terminal RPC submission failures a suspect is allowed before it is removed from the pool. `0` disables removal. (default: `3`)
+- `--pool.max_suspect_rpc_failures`: Number of non-terminal RPC submission failures a suspect is allowed before it is removed from the pool. `0` disables removal. (default: `8`)
   - env: _POOL_MAX_SUSPECT_RPC_FAILURES_
   - The suspect backoff schedule spaces these failures; a provider incident outlasting the cumulative backoff can remove healthy UOs. Raise this threshold to tolerate longer incidents.
 - `--pool.suspect_rpc_backoff_initial_secs`: Initial delay in seconds between suspect isolation attempts, doubling with each failure (default: `1`)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -209,6 +209,9 @@ List of command line options for configuring the Pool.
   - env: _POOL_DROP_MIN_NUM_BLOCKS_
 - `--pool.max_time_in_pool_secs`: The maximum amount of time a UO is allowed to be in the mempool, in seconds. (default: `None`)
   - env: _POOL_MAX_TIME_IN_POOL_SECS_
+- `--pool.suspect_tracking_enabled`: Master switch for poison user operation handling — suspect tracking, isolation, and removal (default: `false`)
+  - env: _POOL_SUSPECT_TRACKING_ENABLED_
+  - When disabled, bundle outcomes change no UO state and the `pool.*suspect*` options below have no effect.
 - `--pool.rpc_failures_before_suspect`: Number of non-terminal RPC submission failures before a UO becomes a suspect and is only submitted alone (default: `3`)
   - env: _POOL_RPC_FAILURES_BEFORE_SUSPECT_
   - See [poison user operations](./designs/poison-user-operations.md) for details. With a single builder signer, the scheduler cannot guarantee progress for both suspect and normal work when both remain continuously eligible.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -209,6 +209,16 @@ List of command line options for configuring the Pool.
   - env: _POOL_DROP_MIN_NUM_BLOCKS_
 - `--pool.max_time_in_pool_secs`: The maximum amount of time a UO is allowed to be in the mempool, in seconds. (default: `None`)
   - env: _POOL_MAX_TIME_IN_POOL_SECS_
+- `--pool.rpc_failures_before_suspect`: Number of non-terminal RPC submission failures before a UO becomes a suspect and is only submitted alone (default: `3`)
+  - env: _POOL_RPC_FAILURES_BEFORE_SUSPECT_
+  - See [poison user operations](./designs/poison-user-operations.md) for details. With a single builder signer, the scheduler cannot guarantee progress for both suspect and normal work when both remain continuously eligible.
+- `--pool.max_suspect_rpc_failures`: Number of non-terminal RPC submission failures a suspect is allowed before it is removed from the pool. `0` disables removal. (default: `3`)
+  - env: _POOL_MAX_SUSPECT_RPC_FAILURES_
+  - The suspect backoff schedule spaces these failures; a provider incident outlasting the cumulative backoff can remove healthy UOs. Raise this threshold to tolerate longer incidents.
+- `--pool.suspect_rpc_backoff_initial_secs`: Initial delay in seconds between suspect isolation attempts, doubling with each failure (default: `1`)
+  - env: _POOL_SUSPECT_RPC_BACKOFF_INITIAL_SECS_
+- `--pool.suspect_rpc_backoff_max_secs`: Maximum delay in seconds between suspect isolation attempts (default: `600`)
+  - env: _POOL_SUSPECT_RPC_BACKOFF_MAX_SECS_
 
 ## Builder Options
 

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -1,0 +1,163 @@
+# Poison User Operations
+
+Status: Draft
+
+## Goals
+
+1. **Liveness:** isolate suspected poison UOs and eventually remove UOs that continue to
+   fail, preventing them from blocking bundle submission indefinitely.
+2. **Fairness:** schedule healthy and suspect UOs so neither work class can starve the
+   other.
+3. **Provider resilience:** detect provider-health events and prevent their failures from
+   causing non-poison UOs to be removed in most cases.
+
+## How the goals are achieved
+
+### Liveness
+
+Attributed execution failures and singleton terminal RPC errors remove their UOs
+immediately. Ambiguous multi-UO failures move their UOs into suspect isolation, where
+each is attempted alone. Repeated non-terminal failures from an isolated UO are spaced
+with exponential backoff and eventually remove the UO at the configured threshold.
+
+Setting `--pool.max_suspect_rpc_failures=0` deliberately disables the eventual-removal
+guarantee for non-terminal failures.
+
+### Fairness
+
+Suspects cannot consume normal bundle capacity because they are submitted alone and
+isolation is capped while normal work remains. When both work classes are eligible, the
+assigner fills isolation capacity up to `max(1, num_signers / 2)` and uses the remaining
+builders for normal bundles. When normal work is exhausted, the limit expands so idle
+builders can drain suspects. Per-suspect backoff prevents one suspect from continuously
+consuming isolation capacity.
+
+Two-way starvation protection requires at least two builders. With one builder and no
+alternation rule, the scheduler cannot guarantee progress for both work classes when
+both remain continuously eligible.
+
+### Provider resilience
+
+Only final outcomes after provider retries and fallbacks affect the provider-event
+signal. During a detected event, non-terminal failures do not create suspects, advance
+removal counters, or remove UOs. Entering the event clears accumulated non-terminal
+failure evidence, while suspect backoff continues to limit repeated isolation attempts.
+
+Detection requires a rolling sample, so failures observed before the signal activates
+may still affect UO state. Terminal RPC errors also bypass provider-health gating because
+they definitively reject the transaction. These are the principal cases in which a
+provider event could still affect a non-poison UO.
+
+## Failure flow
+
+| Failure | Bundle size | Action |
+| --- | ---: | --- |
+| Attributed execution failure | Any | Remove the attributed UOs immediately. |
+| Unattributed mined revert | 1 | Remove the sole UO immediately. |
+| Unattributed mined revert | More than 1 | Mark every UO as suspect. |
+| Terminal RPC error | 1 | Remove the sole UO immediately. |
+| Terminal RPC error | More than 1 | Mark every UO as suspect immediately. |
+| Non-terminal provider failure while provider is healthy | Any | Increment each non-suspect UO's RPC-failure count; mark it suspect at the configured threshold. |
+| Non-terminal provider failure from an isolated suspect while provider is healthy | 1 | Increment its suspect RPC-failure count and either back off or remove it at the configured threshold. |
+| Non-terminal provider failure from an isolated suspect during a provider event | 1 | Apply suspect backoff without incrementing its removal count. |
+| Non-terminal provider failure from a normal bundle during a provider event | Any | Do not change UO state. |
+| Known operational error | Any | Preserve existing behavior. |
+
+Provider retries and configured fallbacks are exhausted before an RPC outcome enters
+this flow. A successful fallback has no effect on UO state.
+
+A terminal RPC error is a final response indicating that the transaction was rejected
+and should not be retried unchanged. It bypasses provider-health gating and repeated-
+failure thresholds. Transport failures, timeouts, and responses that leave acceptance
+unknown are non-terminal.
+
+## Provider-event signal
+
+Each configured submission route, including its primary and fallbacks, maintains a
+rolling window shared by its builders. Only final submission outcomes are recorded:
+
+- `Success`: the transaction was accepted.
+- `ProviderFailure`: non-terminal transport failure, timeout, sender unavailable, or
+  exhausted rate limit.
+- `Neutral`: known operational errors such as underpriced or nonce-too-low. Neutral
+  outcomes are excluded from the window.
+
+Terminal RPC errors are handled before this signal and are excluded from its window.
+
+Initial parameters:
+
+- Window: last 20 non-neutral outcomes.
+- Enter a provider event after at least 10 observations when at least 30% are failures.
+- Exit the event when fewer than 10% are failures.
+
+Different enter and exit thresholds prevent flapping. The signal does not change bundle
+construction or submission rate; existing provider rate limiting handles request pacing.
+
+The builder updates the signal before processing non-terminal UO feedback. While a
+provider event is active, non-terminal failures cannot mark suspects, increment removal
+counters, or remove UOs. They may still defer an isolated suspect's next attempt.
+Entering an event clears all accumulated non-terminal RPC-failure counters. Existing
+suspect status remains, including suspicion created by mined reverts or terminal RPC
+errors, but its non-terminal removal counter resets.
+
+## Non-terminal RPC evidence
+
+Outside a provider event:
+
+1. A final non-terminal provider failure increments the pre-suspect count of every UO in
+   the failed bundle.
+2. A successful submission clears the pre-suspect counts of every UO in that bundle.
+3. At `--pool.rpc_failures_before_suspect` (default `3`), a UO becomes a suspect and its
+   count resets.
+4. A final provider failure from its single-UO attempt schedules an exponentially
+   increasing retry delay with jitter.
+5. If the provider-event signal is healthy, the failure also increments the suspect's
+   removal count.
+6. At `--pool.max_suspect_rpc_failures` (default `3`), the pool removes the UO and logs
+   `RepeatedNonTerminalRpcFailure`.
+
+`--pool.max_suspect_rpc_failures=0` disables RPC-based removal. Provider-event periods do
+not contribute to either threshold, but suspect backoff still applies.
+
+Suspect backoff is configured with `--pool.suspect_rpc_backoff_initial_secs` and
+`--pool.suspect_rpc_backoff_max_secs`.
+
+## Suspect scheduling
+
+- Suspects are excluded from normal bundles and are attempted one UO at a time after
+  their retry delay has elapsed.
+- When both work classes are eligible, isolation assignments are filled up to the
+  current isolation limit and remaining builders receive normal work.
+- When normal work is eligible, new isolation assignments may use at most
+  `max(1, num_signers / 2)` builders.
+- When all normal work has been assigned or is otherwise ineligible, every builder may
+  isolate.
+- The assigner recomputes this limit for every assignment.
+- Existing isolation transactions are not canceled when normal work arrives, but no new
+  isolation work is assigned above the reduced limit.
+
+A successful isolation submission follows normal transaction tracking. A mined revert
+or terminal RPC error removes the UO immediately. Other failures preserve its suspect
+state.
+
+## State ownership
+
+The submission route owns the provider-event signal. The pool owns pre-suspect counts,
+suspect status, suspect removal counts, and suspect retry times so they are shared across
+builders and cleared with the UO lifecycle. Backoff progression is separate from removal
+evidence: provider-event failures increase the former but not the latter. This state is
+in-memory and does not track transaction hashes for deduplication.
+
+## Tradeoffs
+
+- **Liveness versus false removal:** eventual removal protects bundling, but repeated
+  non-terminal failures can still remove a healthy UO when the provider-event signal
+  does not activate. Higher thresholds reduce false removals but extend poison lifetime.
+- **Isolation versus throughput:** singleton attempts identify poison UOs without adding
+  innocent fillers, but consume more transactions than normal bundles. The dynamic
+  isolation limit preserves normal capacity at the cost of slower suspect draining.
+- **Provider protection versus poison detection:** suppressing evidence during provider
+  events prevents broad false attribution, but a poison UO encountered during an event
+  takes longer to identify. Detection lag can also allow early event failures to count.
+- **Backoff versus recovery latency:** per-suspect backoff prevents hot loops and resource
+  churn, but delays successful retry after a transient failure.

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -324,6 +324,13 @@ exclusion behind PR 4.
   all.
 - Ships last deliberately — without it the system is fully functional, just without
   outage protection (bounded in the interim only by the backoff spacing from PR 2).
+- Deliberately independent of `FallbackTransactionSender`'s own consecutive-failure
+  failover: that counter reacts to a handful of consecutive errors from one builder's
+  primary sender so it can reroute traffic quickly, while this signal needs a larger,
+  hysteretic sample across all of a route's builders before it gates something as
+  consequential as pausing removal pool-wide. It's also circular to feed one from the
+  other — the signal only observes outcomes *after* failover has already run. The two
+  stay independently tunable.
 
 ## Related work
 

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -173,8 +173,10 @@ state.
 
 ## State ownership
 
-The submission route owns the provider-event signal; the pool consumes it as a single
-boolean gate on suspect removal progress. The pool owns each UO's failure counter (from
+One provider-event signal exists per submission route, shared by the route's builders;
+the bundle sender records final outcomes into it downstream of provider retries and
+fallbacks, and the pool consumes it as a single boolean gate on suspect removal
+progress. The pool owns each UO's failure counter (from
 which suspect status is derived) and suspect retry time so they are shared across
 builders and cleared with the UO lifecycle. This state is in-memory and does not track
 transaction hashes for deduplication.
@@ -297,15 +299,19 @@ exclusion behind PR 4.
 ### PR 5 — Provider-event signal
 
 - Implement the rolling window (last 20 non-neutral final outcomes; enter event at ≥10
-  observations with ≥30% failures, exit below 10%) as a small shared struct owned by
-  the submission route. Record outcomes in `FallbackTransactionSender`
-  (`crates/builder/src/sender/fallback.rs`) after retries/fallbacks are exhausted —
-  success, `ProviderFailure`, or neutral (excluded). Non-fallback senders wrap the same
-  recorder.
-- Expose it as a shared `Arc` boolean checked by the bundle sender when calling
-  `report_bundle_outcome` (the `provider_event_active` flag from PR 2). Its only
-  effect: pause suspect removal progress. Suspect creation and backoff are
-  unaffected, and no counters are cleared on enter/exit.
+  observations with ≥30% failures, exit below 10%) as a small shared struct
+  (`ProviderEventSignal`, `crates/builder/src/sender/health.rs`), one per submission
+  route, shared by the route's builders.
+- Record outcomes in the bundle sender where it already classifies final submission
+  results (`send_bundle_from_data`): this sits downstream of the
+  `FallbackTransactionSender`'s internal retries and failover, so only final outcomes
+  after retries/fallbacks are observed — success, non-terminal provider failure, or
+  neutral/terminal (excluded). Cancellation transactions are not recorded.
+- The bundle sender checks the signal when calling `report_bundle_outcome` (the
+  `provider_event_active` flag from PR 2), recording a failure before reporting it so
+  the report is gated by the freshest state. The signal's only effect: pause suspect
+  removal progress. Suspect creation and backoff are unaffected, and no counters are
+  cleared on enter/exit.
 - Consider recording only transport-level failures (timeouts, connection failures,
   sender unavailable) in the window and excluding error responses: a node that
   evaluates a transaction and answers is not an outage, and rejected-with-a-response

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -209,8 +209,8 @@ helper (`builder_sender` scope) for anything that varies by submission route.
 | `num_suspects_cleared` | Counter | pool | Liveness | Successful submissions that reset a suspect's counter — the recovery path the provider-resilience tradeoff depends on. |
 | `num_suspects_removed` | Counter | pool | Liveness | Removals via `TerminalRpcError` or `RepeatedNonTerminalRpcFailure`, combined. |
 | `suspect_tracking_enabled` | Gauge (0/1) | pool | — | Master switch state, set once at construction; lets a dashboard confirm rollout state without cross-referencing CLI flags. |
-| `ep_isolation_limit` | Gauge, per entry point | assigner | Fairness | The computed cap for the current assignment cycle: `max(1, num_signers / 2)` while normal work is eligible, otherwise uncapped. |
-| `ep_isolating_builders` | Gauge, per entry point | assigner | Fairness | Current size of `isolating_builders`. Paired with the limit, shows whether isolation is capacity-starved or simply idle. |
+| `isolation_limit` | Gauge, global | assigner | Fairness | The computed cap for the current assignment cycle: `max(1, num_signers / 2)` while normal work is eligible, otherwise uncapped. Global, not per entry point — isolation capacity is shared by one builder pool across all configured entrypoints. |
+| `isolating_builders` | Gauge, global | assigner | Fairness | Current size of `isolating_builders`. Paired with the limit, shows whether isolation is capacity-starved or simply idle. |
 | `builder_bundle_outcome_success` / `_non_terminal_failure` / `_terminal_failure` / `_mark_suspect` | Counter, per sender + entry point | sender | Liveness / Provider resilience | One counter per `BundleOutcome` reported via `report_bundle_outcome`, at the same call sites that classify the submission result. |
 | `builder_bundle_outcome_report_failed` | Counter, per sender + entry point | sender | — | The existing "Failed to report bundle outcome to pool" warning, counted. A sustained rate means pool suspect state is silently diverging from what actually happened on submission. |
 | `provider_events_total` | Counter | sender | Provider resilience | Total enter transitions, alongside the existing `provider_event_active` gauge — a rate here is a flapping detector the gauge alone can't show. |
@@ -241,7 +241,7 @@ rather than by crate:
 
 - **Liveness** — `num_suspect_ops` over time; marked/cleared/removed rates plotted
   together to show whether isolation is keeping pace.
-- **Fairness** — `ep_isolating_builders` vs. `ep_isolation_limit` vs. `num_signers`,
+- **Fairness** — `isolating_builders` vs. `isolation_limit` vs. `num_signers`,
   alongside isolation- vs. normal-assignment rates.
 - **Provider resilience** — `provider_event_active` as a state timeline with
   `provider_events_total` rate overlaid, and suspect-removal rate on the same timeline to

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -106,30 +106,39 @@ is entered or exited.
 
 ## Non-terminal RPC evidence
 
+Each UO carries a single failure counter measured against two thresholds. Suspect
+status is derived, not stored: a UO is a suspect once its counter reaches
+`--pool.rpc_failures_before_suspect` (default `3`), and is removed
+`--pool.max_suspect_rpc_failures` (default `3`) failures later.
+
 1. Outside a provider event, a final non-terminal provider failure increments the
-   pre-suspect count of every UO in the failed bundle. During an event, pre-suspect
-   counts do not advance.
-2. A successful submission clears the pre-suspect counts of every UO in that bundle.
-3. At `--pool.rpc_failures_before_suspect` (default `3`), a UO becomes a suspect and its
-   count resets.
-4. A final provider failure from its single-UO attempt schedules an exponentially
-   increasing retry delay with jitter.
-5. The failure also increments the suspect's removal count, regardless of
-   provider-event state.
-6. At `--pool.max_suspect_rpc_failures` (default `3`), the pool removes the UO and logs
-   `RepeatedNonTerminalRpcFailure`.
+   failure counter of every UO in the failed bundle. During an event, only counters
+   already past the suspect threshold advance.
+2. A successful submission resets the failure counter of every UO in that bundle,
+   clearing suspect status.
+3. At the suspect threshold the UO is excluded from normal bundles and becomes
+   eligible for an immediate isolation attempt.
+4. Each failure past the suspect threshold schedules an exponentially increasing
+   retry delay with jitter, and counts toward removal regardless of provider-event
+   state.
+5. At `suspect threshold + max_suspect_rpc_failures` total failures, the pool removes
+   the UO and logs `RepeatedNonTerminalRpcFailure`.
+
+Ambiguous multi-UO terminal failures and unattributed mined reverts force suspicion
+by raising the counter directly to the suspect threshold, never lowering it.
 
 `--pool.max_suspect_rpc_failures=0` disables RPC-based removal. Provider events pause
 pre-suspect counting only; suspect removal counting and backoff continue.
 
-Suspect backoff is configured with `--pool.suspect_rpc_backoff_initial_secs` and
-`--pool.suspect_rpc_backoff_max_secs`. The schedule is load-bearing for the
-false-removal bound: the cumulative delay across `max_suspect_rpc_failures` consecutive
-attempts must exceed the longest provider incident that removal should tolerate, so
-that a single incident contributes at most one removal increment. With doubling from a
-60-second initial, three increments span only about three minutes; tolerating a
-30-minute incident requires a larger initial (for example 600 seconds: 10 m + 20 m
-between increments), a steeper curve, or a higher removal threshold.
+Suspect backoff is configured with `--pool.suspect_rpc_backoff_initial_secs`
+(default `1`) and `--pool.suspect_rpc_backoff_max_secs` (default `600`). The schedule
+bounds false removal: the cumulative delay across `max_suspect_rpc_failures`
+consecutive attempts must exceed the longest provider incident that removal should
+tolerate, so that a single incident contributes at most one removal increment. The
+defaults favor fast poison eviction — the first three increments span only a few
+seconds, so a provider blip can remove a suspect. Tolerating a 30-minute incident
+requires a larger initial (for example 600 seconds: 10 m + 20 m between increments),
+a steeper curve, or a higher removal threshold.
 
 ## Suspect scheduling
 
@@ -152,10 +161,10 @@ state.
 ## State ownership
 
 The submission route owns the provider-event signal; the pool consumes it as a single
-boolean gate on pre-suspect counting. The pool owns pre-suspect counts, suspect status,
-suspect removal counts, and suspect retry times so they are shared across builders and
-cleared with the UO lifecycle. This state is in-memory and does not track transaction
-hashes for deduplication.
+boolean gate on pre-suspect counting. The pool owns each UO's failure counter (from
+which suspect status is derived) and suspect retry time so they are shared across
+builders and cleared with the UO lifecycle. This state is in-memory and does not track
+transaction hashes for deduplication.
 
 ## Tradeoffs
 
@@ -203,25 +212,32 @@ sees it.
 ### PR 2 — Pool-owned suspect state + trait surface
 
 - Add per-UO mutable state to `OrderedPoolOperation`
-  (`crates/pool/src/mempool/pool.rs`), which already uses interior `RwLock`s:
-  `pre_suspect_failures: u32`, `suspect: bool`, `suspect_removal_failures: u32`,
-  `retry_after: Option<Instant>`. State dies with the UO — no separate tracker needed.
+  (`crates/pool/src/mempool/pool.rs`), which already uses interior `RwLock`s: a single
+  `failures: u32` counter plus `retry_after: Option<Instant>`. Suspect status is
+  derived from the counter against the two thresholds; a success resets it. State
+  dies with the UO — no separate tracker needed.
 - Add config to `PoolConfig` (`crates/pool/src/mempool/mod.rs`) and CLI args in
   `bin/rundler/src/cli/pool.rs`: `rpc_failures_before_suspect` (default 3),
   `max_suspect_rpc_failures` (default 3, 0 disables removal),
-  `suspect_rpc_backoff_initial_secs`, `suspect_rpc_backoff_max_secs`.
-- Add one new `Pool` trait method (`crates/types/src/pool/traits.rs`), roughly
-  `report_bundle_outcome(ops, outcome, provider_event_active)`, where outcome is
-  success / non-terminal failure / terminal failure / mark-suspect. The pool applies
-  the failure-flow table internally: clear counts on success, increment pre-suspect
-  counts (unless a provider event is active), promote to suspect at threshold,
-  increment removal counts + compute backoff for isolated suspects, remove at
-  `max_suspect_rpc_failures` with a new
-  `OpRemovalReason::RepeatedNonTerminalRpcFailure` (`crates/pool/src/emit.rs`).
-  Implement in `UoPool`, `LocalPoolHandle`, and the remote protobuf client/server.
-- Exclude suspects from `best_operations` (`crates/pool/src/mempool/uo_pool.rs`) and
-  expose suspects whose `retry_after` has elapsed (a flag on the existing summaries
-  query is simpler than a new method).
+  `suspect_rpc_backoff_initial_secs` (default 1), `suspect_rpc_backoff_max_secs`
+  (default 600).
+- Add one new `Pool` trait method (`crates/types/src/pool/traits.rs`),
+  `report_bundle_outcome(entry_point, ops, outcome, provider_event_active)`, where
+  outcome is success / non-terminal failure / terminal failure / mark-suspect. The
+  pool applies the failure-flow table internally: reset counters on success,
+  increment counters on non-terminal failure (skipping non-suspects while a provider
+  event is active), compute backoff for isolated suspects, remove at the removal
+  threshold with a new `OpRemovalReason::RepeatedNonTerminalRpcFailure`, and remove
+  terminally rejected singletons with `OpRemovalReason::TerminalRpcError`
+  (`crates/pool/src/emit.rs`). Implement in `UoPool`, `LocalPoolHandle`, and the
+  remote protobuf client/server.
+- Exclude suspects from `best_operations` (`crates/pool/src/mempool/pool.rs`). Rather
+  than a new query method, `get_ops_summaries` takes a `max_suspects` cap and appends
+  due suspects (retry delay elapsed) to its response, marked with a `suspect` flag on
+  `PoolOperationSummary`; the assigner passes `max_suspects: 0` until PR 4. Because
+  the flag rides on the summary, this degrades gracefully if PR 3 lands first:
+  requesting no suspects leaves them waiting invisibly, and any nonzero cap without
+  isolation scheduling simply restores today's behavior.
 
 ### PR 3 — Failure flow in the bundle sender
 

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -175,6 +175,107 @@ hashes for deduplication.
 - **Backoff versus recovery latency:** per-suspect backoff prevents hot loops and resource
   churn, but delays successful retry after a transient failure.
 
+## Implementation plan
+
+Five self-contained PRs that build in order. PRs 1–2 are inert plumbing (no visible
+behavior change), PR 3 is the behavior switch, and PRs 4–5 are independent of each
+other once PR 3 lands.
+
+### PR 1 — Terminal vs. non-terminal error classification (foundation)
+
+Everything downstream depends on knowing whether a submission failure is terminal,
+non-terminal, or neutral. Today that distinction is destroyed before the bundle sender
+sees it.
+
+- Add a classification to `TxSenderError` (`crates/builder/src/sender/mod.rs`):
+  terminal (final rejection, don't retry unchanged), non-terminal (transport failure,
+  timeout, `SenderUnavailable`, rate-limit exhaustion), neutral (underpriced,
+  nonce-too-low, other known operational errors). A small `enum RpcOutcomeClass` plus a
+  `classify()` method is enough.
+- Fix the collapse in `From<TxSenderError> for TransactionTrackerError`
+  (`crates/builder/src/transaction_tracker.rs`), where `SenderUnavailable` and `Other`
+  both become `TransactionTrackerError::Other`. The tracker error must carry the class
+  through to `bundle_sender.rs`.
+- Route the `-32000: internal error` class to non-terminal-ambiguous (it currently maps
+  to `SenderUnavailable`). Per this design, this supersedes the PR #1304 approach —
+  that PR's remove-all behavior must not land alongside this.
+
+### PR 2 — Pool-owned suspect state + trait surface
+
+- Add per-UO mutable state to `OrderedPoolOperation`
+  (`crates/pool/src/mempool/pool.rs`), which already uses interior `RwLock`s:
+  `pre_suspect_failures: u32`, `suspect: bool`, `suspect_removal_failures: u32`,
+  `retry_after: Option<Instant>`. State dies with the UO — no separate tracker needed.
+- Add config to `PoolConfig` (`crates/pool/src/mempool/mod.rs`) and CLI args in
+  `bin/rundler/src/cli/pool.rs`: `rpc_failures_before_suspect` (default 3),
+  `max_suspect_rpc_failures` (default 3, 0 disables removal),
+  `suspect_rpc_backoff_initial_secs`, `suspect_rpc_backoff_max_secs`.
+- Add one new `Pool` trait method (`crates/types/src/pool/traits.rs`), roughly
+  `report_bundle_outcome(ops, outcome, provider_event_active)`, where outcome is
+  success / non-terminal failure / terminal failure / mark-suspect. The pool applies
+  the failure-flow table internally: clear counts on success, increment pre-suspect
+  counts (unless a provider event is active), promote to suspect at threshold,
+  increment removal counts + compute backoff for isolated suspects, remove at
+  `max_suspect_rpc_failures` with a new
+  `OpRemovalReason::RepeatedNonTerminalRpcFailure` (`crates/pool/src/emit.rs`).
+  Implement in `UoPool`, `LocalPoolHandle`, and the remote protobuf client/server.
+- Exclude suspects from `best_operations` (`crates/pool/src/mempool/uo_pool.rs`) and
+  expose suspects whose `retry_after` has elapsed (a flag on the existing summaries
+  query is simpler than a new method).
+
+### PR 3 — Failure flow in the bundle sender
+
+Wire `bundle_sender.rs` to call `report_bundle_outcome` per the failure-flow table:
+
+- **Attributed execution failures**: already removed via `rejected_op_hashes` —
+  unchanged.
+- **Unattributed mined revert** (`handle_pending_state` → `process_revert`, decoding in
+  `bundle_proposer.rs`): the `None | Revert | PostOpRevert` arm currently removes all
+  ops; change to remove if bundle size is 1, mark all suspect if greater than 1.
+  `FailedOp` stays remove-attributed.
+- **Terminal RPC error**: same size-1-remove / larger-suspect branch, in the
+  `Err(error)` arm of `handle_building_state` using PR 1's classification.
+- **Non-terminal failure**: report to the pool so it increments pre-suspect counts
+  (normal bundle) or removal count + backoff (isolation bundle). The sender needs to
+  know which kind of bundle it sent — a flag on the assignment (PR 4) or on the send
+  context.
+- **Success**: report so the pool clears pre-suspect counts for the bundle's ops.
+
+Risk note: once the multi-UO remove-all path becomes mark-suspect, suspects sit
+excluded from bundles with nothing draining them until PR 4 lands. Either land PR 3
+and PR 4 together, or keep suspects eligible for normal bundles in PR 3 and gate
+exclusion behind PR 4.
+
+### PR 4 — Suspect scheduling in the assigner
+
+- In `Assigner` (`crates/builder/src/assigner.rs`, which already holds `num_signers`):
+  when assigning work, fetch due suspects alongside normal summaries. While normal work
+  is eligible, cap new isolation assignments at `max(1, num_signers / 2)`; when normal
+  work is exhausted, let any idle builder isolate. Recompute the limit per assignment;
+  never cancel in-flight isolation work.
+- An isolation assignment is a single-UO bundle for one suspect, tagged so the bundle
+  sender reports outcomes down the suspect path (PR 3). Mined revert or terminal error
+  in isolation removes immediately; success follows normal tracking and clears suspect
+  state; other failures keep it suspect and back off.
+- The one-builder caveat (no two-way starvation guarantee with a single signer) needs
+  no code — document it on the CLI args.
+
+### PR 5 — Provider-event signal
+
+- Implement the rolling window (last 20 non-neutral final outcomes; enter event at ≥10
+  observations with ≥30% failures, exit below 10%) as a small shared struct owned by
+  the submission route. Record outcomes in `FallbackTransactionSender`
+  (`crates/builder/src/sender/fallback.rs`) after retries/fallbacks are exhausted —
+  success, `ProviderFailure`, or neutral (excluded). Non-fallback senders wrap the same
+  recorder.
+- Expose it as a shared `Arc` boolean checked by the bundle sender when calling
+  `report_bundle_outcome` (the `provider_event_active` flag from PR 2). Its only
+  effect: pause pre-suspect counting. No counters are cleared on enter/exit, and
+  suspect backoff/removal counting are unaffected.
+- Ships last deliberately — without it the system is fully functional, just without
+  outage protection for suspect creation (removal is already protected by backoff
+  spacing from PR 2).
+
 ## Related work
 
 - **EIP-7702 auth-nonce recheck at bundle assembly** (fix 2 in

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -78,9 +78,14 @@ reject the transaction.
 | Known operational error | Any | Preserve existing behavior. |
 
 The entire flow is gated behind `--pool.suspect_tracking_enabled` (default `false`).
-When disabled, bundle outcomes change no UO state: no operation is ever suspected or
-removed by this system. This allows the mechanism to ship dark and be enabled
-deliberately once every stage — including the provider-event signal — is deployed.
+When disabled, no operation is ever suspected, and no new removal path (RPC-failure
+thresholds, terminal-error suspicion) fires. The one exception: an unattributed
+multi-op revert still removes every op, exactly as it did before this system existed —
+disabling the switch must not regress bundling to the pre-feature livelock this
+mechanism was partly designed to close (see
+`INVESTIGATION-empty-revert-bundle-livelock.md`). This allows the mechanism to ship
+dark and be enabled deliberately once every stage — including the provider-event
+signal — is deployed.
 
 Provider retries and configured fallbacks are exhausted before an RPC outcome enters
 this flow. A successful fallback has no effect on UO state.

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -8,9 +8,11 @@ Status: Draft
    fail, preventing them from blocking bundle submission indefinitely.
 2. **Fairness:** schedule healthy and suspect UOs so neither work class can starve the
    other.
-3. **Provider resilience:** once a provider-health event is detected, stop punishing
-   UOs entirely — no suspicion, no removal progress. Detection is best effort; the
-   suspect backoff schedule spaces evidence to bound damage from undetected incidents.
+3. **Provider resilience:** once a provider-health event is detected, no UO makes
+   progress toward removal, so provider issues cannot remove operations. Suspect
+   analysis continues during events because suspicion is recoverable and isolation is
+   what protects bundling. Detection is best effort; the suspect backoff schedule
+   spaces evidence to bound damage from undetected incidents.
 
 ## How the goals are achieved
 
@@ -39,13 +41,20 @@ both remain continuously eligible.
 
 ### Provider resilience
 
-A failure during a detected provider event is not evidence against a UO. Only final
-outcomes after provider retries and fallbacks affect the provider-event signal, and
-while an event is active, a non-terminal failure changes no UO state — no counter
-advances toward suspicion or removal — so a detected outage can neither mass-convert
-the pool into suspects nor remove UOs. Submissions during an event are treated as if
-they never happened; retry pacing is left to normal submission cadence and provider
-rate limiting, as it is for normal bundles.
+A detected provider event pauses removal, not analysis. While an event is active,
+non-terminal failures still count toward suspicion — quarantine keeps working — but a
+suspect's counter freezes: it makes no progress toward removal, and failures during
+the event never contribute to a later removal. Suspects failing during an event still
+refresh their isolation backoff so retries stay spaced.
+
+Suspicion deliberately stays live during events because gating it is exploitable: a
+herd of poison UOs large enough to trip the provider-event signal with its own
+failures would otherwise keep riding in normal bundles — unsuspectable for exactly as
+long as it sustains the event. With analysis live, such a herd is quarantined into
+isolation even while the event is active; once quarantined, normal bundles recover,
+the event clears, and removal resumes. The cost is that a genuine outage progressively
+suspects the UOs it touches; suspicion is recoverable, so after recovery each false
+suspect clears itself with one successful singleton, at isolation throughput.
 
 Detection requires a rolling sample, so failures observed before the signal activates
 still count; the suspect backoff schedule spaces those increments to bound the damage
@@ -65,7 +74,7 @@ reject the transaction.
 | Terminal RPC error | More than 1 | Mark every UO as suspect immediately. |
 | Non-terminal provider failure while provider is healthy | Any | Increment each non-suspect UO's RPC-failure count; mark it suspect at the configured threshold. |
 | Non-terminal provider failure from an isolated suspect | 1 | Increment its suspect removal count, back off, and remove it at the configured threshold. |
-| Non-terminal provider failure during a provider event | Any | No UO state change. |
+| Non-terminal provider failure during a provider event | Any | Non-suspects accrue toward suspicion as normal; suspects only refresh their isolation backoff, making no removal progress. |
 | Known operational error | Any | Preserve existing behavior. |
 
 Provider retries and configured fallbacks are exhausted before an RPC outcome enters
@@ -98,9 +107,9 @@ Initial parameters:
 Different enter and exit thresholds prevent flapping. The signal does not change bundle
 construction or submission rate; existing provider rate limiting handles request pacing.
 
-The signal has exactly one effect: while a provider event is active, a non-terminal
-failure changes no UO state, so no new suspects are created and no suspects progress
-toward removal. No counter state is cleared when an event is entered or exited.
+The signal has exactly one effect: while a provider event is active, suspects make no
+progress toward removal. Suspect creation and isolation backoff are unaffected. No
+counter state is cleared when an event is entered or exited.
 
 ## Non-terminal RPC evidence
 
@@ -109,9 +118,9 @@ status is derived, not stored: a UO is a suspect once its counter reaches
 `--pool.rpc_failures_before_suspect` (default `3`), and is removed
 `--pool.max_suspect_rpc_failures` (default `3`) failures later.
 
-1. Outside a provider event, a final non-terminal provider failure increments the
-   failure counter of every UO in the failed bundle. During an event, no counters
-   advance.
+1. A final non-terminal provider failure increments the failure counter of every
+   non-suspect UO in the failed bundle. During a provider event, suspects' counters
+   freeze; non-suspects continue to accrue.
 2. A successful submission resets the failure counter of every UO in that bundle,
    clearing suspect status.
 3. At the suspect threshold the UO is excluded from normal bundles and becomes
@@ -125,11 +134,11 @@ Ambiguous multi-UO terminal failures and unattributed mined reverts force suspic
 by raising the counter directly to the suspect threshold, never lowering it.
 
 `--pool.max_suspect_rpc_failures=0` disables RPC-based removal. Provider events pause
-all failure counting; failures during an event change no UO state.
+removal progress only; suspect creation and isolation backoff continue.
 
 Suspect backoff is configured with `--pool.suspect_rpc_backoff_initial_secs`
 (default `1`) and `--pool.suspect_rpc_backoff_max_secs` (default `600`). Detected
-provider events do not count against UOs at all; the backoff schedule bounds false
+provider events pause removal progress entirely; the backoff schedule bounds false
 removal from incidents the signal misses (detection lag, or failure rates below the
 event threshold): the cumulative delay across `max_suspect_rpc_failures` consecutive
 attempts must exceed the longest undetected incident that removal should tolerate.
@@ -159,28 +168,29 @@ state.
 ## State ownership
 
 The submission route owns the provider-event signal; the pool consumes it as a single
-boolean gate on failure counting. The pool owns each UO's failure counter (from
+boolean gate on suspect removal progress. The pool owns each UO's failure counter (from
 which suspect status is derived) and suspect retry time so they are shared across
 builders and cleared with the UO lifecycle. This state is in-memory and does not track
 transaction hashes for deduplication.
 
 ## Tradeoffs
 
-- **Liveness versus false removal:** eventual removal protects bundling, but a
-  poison UO that keeps the provider-event signal active (its own failures feed the
-  window) is never removed while the event lasts, and failures persisting across the
-  backoff span during an undetected incident can still remove a healthy UO. Higher
-  thresholds and longer backoff reduce false removals but extend poison lifetime.
+- **Liveness versus false removal:** eventual removal protects bundling, but
+  failures persisting across the backoff span during an undetected incident can
+  still remove a healthy UO. Higher thresholds and longer backoff reduce false
+  removals but extend poison lifetime. Poison that sustains a provider event is
+  quarantined but not removed until the event clears; bundling is protected by the
+  quarantine, and pool size and age limits bound the accumulation.
 - **Isolation versus throughput:** singleton attempts identify poison UOs without adding
   innocent fillers, but consume more transactions than normal bundles. The dynamic
   isolation limit preserves normal capacity at the cost of slower suspect draining.
-- **Provider protection versus poison detection:** pausing all failure counting during
-  provider events prevents false suspicion and false removal, but a poison UO
-  encountered during an event makes no progress toward identification or removal until
-  the event clears. Detection lag can still create false suspects before the signal
-  activates; each costs one wasted singleton attempt after recovery and then
-  self-clears. An outage that outlasts detection lag may still suspect part of the
-  pool, which drains at singleton throughput after recovery.
+- **Provider protection versus poison detection:** pausing removal during provider
+  events guarantees provider issues cannot remove UOs, at the cost that poison
+  sustaining an event lingers in isolation until the event clears. Keeping suspect
+  analysis live during events closes the herd loophole but means a genuine outage
+  progressively suspects the UOs it touches; each false suspect self-clears with one
+  successful singleton after recovery, so a long outage drains at isolation
+  throughput afterward.
 - **Backoff versus recovery latency:** per-suspect backoff prevents hot loops and resource
   churn, but delays successful retry after a transient failure.
 
@@ -225,9 +235,10 @@ sees it.
   `report_bundle_outcome(entry_point, ops, outcome, provider_event_active)`, where
   outcome is success / non-terminal failure / terminal failure / mark-suspect. The
   pool applies the failure-flow table internally: reset counters on success,
-  increment counters on non-terminal failure (a no-op while a provider event is
-  active), compute backoff for isolated suspects, remove at the removal
-  threshold with a new `OpRemovalReason::RepeatedNonTerminalRpcFailure`, and remove
+  increment counters on non-terminal failure (suspects' counters freeze while a
+  provider event is active), compute backoff for isolated suspects, remove at the
+  removal threshold with a new `OpRemovalReason::RepeatedNonTerminalRpcFailure`, and
+  remove
   terminally rejected singletons with `OpRemovalReason::TerminalRpcError`
   (`crates/pool/src/emit.rs`). Implement in `UoPool`, `LocalPoolHandle`, and the
   remote protobuf client/server.
@@ -286,8 +297,13 @@ exclusion behind PR 4.
   recorder.
 - Expose it as a shared `Arc` boolean checked by the bundle sender when calling
   `report_bundle_outcome` (the `provider_event_active` flag from PR 2). Its only
-  effect: pause all failure counting, so failures during an event change no UO
-  state. No counters are cleared on enter/exit.
+  effect: pause suspect removal progress. Suspect creation and backoff are
+  unaffected, and no counters are cleared on enter/exit.
+- Consider recording only transport-level failures (timeouts, connection failures,
+  sender unavailable) in the window and excluding error responses: a node that
+  evaluates a transaction and answers is not an outage, and rejected-with-a-response
+  is what poison looks like, so this keeps poison herds from tripping the signal at
+  all.
 - Ships last deliberately — without it the system is fully functional, just without
   outage protection (bounded in the interim only by the backoff spacing from PR 2).
 

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -186,6 +186,81 @@ which suspect status is derived) and suspect retry time so they are shared acros
 builders and cleared with the UO lifecycle. This state is in-memory and does not track
 transaction hashes for deduplication.
 
+## Telemetry
+
+The mechanism's internal state is otherwise invisible in production: `apply_bundle_outcome`
+performs no logging today, and the only existing signals are `ep_isolation_assignments`,
+`provider_event_active`, and generic removal logging via `OpRemovalReason`. The additions
+below are scoped to what each goal needs to be observable, not to instrument every
+internal transition.
+
+### Metrics
+
+New metrics follow the existing per-crate conventions: derived `#[derive(Metrics)]`
+structs scoped `op_pool` (pool.rs) and `builder_assigner` (assigner.rs), and per-sender,
+per-entry-point labeled counters via the bundle sender's existing `increment_counter_ep`
+helper (`builder_sender` scope) for anything that varies by submission route.
+
+| Metric | Type | Where | Goal | Purpose |
+| --- | --- | --- | --- | --- |
+| `num_suspect_ops` | Gauge | pool | Liveness | Current suspect population — the primary signal for whether suspects are accumulating faster than isolation drains them. |
+| `num_marked_suspect_multi_op_failure` | Counter | pool | Liveness | Suspicions forced immediately by an unattributed mined revert or a terminal RPC error on a bundle of more than one op. |
+| `num_marked_suspect_threshold` | Counter | pool | Liveness | Suspicions from the non-terminal failure counter reaching `rpc_failures_before_suspect`. |
+| `num_suspects_cleared` | Counter | pool | Liveness | Successful submissions that reset a suspect's counter — the recovery path the provider-resilience tradeoff depends on. |
+| `num_suspects_removed` | Counter | pool | Liveness | Removals via `TerminalRpcError` or `RepeatedNonTerminalRpcFailure`, combined. |
+| `suspect_tracking_enabled` | Gauge (0/1) | pool | — | Master switch state, set once at construction; lets a dashboard confirm rollout state without cross-referencing CLI flags. |
+| `ep_isolation_limit` | Gauge, per entry point | assigner | Fairness | The computed cap for the current assignment cycle: `max(1, num_signers / 2)` while normal work is eligible, otherwise uncapped. |
+| `ep_isolating_builders` | Gauge, per entry point | assigner | Fairness | Current size of `isolating_builders`. Paired with the limit, shows whether isolation is capacity-starved or simply idle. |
+| `builder_bundle_outcome_success` / `_non_terminal_failure` / `_terminal_failure` / `_mark_suspect` | Counter, per sender + entry point | sender | Liveness / Provider resilience | One counter per `BundleOutcome` reported via `report_bundle_outcome`, at the same call sites that classify the submission result. |
+| `builder_bundle_outcome_report_failed` | Counter, per sender + entry point | sender | — | The existing "Failed to report bundle outcome to pool" warning, counted. A sustained rate means pool suspect state is silently diverging from what actually happened on submission. |
+| `provider_events_total` | Counter | sender | Provider resilience | Total enter transitions, alongside the existing `provider_event_active` gauge — a rate here is a flapping detector the gauge alone can't show. |
+
+`ep_isolation_assignments` and `provider_event_active` (both existing) are unchanged.
+
+None of these are labeled by `op_hash`, consistent with the existing convention (the
+bundle sender labels only by `sender`/`entry_point`) and necessary to keep the Prometheus
+endpoint's cardinality bounded under a poison-op herd.
+
+### Logs
+
+Two new `OpPoolEvent` variants (`crates/pool/src/emit.rs`), logged for free at `info` via
+the existing generic sink the same way `RemovedOp` already is:
+
+- `MarkedSuspect { op_hash, trigger }` — `trigger` distinguishes multi-op-failure from
+  threshold, mirroring the metric split above.
+- `SuspectCleared { op_hash }`.
+
+`OpPoolEvent` is an in-process broadcast channel only, never serialized over the pool's
+gRPC boundary, so these additions carry no proto or remote-client cost.
+
+### Dashboards
+
+No dashboard or alerting config exists in this repo today; these panels are the first,
+built on the Prometheus endpoint already exposed by the metrics CLI. Organized by goal
+rather than by crate:
+
+- **Liveness** — `num_suspect_ops` over time; marked/cleared/removed rates plotted
+  together to show whether isolation is keeping pace.
+- **Fairness** — `ep_isolating_builders` vs. `ep_isolation_limit` vs. `num_signers`,
+  alongside isolation- vs. normal-assignment rates.
+- **Provider resilience** — `provider_event_active` as a state timeline with
+  `provider_events_total` rate overlaid, and suspect-removal rate on the same timeline to
+  visually confirm removals pause while an event is active.
+
+### Alerts
+
+- **Suspects accumulating without draining**: `num_suspect_ops` sustained high while
+  `num_suspects_cleared` is ~0 — isolation starvation or a systemic problem beyond a
+  couple poison ops.
+- **Provider event flapping**: high rate of `provider_events_total` — enter/exit
+  thresholds likely miscalibrated for that route.
+- **Sustained provider event**: `provider_event_active == 1` for longer than an
+  operator-chosen duration — treat as an outage independent of the poison-ops mechanism.
+- **Master-switch drift**: `suspect_tracking_enabled` differing across a fleet for the
+  same entry point — config skew that should never occur post-rollout.
+- **Outcome-report failures**: sustained `builder_bundle_outcome_report_failed` rate —
+  pool state silently diverging from actual submission outcomes.
+
 ## Tradeoffs
 
 - **Liveness versus false removal:** eventual removal protects bundling, but
@@ -209,9 +284,10 @@ transaction hashes for deduplication.
 
 ## Implementation plan
 
-Five self-contained PRs that build in order. PRs 1–2 are inert plumbing (no visible
-behavior change), PR 3 is the behavior switch, and PRs 4–5 are independent of each
-other once PR 3 lands.
+Six self-contained PRs that build in order. PRs 1–2 are inert plumbing (no visible
+behavior change), PR 3 is the behavior switch, PRs 4–5 are independent of each
+other once PR 3 lands, and PR 6 (telemetry) is additive and lands incrementally
+alongside 2–5 — each metric only becomes meaningful once its source PR is in.
 
 ### PR 1 — Terminal vs. non-terminal error classification (foundation)
 
@@ -331,6 +407,24 @@ exclusion behind PR 4.
   consequential as pausing removal pool-wide. It's also circular to feed one from the
   other — the signal only observes outcomes *after* failover has already run. The two
   stay independently tunable.
+
+### PR 6 — Telemetry
+
+Adds the metrics, logs, dashboards, and alerts from the Telemetry section. Independent
+of PR 4–5 internally, but each metric only becomes meaningful once its source PR has
+landed (isolation metrics need PR 4, provider-event metrics need PR 5), so it lands
+incrementally alongside them rather than all at once.
+
+- Pool metrics (extending `PoolMetrics` in `crates/pool/src/mempool/pool.rs`) and the two
+  new `OpPoolEvent` variants (`crates/pool/src/emit.rs`), wired at the
+  `apply_bundle_outcome` call sites already added in PR 2.
+- Assigner metrics (extending `PerEntrypointMetrics` in `crates/builder/src/assigner.rs`),
+  set alongside the existing `ep_isolation_assignments` increment.
+- Sender metrics (`crates/builder/src/bundle_sender.rs`), via the existing
+  `increment_counter_ep` helper at the `report_bundle_outcome` call sites (PR 3) and the
+  two existing `warn!` sites for report failures.
+- `provider_events_total` (`crates/builder/src/sender/health.rs`), incremented alongside
+  the existing `provider_event_active` gauge sets.
 
 ## Related work
 

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -8,9 +8,9 @@ Status: Draft
    fail, preventing them from blocking bundle submission indefinitely.
 2. **Fairness:** schedule healthy and suspect UOs so neither work class can starve the
    other.
-3. **Provider resilience:** prevent provider-health events from converting healthy UOs
-   into suspects (best effort, via detection) or removing them (unconditional, via
-   evidence spacing).
+3. **Provider resilience:** once a provider-health event is detected, stop punishing
+   UOs entirely — no suspicion, no removal progress. Detection is best effort; the
+   suspect backoff schedule spaces evidence to bound damage from undetected incidents.
 
 ## How the goals are achieved
 
@@ -39,19 +39,20 @@ both remain continuously eligible.
 
 ### Provider resilience
 
-Protection is two-tier. Suspect creation is gated by detection: only final outcomes
-after provider retries and fallbacks affect the provider-event signal, and while an
-event is active, non-terminal failures do not advance pre-suspect counts, so an outage
-cannot mass-convert the pool into suspects. Removal is protected independently of
-detection: the suspect backoff schedule spaces removal-counter increments so that a
-single provider incident contributes at most one increment (see "Non-terminal RPC
-evidence").
+A failure during a detected provider event is not evidence against a UO. Only final
+outcomes after provider retries and fallbacks affect the provider-event signal, and
+while an event is active, a non-terminal failure changes no UO state — no counter
+advances toward suspicion or removal — so a detected outage can neither mass-convert
+the pool into suspects nor remove UOs. Submissions during an event are treated as if
+they never happened; retry pacing is left to normal submission cadence and provider
+rate limiting, as it is for normal bundles.
 
 Detection requires a rolling sample, so failures observed before the signal activates
-may still create suspects. Because suspicion is recoverable — a healthy suspect
-succeeds in isolation and clears — detection lag costs wasted singleton attempts, not
-false removals. Terminal RPC errors bypass provider-health gating because they
-definitively reject the transaction.
+still count; the suspect backoff schedule spaces those increments to bound the damage
+from an undetected incident. Because suspicion is recoverable — a healthy suspect
+succeeds in isolation and clears — detection lag mostly costs wasted singleton
+attempts. Terminal RPC errors bypass provider-health gating because they definitively
+reject the transaction.
 
 ## Failure flow
 
@@ -64,7 +65,7 @@ definitively reject the transaction.
 | Terminal RPC error | More than 1 | Mark every UO as suspect immediately. |
 | Non-terminal provider failure while provider is healthy | Any | Increment each non-suspect UO's RPC-failure count; mark it suspect at the configured threshold. |
 | Non-terminal provider failure from an isolated suspect | 1 | Increment its suspect removal count, back off, and remove it at the configured threshold. |
-| Non-terminal provider failure from a normal bundle during a provider event | Any | Do not advance pre-suspect counts; no other UO state change. |
+| Non-terminal provider failure during a provider event | Any | No UO state change. |
 | Known operational error | Any | Preserve existing behavior. |
 
 Provider retries and configured fallbacks are exhausted before an RPC outcome enters
@@ -97,12 +98,9 @@ Initial parameters:
 Different enter and exit thresholds prevent flapping. The signal does not change bundle
 construction or submission rate; existing provider rate limiting handles request pacing.
 
-The signal has exactly one effect: while a provider event is active, non-terminal
-failures do not advance pre-suspect counts, so no new suspects are created. Suspect
-backoff and removal counting are unaffected by the signal; false removal is bounded by
-the backoff schedule's evidence spacing rather than by detection. Because the gate's
-only failure mode is recoverable suspicion, no counter state is cleared when an event
-is entered or exited.
+The signal has exactly one effect: while a provider event is active, a non-terminal
+failure changes no UO state, so no new suspects are created and no suspects progress
+toward removal. No counter state is cleared when an event is entered or exited.
 
 ## Non-terminal RPC evidence
 
@@ -112,15 +110,14 @@ status is derived, not stored: a UO is a suspect once its counter reaches
 `--pool.max_suspect_rpc_failures` (default `3`) failures later.
 
 1. Outside a provider event, a final non-terminal provider failure increments the
-   failure counter of every UO in the failed bundle. During an event, only counters
-   already past the suspect threshold advance.
+   failure counter of every UO in the failed bundle. During an event, no counters
+   advance.
 2. A successful submission resets the failure counter of every UO in that bundle,
    clearing suspect status.
 3. At the suspect threshold the UO is excluded from normal bundles and becomes
    eligible for an immediate isolation attempt.
-4. Each failure past the suspect threshold schedules an exponentially increasing
-   retry delay with jitter, and counts toward removal regardless of provider-event
-   state.
+4. Each counted failure past the suspect threshold schedules an exponentially
+   increasing retry delay with jitter.
 5. At `suspect threshold + max_suspect_rpc_failures` total failures, the pool removes
    the UO and logs `RepeatedNonTerminalRpcFailure`.
 
@@ -128,17 +125,18 @@ Ambiguous multi-UO terminal failures and unattributed mined reverts force suspic
 by raising the counter directly to the suspect threshold, never lowering it.
 
 `--pool.max_suspect_rpc_failures=0` disables RPC-based removal. Provider events pause
-pre-suspect counting only; suspect removal counting and backoff continue.
+all failure counting; failures during an event change no UO state.
 
 Suspect backoff is configured with `--pool.suspect_rpc_backoff_initial_secs`
-(default `1`) and `--pool.suspect_rpc_backoff_max_secs` (default `600`). The schedule
-bounds false removal: the cumulative delay across `max_suspect_rpc_failures`
-consecutive attempts must exceed the longest provider incident that removal should
-tolerate, so that a single incident contributes at most one removal increment. The
-defaults favor fast poison eviction — the first three increments span only a few
-seconds, so a provider blip can remove a suspect. Tolerating a 30-minute incident
-requires a larger initial (for example 600 seconds: 10 m + 20 m between increments),
-a steeper curve, or a higher removal threshold.
+(default `1`) and `--pool.suspect_rpc_backoff_max_secs` (default `600`). Detected
+provider events do not count against UOs at all; the backoff schedule bounds false
+removal from incidents the signal misses (detection lag, or failure rates below the
+event threshold): the cumulative delay across `max_suspect_rpc_failures` consecutive
+attempts must exceed the longest undetected incident that removal should tolerate.
+The defaults favor fast poison eviction — the first three increments span only a few
+seconds — and lean on the provider-event signal for outage protection. Tolerating
+longer undetected incidents requires a larger initial, a steeper curve, or a higher
+removal threshold.
 
 ## Suspect scheduling
 
@@ -161,24 +159,26 @@ state.
 ## State ownership
 
 The submission route owns the provider-event signal; the pool consumes it as a single
-boolean gate on pre-suspect counting. The pool owns each UO's failure counter (from
+boolean gate on failure counting. The pool owns each UO's failure counter (from
 which suspect status is derived) and suspect retry time so they are shared across
 builders and cleared with the UO lifecycle. This state is in-memory and does not track
 transaction hashes for deduplication.
 
 ## Tradeoffs
 
-- **Liveness versus false removal:** eventual removal protects bundling, but failures
-  persisting across the entire backoff span can still remove a healthy UO — for
-  example, a provider incident longer than the cumulative suspect backoff. Higher
+- **Liveness versus false removal:** eventual removal protects bundling, but a
+  poison UO that keeps the provider-event signal active (its own failures feed the
+  window) is never removed while the event lasts, and failures persisting across the
+  backoff span during an undetected incident can still remove a healthy UO. Higher
   thresholds and longer backoff reduce false removals but extend poison lifetime.
 - **Isolation versus throughput:** singleton attempts identify poison UOs without adding
   innocent fillers, but consume more transactions than normal bundles. The dynamic
   isolation limit preserves normal capacity at the cost of slower suspect draining.
-- **Provider protection versus poison detection:** pausing pre-suspect counting during
-  provider events prevents mass false suspicion, but a poison UO encountered during an
-  event takes longer to identify. Detection lag can still create false suspects before
-  the signal activates; each costs one wasted singleton attempt after recovery and then
+- **Provider protection versus poison detection:** pausing all failure counting during
+  provider events prevents false suspicion and false removal, but a poison UO
+  encountered during an event makes no progress toward identification or removal until
+  the event clears. Detection lag can still create false suspects before the signal
+  activates; each costs one wasted singleton attempt after recovery and then
   self-clears. An outage that outlasts detection lag may still suspect part of the
   pool, which drains at singleton throughput after recovery.
 - **Backoff versus recovery latency:** per-suspect backoff prevents hot loops and resource
@@ -225,8 +225,8 @@ sees it.
   `report_bundle_outcome(entry_point, ops, outcome, provider_event_active)`, where
   outcome is success / non-terminal failure / terminal failure / mark-suspect. The
   pool applies the failure-flow table internally: reset counters on success,
-  increment counters on non-terminal failure (skipping non-suspects while a provider
-  event is active), compute backoff for isolated suspects, remove at the removal
+  increment counters on non-terminal failure (a no-op while a provider event is
+  active), compute backoff for isolated suspects, remove at the removal
   threshold with a new `OpRemovalReason::RepeatedNonTerminalRpcFailure`, and remove
   terminally rejected singletons with `OpRemovalReason::TerminalRpcError`
   (`crates/pool/src/emit.rs`). Implement in `UoPool`, `LocalPoolHandle`, and the
@@ -286,11 +286,10 @@ exclusion behind PR 4.
   recorder.
 - Expose it as a shared `Arc` boolean checked by the bundle sender when calling
   `report_bundle_outcome` (the `provider_event_active` flag from PR 2). Its only
-  effect: pause pre-suspect counting. No counters are cleared on enter/exit, and
-  suspect backoff/removal counting are unaffected.
+  effect: pause all failure counting, so failures during an event change no UO
+  state. No counters are cleared on enter/exit.
 - Ships last deliberately — without it the system is fully functional, just without
-  outage protection for suspect creation (removal is already protected by backoff
-  spacing from PR 2).
+  outage protection (bounded in the interim only by the backoff spacing from PR 2).
 
 ## Related work
 

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -77,6 +77,11 @@ reject the transaction.
 | Non-terminal provider failure during a provider event | Any | Non-suspects accrue toward suspicion as normal; suspects only refresh their isolation backoff, making no removal progress. |
 | Known operational error | Any | Preserve existing behavior. |
 
+The entire flow is gated behind `--pool.suspect_tracking_enabled` (default `false`).
+When disabled, bundle outcomes change no UO state: no operation is ever suspected or
+removed by this system. This allows the mechanism to ship dark and be enabled
+deliberately once every stage — including the provider-event signal — is deployed.
+
 Provider retries and configured fallbacks are exhausted before an RPC outcome enters
 this flow. A successful fallback has no effect on UO state.
 
@@ -227,7 +232,8 @@ sees it.
   derived from the counter against the two thresholds; a success resets it. State
   dies with the UO — no separate tracker needed.
 - Add config to `PoolConfig` (`crates/pool/src/mempool/mod.rs`) and CLI args in
-  `bin/rundler/src/cli/pool.rs`: `rpc_failures_before_suspect` (default 3),
+  `bin/rundler/src/cli/pool.rs`: `suspect_tracking_enabled` (default false, the
+  master switch), `rpc_failures_before_suspect` (default 3),
   `max_suspect_rpc_failures` (default 3, 0 disables removal),
   `suspect_rpc_backoff_initial_secs` (default 1), `suspect_rpc_backoff_max_secs`
   (default 600).

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -121,7 +121,7 @@ counter state is cleared when an event is entered or exited.
 Each UO carries a single failure counter measured against two thresholds. Suspect
 status is derived, not stored: a UO is a suspect once its counter reaches
 `--pool.rpc_failures_before_suspect` (default `3`), and is removed
-`--pool.max_suspect_rpc_failures` (default `3`) failures later.
+`--pool.max_suspect_rpc_failures` (default `8`) failures later.
 
 1. A final non-terminal provider failure increments the failure counter of every
    non-suspect UO in the failed bundle. During a provider event, suspects' counters
@@ -147,10 +147,11 @@ provider events pause removal progress entirely; the backoff schedule bounds fal
 removal from incidents the signal misses (detection lag, or failure rates below the
 event threshold): the cumulative delay across `max_suspect_rpc_failures` consecutive
 attempts must exceed the longest undetected incident that removal should tolerate.
-The defaults favor fast poison eviction — the first three increments span only a few
-seconds — and lean on the provider-event signal for outage protection. Tolerating
-longer undetected incidents requires a larger initial, a steeper curve, or a higher
-removal threshold.
+The defaults spend roughly four minutes of cumulative backoff (1+2+4+8+16+32+64+128s
+before jitter) across the 8 allowed failures before removal, giving the
+provider-event signal a real chance to observe a genuine incident and pause removal
+before it fires. Tolerating longer undetected incidents still requires a larger
+initial, a steeper curve, or a higher removal threshold.
 
 ## Suspect scheduling
 
@@ -234,7 +235,7 @@ sees it.
 - Add config to `PoolConfig` (`crates/pool/src/mempool/mod.rs`) and CLI args in
   `bin/rundler/src/cli/pool.rs`: `suspect_tracking_enabled` (default false, the
   master switch), `rpc_failures_before_suspect` (default 3),
-  `max_suspect_rpc_failures` (default 3, 0 disables removal),
+  `max_suspect_rpc_failures` (default 8, 0 disables removal),
   `suspect_rpc_backoff_initial_secs` (default 1), `suspect_rpc_backoff_max_secs`
   (default 600).
 - Add one new `Pool` trait method (`crates/types/src/pool/traits.rs`),

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -8,8 +8,9 @@ Status: Draft
    fail, preventing them from blocking bundle submission indefinitely.
 2. **Fairness:** schedule healthy and suspect UOs so neither work class can starve the
    other.
-3. **Provider resilience:** detect provider-health events and prevent their failures from
-   causing non-poison UOs to be removed in most cases.
+3. **Provider resilience:** prevent provider-health events from converting healthy UOs
+   into suspects (best effort, via detection) or removing them (unconditional, via
+   evidence spacing).
 
 ## How the goals are achieved
 
@@ -38,15 +39,19 @@ both remain continuously eligible.
 
 ### Provider resilience
 
-Only final outcomes after provider retries and fallbacks affect the provider-event
-signal. During a detected event, non-terminal failures do not create suspects, advance
-removal counters, or remove UOs. Entering the event clears accumulated non-terminal
-failure evidence, while suspect backoff continues to limit repeated isolation attempts.
+Protection is two-tier. Suspect creation is gated by detection: only final outcomes
+after provider retries and fallbacks affect the provider-event signal, and while an
+event is active, non-terminal failures do not advance pre-suspect counts, so an outage
+cannot mass-convert the pool into suspects. Removal is protected independently of
+detection: the suspect backoff schedule spaces removal-counter increments so that a
+single provider incident contributes at most one increment (see "Non-terminal RPC
+evidence").
 
 Detection requires a rolling sample, so failures observed before the signal activates
-may still affect UO state. Terminal RPC errors also bypass provider-health gating because
-they definitively reject the transaction. These are the principal cases in which a
-provider event could still affect a non-poison UO.
+may still create suspects. Because suspicion is recoverable — a healthy suspect
+succeeds in isolation and clears — detection lag costs wasted singleton attempts, not
+false removals. Terminal RPC errors bypass provider-health gating because they
+definitively reject the transaction.
 
 ## Failure flow
 
@@ -58,9 +63,8 @@ provider event could still affect a non-poison UO.
 | Terminal RPC error | 1 | Remove the sole UO immediately. |
 | Terminal RPC error | More than 1 | Mark every UO as suspect immediately. |
 | Non-terminal provider failure while provider is healthy | Any | Increment each non-suspect UO's RPC-failure count; mark it suspect at the configured threshold. |
-| Non-terminal provider failure from an isolated suspect while provider is healthy | 1 | Increment its suspect RPC-failure count and either back off or remove it at the configured threshold. |
-| Non-terminal provider failure from an isolated suspect during a provider event | 1 | Apply suspect backoff without incrementing its removal count. |
-| Non-terminal provider failure from a normal bundle during a provider event | Any | Do not change UO state. |
+| Non-terminal provider failure from an isolated suspect | 1 | Increment its suspect removal count, back off, and remove it at the configured threshold. |
+| Non-terminal provider failure from a normal bundle during a provider event | Any | Do not advance pre-suspect counts; no other UO state change. |
 | Known operational error | Any | Preserve existing behavior. |
 
 Provider retries and configured fallbacks are exhausted before an RPC outcome enters
@@ -93,34 +97,39 @@ Initial parameters:
 Different enter and exit thresholds prevent flapping. The signal does not change bundle
 construction or submission rate; existing provider rate limiting handles request pacing.
 
-The builder updates the signal before processing non-terminal UO feedback. While a
-provider event is active, non-terminal failures cannot mark suspects, increment removal
-counters, or remove UOs. They may still defer an isolated suspect's next attempt.
-Entering an event clears all accumulated non-terminal RPC-failure counters. Existing
-suspect status remains, including suspicion created by mined reverts or terminal RPC
-errors, but its non-terminal removal counter resets.
+The signal has exactly one effect: while a provider event is active, non-terminal
+failures do not advance pre-suspect counts, so no new suspects are created. Suspect
+backoff and removal counting are unaffected by the signal; false removal is bounded by
+the backoff schedule's evidence spacing rather than by detection. Because the gate's
+only failure mode is recoverable suspicion, no counter state is cleared when an event
+is entered or exited.
 
 ## Non-terminal RPC evidence
 
-Outside a provider event:
-
-1. A final non-terminal provider failure increments the pre-suspect count of every UO in
-   the failed bundle.
+1. Outside a provider event, a final non-terminal provider failure increments the
+   pre-suspect count of every UO in the failed bundle. During an event, pre-suspect
+   counts do not advance.
 2. A successful submission clears the pre-suspect counts of every UO in that bundle.
 3. At `--pool.rpc_failures_before_suspect` (default `3`), a UO becomes a suspect and its
    count resets.
 4. A final provider failure from its single-UO attempt schedules an exponentially
    increasing retry delay with jitter.
-5. If the provider-event signal is healthy, the failure also increments the suspect's
-   removal count.
+5. The failure also increments the suspect's removal count, regardless of
+   provider-event state.
 6. At `--pool.max_suspect_rpc_failures` (default `3`), the pool removes the UO and logs
    `RepeatedNonTerminalRpcFailure`.
 
-`--pool.max_suspect_rpc_failures=0` disables RPC-based removal. Provider-event periods do
-not contribute to either threshold, but suspect backoff still applies.
+`--pool.max_suspect_rpc_failures=0` disables RPC-based removal. Provider events pause
+pre-suspect counting only; suspect removal counting and backoff continue.
 
 Suspect backoff is configured with `--pool.suspect_rpc_backoff_initial_secs` and
-`--pool.suspect_rpc_backoff_max_secs`.
+`--pool.suspect_rpc_backoff_max_secs`. The schedule is load-bearing for the
+false-removal bound: the cumulative delay across `max_suspect_rpc_failures` consecutive
+attempts must exceed the longest provider incident that removal should tolerate, so
+that a single incident contributes at most one removal increment. With doubling from a
+60-second initial, three increments span only about three minutes; tolerating a
+30-minute incident requires a larger initial (for example 600 seconds: 10 m + 20 m
+between increments), a steeper curve, or a higher removal threshold.
 
 ## Suspect scheduling
 
@@ -142,22 +151,37 @@ state.
 
 ## State ownership
 
-The submission route owns the provider-event signal. The pool owns pre-suspect counts,
-suspect status, suspect removal counts, and suspect retry times so they are shared across
-builders and cleared with the UO lifecycle. Backoff progression is separate from removal
-evidence: provider-event failures increase the former but not the latter. This state is
-in-memory and does not track transaction hashes for deduplication.
+The submission route owns the provider-event signal; the pool consumes it as a single
+boolean gate on pre-suspect counting. The pool owns pre-suspect counts, suspect status,
+suspect removal counts, and suspect retry times so they are shared across builders and
+cleared with the UO lifecycle. This state is in-memory and does not track transaction
+hashes for deduplication.
 
 ## Tradeoffs
 
-- **Liveness versus false removal:** eventual removal protects bundling, but repeated
-  non-terminal failures can still remove a healthy UO when the provider-event signal
-  does not activate. Higher thresholds reduce false removals but extend poison lifetime.
+- **Liveness versus false removal:** eventual removal protects bundling, but failures
+  persisting across the entire backoff span can still remove a healthy UO — for
+  example, a provider incident longer than the cumulative suspect backoff. Higher
+  thresholds and longer backoff reduce false removals but extend poison lifetime.
 - **Isolation versus throughput:** singleton attempts identify poison UOs without adding
   innocent fillers, but consume more transactions than normal bundles. The dynamic
   isolation limit preserves normal capacity at the cost of slower suspect draining.
-- **Provider protection versus poison detection:** suppressing evidence during provider
-  events prevents broad false attribution, but a poison UO encountered during an event
-  takes longer to identify. Detection lag can also allow early event failures to count.
+- **Provider protection versus poison detection:** pausing pre-suspect counting during
+  provider events prevents mass false suspicion, but a poison UO encountered during an
+  event takes longer to identify. Detection lag can still create false suspects before
+  the signal activates; each costs one wasted singleton attempt after recovery and then
+  self-clears. An outage that outlasts detection lag may still suspect part of the
+  pool, which drains at singleton throughput after recovery.
 - **Backoff versus recovery latency:** per-suspect backoff prevents hot loops and resource
   churn, but delays successful retry after a transient failure.
+
+## Related work
+
+- **EIP-7702 auth-nonce recheck at bundle assembly** (fix 2 in
+  `INVESTIGATION-empty-revert-bundle-livelock.md`): re-validating authorization tuple
+  nonces at proposal time deterministically prevents the primary observed poison class
+  before it ever reaches this system. Companion change, tracked separately.
+- **PR #1304 (`fix(builder): remove ops after internal RPC error`):** removing every UO
+  in a bundle on a terminal `-32000: internal error` is superseded by this design. That
+  error class should instead follow the ambiguous multi-UO path (mark every UO suspect)
+  so innocent UOs survive; the two mechanisms must not both fire on the same error.


### PR DESCRIPTION
N/A

## Proposed Changes

Combined view of the poison user operations stack (design + PRs 1-6), squashed
across #1306, #1312, #1313, #1314, #1315 onto `main`:

- **docs**: add `docs/designs/poison-user-operations.md` describing the
  liveness/fairness/provider-resilience goals, the failure-flow table, and a
  telemetry section (metrics, logs, dashboards, alerts).
- **builder**: classify submission errors as terminal, non-terminal, or
  neutral; treat intrinsic-gas-too-low and internal RPC errors as terminal
  (the latter behind a chain-spec flag); wrap `TxSenderError` in
  `TransactionTrackerError`.
- **pool**: track poison user operation suspects in the mempool, gated behind
  a `--pool.suspect_tracking_enabled` master switch (default `false`);
  pause suspect *removal* (not analysis) during provider events; fall back to
  removal for unattributed reverts when suspect tracking is disabled; raise
  the default `max_suspect_rpc_failures` to 8.
- **builder**: wire the failure flow end-to-end — report bundle submission
  outcomes to the pool, schedule suspect isolation bundles in the assigner,
  detect provider-health events via a rolling outcome window, record
  submission outcomes in the provider-event signal, and make isolation slot
  reservation atomic in the assigner.
- **telemetry**: live suspect-count gauges, marked/cleared/removed counters,
  isolation gauges, per-sender bundle-outcome counters, and provider-event
  counters — purely additive observability, no config/CLI/behavior changes.

No behavior changes beyond what's already described in the stacked PRs; this
PR is the single merge target for that work into `main`.

## Test plan

- [x] `cargo check` (workspace)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (pool + builder suites green)
- [x] `make fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
