### PR TITLE
fix(sim): distinguish out-of-gas from empty revert in call gas testing

### DIFF
--- a/crates/rpc/src/eth/error.rs
+++ b/crates/rpc/src/eth/error.rs
@@ -553,6 +553,9 @@ impl From<GasEstimationError> for EthRpcError {
             GasEstimationError::RevertInCallWithBytes(b) => {
                 Self::ExecutionRevertedWithBytes(ExecutionRevertedWithBytesData { revert_data: b })
             }
+            error @ GasEstimationError::CallGasLimitTooLow(_) => {
+                Self::ExecutionReverted(error.to_string())
+            }
             error @ GasEstimationError::GasUsedTooLarge => {
                 Self::EntryPointValidationRejected(error.to_string())
             }

--- a/crates/sim/src/estimation/estimate_call_gas.rs
+++ b/crates/sim/src/estimation/estimate_call_gas.rs
@@ -198,8 +198,7 @@ where
         } else {
             let error = if let Ok(revert) = Revert::abi_decode(&result.revertData) {
                 GasEstimationError::RevertInCallWithMessage(revert.reason)
-            } else if result.revertData.is_empty() && result.gasUsed >= U256::from(call_gas_limit)
-            {
+            } else if result.revertData.is_empty() && result.gasUsed >= U256::from(call_gas_limit) {
                 // No revert reason and the call consumed at least the entire gas limit we
                 // gave it: an EVM out-of-gas exceptional halt clears returndata the same
                 // way a `revert(0, 0)` does, so this is the only signal available to tell

--- a/crates/sim/src/estimation/estimate_call_gas.rs
+++ b/crates/sim/src/estimation/estimate_call_gas.rs
@@ -13,7 +13,7 @@
 
 use std::{future::Future, pin::Pin};
 
-use alloy_primitives::{Address, B256, Bytes};
+use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_sol_types::{Revert, SolError};
 use anyhow::Context;
 use async_trait::async_trait;
@@ -198,6 +198,13 @@ where
         } else {
             let error = if let Ok(revert) = Revert::abi_decode(&result.revertData) {
                 GasEstimationError::RevertInCallWithMessage(revert.reason)
+            } else if result.revertData.is_empty() && result.gasUsed >= U256::from(call_gas_limit)
+            {
+                // No revert reason and the call consumed at least the entire gas limit we
+                // gave it: an EVM out-of-gas exceptional halt clears returndata the same
+                // way a `revert(0, 0)` does, so this is the only signal available to tell
+                // the two apart from the caller's side.
+                GasEstimationError::CallGasLimitTooLow(call_gas_limit)
             } else {
                 GasEstimationError::RevertInCallWithBytes(result.revertData)
             };

--- a/crates/sim/src/estimation/mod.rs
+++ b/crates/sim/src/estimation/mod.rs
@@ -56,6 +56,12 @@ pub enum GasEstimationError {
     /// Call reverted with bytes
     #[error("user operation's call reverted: {0:#x}")]
     RevertInCallWithBytes(Bytes),
+    /// Call reverted with no data while consuming the entire supplied call gas limit,
+    /// indicating it likely ran out of gas rather than hitting a genuine revert
+    #[error(
+        "call likely ran out of gas: consumed the entire callGasLimit ({0}) and reverted with no data"
+    )]
+    CallGasLimitTooLow(u128),
     /// Call used too much gas
     #[error("gas_used cannot be larger than a u64 integer")]
     GasUsedTooLarge,


### PR DESCRIPTION
## Summary
- When `eth_estimateUserOperationGas` tests a caller-supplied `callGasLimit` (via `CallGasEstimationProxy.testCallGas`), a genuine revert-with-no-reason and an out-of-gas exceptional halt are indistinguishable from returndata alone — both return `success=false` with empty bytes, since `innerCall` makes a raw, unwrapped low-level call.
- If the test consumed the entire supplied `callGasLimit` and returned empty revert data, rundler now returns an actionable message (`GasEstimationError::CallGasLimitTooLow`) instead of the opaque `"execution reverted"` with `revertData: 0x`.

## Context
Found while replicating a customer incident (Robinhood chain) where `eth_estimateUserOperationGas` returned an empty-data revert for a legitimate transfer. Root cause: the client reused a `callGasLimit` from a prior estimate, which was no longer sufficient against current chain state (most likely EIP-2929 cold/warm access variance across ops) — not a node-lag or balance issue as initially suspected. Replayed the customer's exact op against the historical block rundler had simulated against (via a temporary local patch, not included here) and confirmed: the same limit reproduces the empty revert, while letting rundler fully re-estimate (`callGasLimit: 0x0`) succeeds cleanly.

This change doesn't fix the client-side staleness issue, but turns a confusing, opaque error into one that points integrators at the actual problem.

## Test plan
- [x] `cargo test -p rundler-sim estimation::` — 27 passed
- [x] Verified live against the reproduced incident payload: before the fix, the exact customer request returned `{"code": -32521, "message": "execution reverted", "data": {"revertData": "0x"}}`; after, it returns `{"code": -32521, "message": "call likely ran out of gas: consumed the entire callGasLimit (31837) and reverted with no data"}`
- [ ] Reviewer: confirm no downstream consumers pattern-match on the previous generic `"execution reverted"` message text for this specific empty-data case

🤖 Generated with [Claude Code](https://claude.com/claude-code)