### PR TITLE
fix(builder): treat rate limits as pacing, not poison evidence

### DIFF
--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use std::{net::SocketAddr, str::FromStr, sync::Arc};
+use std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
 use anyhow::Context;
@@ -227,6 +227,28 @@ pub struct BuilderArgs {
         default_value = "0.50"
     )]
     assigner_starvation_ratio: f64,
+
+    /// Initial delay a builder waits before its next submission after the
+    /// submission endpoint rate limited it, doubling with each consecutive
+    /// rate-limited attempt and applied on top of the normal bundle trigger
+    /// interval. Any attempt that is not rate limited resets it.
+    #[arg(
+        long = "builder.rate_limit_backoff_initial_millis",
+        name = "builder.rate_limit_backoff_initial_millis",
+        env = "BUILDER_RATE_LIMIT_BACKOFF_INITIAL_MILLIS",
+        default_value = "1000"
+    )]
+    rate_limit_backoff_initial_millis: u64,
+
+    /// Maximum delay a builder waits between submissions while the submission
+    /// endpoint is rate limiting it.
+    #[arg(
+        long = "builder.rate_limit_backoff_max_millis",
+        name = "builder.rate_limit_backoff_max_millis",
+        env = "BUILDER_RATE_LIMIT_BACKOFF_MAX_MILLIS",
+        default_value = "30000"
+    )]
+    rate_limit_backoff_max_millis: u64,
 }
 
 impl BuilderArgs {
@@ -322,6 +344,10 @@ impl BuilderArgs {
             chain_spec,
             assigner_max_ops_per_request: self.assigner_max_ops_per_request,
             assigner_starvation_ratio: self.assigner_starvation_ratio,
+            rate_limit_backoff_initial: Duration::from_millis(
+                self.rate_limit_backoff_initial_millis,
+            ),
+            rate_limit_backoff_max: Duration::from_millis(self.rate_limit_backoff_max_millis),
         })
     }
 

--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU General Public License along with Rundler.
 // If not, see https://www.gnu.org/licenses/.
 
-use std::{net::SocketAddr, str::FromStr, sync::Arc};
+use std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
 use anyhow::Context;
@@ -228,6 +228,28 @@ pub struct BuilderArgs {
         default_value = "0.50"
     )]
     assigner_starvation_ratio: f64,
+
+    /// Initial delay a builder waits before its next submission after the
+    /// submission endpoint rate limited it, doubling with each consecutive
+    /// rate-limited attempt and applied on top of the normal bundle trigger
+    /// interval. Any attempt that is not rate limited resets it.
+    #[arg(
+        long = "builder.rate_limit_backoff_initial_millis",
+        name = "builder.rate_limit_backoff_initial_millis",
+        env = "BUILDER_RATE_LIMIT_BACKOFF_INITIAL_MILLIS",
+        default_value = "1000"
+    )]
+    rate_limit_backoff_initial_millis: u64,
+
+    /// Maximum delay a builder waits between submissions while the submission
+    /// endpoint is rate limiting it.
+    #[arg(
+        long = "builder.rate_limit_backoff_max_millis",
+        name = "builder.rate_limit_backoff_max_millis",
+        env = "BUILDER_RATE_LIMIT_BACKOFF_MAX_MILLIS",
+        default_value = "30000"
+    )]
+    rate_limit_backoff_max_millis: u64,
 }
 
 impl BuilderArgs {
@@ -323,6 +345,10 @@ impl BuilderArgs {
             chain_spec,
             assigner_max_ops_per_request: self.assigner_max_ops_per_request,
             assigner_starvation_ratio: self.assigner_starvation_ratio,
+            rate_limit_backoff_initial: Duration::from_millis(
+                self.rate_limit_backoff_initial_millis,
+            ),
+            rate_limit_backoff_max: Duration::from_millis(self.rate_limit_backoff_max_millis),
         })
     }
 

--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -231,13 +231,12 @@ pub struct BuilderArgs {
 
     /// Initial delay a builder waits before its next submission after the
     /// submission endpoint rate limited it, doubling with each consecutive
-    /// rate-limited attempt and applied on top of the normal bundle trigger
-    /// interval. Any attempt that is not rate limited resets it.
+    /// rate-limited attempt. Any attempt that is not rate limited resets it.
     #[arg(
         long = "builder.rate_limit_backoff_initial_millis",
         name = "builder.rate_limit_backoff_initial_millis",
         env = "BUILDER_RATE_LIMIT_BACKOFF_INITIAL_MILLIS",
-        default_value = "1000"
+        default_value = "100"
     )]
     rate_limit_backoff_initial_millis: u64,
 
@@ -247,7 +246,7 @@ pub struct BuilderArgs {
         long = "builder.rate_limit_backoff_max_millis",
         name = "builder.rate_limit_backoff_max_millis",
         env = "BUILDER_RATE_LIMIT_BACKOFF_MAX_MILLIS",
-        default_value = "30000"
+        default_value = "2000"
     )]
     rate_limit_backoff_max_millis: u64,
 }

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -53,7 +53,7 @@ mockall.workspace = true
 rundler-provider = { workspace = true, features = ["test-utils"] }
 rundler-sim = { workspace = true, features = ["test-utils"] }
 rundler-types = { workspace = true, features = ["test-utils"] }
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/builder/src/assigner.rs
+++ b/crates/builder/src/assigner.rs
@@ -1020,6 +1020,20 @@ impl Assigner {
             .builder_to_pinned_proposer
             .insert(builder_address, proposer_key);
     }
+
+    /// Test helper: true when `sender` is still confirmed to `builder_address`.
+    pub(crate) fn test_holds_confirmed_lock(
+        &self,
+        builder_address: Address,
+        sender: Address,
+    ) -> bool {
+        self.state
+            .lock()
+            .unwrap()
+            .uo_sender_to_builder_state
+            .get(&sender)
+            == Some(&(builder_address, LockState::Confirmed))
+    }
 }
 
 #[derive(Metrics, Clone)]

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -35,6 +35,7 @@ use tokio::{
         mpsc::{UnboundedReceiver, UnboundedSender},
         oneshot,
     },
+    time::Instant,
 };
 use tracing::{debug, error, info, warn};
 
@@ -61,6 +62,8 @@ pub(crate) struct Settings {
     pub(crate) max_replacement_underpriced_blocks: u64,
     pub(crate) max_cancellation_fee_increases: u64,
     pub(crate) max_blocks_to_wait_for_mine: u64,
+    pub(crate) rate_limit_backoff_initial: Duration,
+    pub(crate) rate_limit_backoff_max: Duration,
 }
 
 pub(crate) struct BundleSenderImpl<T, C> {
@@ -85,6 +88,10 @@ pub(crate) struct BundleSenderImpl<T, C> {
     /// builders on the route. Final submission outcomes are recorded here and
     /// its state gates poison user operation evidence in the pool.
     provider_event_signal: Arc<ProviderEventSignal>,
+    /// Backoff against a submission endpoint that is rate limiting this builder.
+    /// Outlives the bundle state machine: it is a property of the endpoint, not
+    /// of any one bundle attempt, so state resets must not clear it.
+    rate_limit_backoff: RateLimitBackoff,
 }
 
 pub enum BundleSenderAction {
@@ -133,6 +140,75 @@ enum SendBundleAttemptResult {
     InsufficientFunds,
     // Nonce too low
     NonceTooLow,
+    // The submission endpoint is rate limiting us
+    RateLimited,
+}
+
+impl SendBundleAttemptResult {
+    /// True when the submission endpoint judged the transaction, meaning it took
+    /// the request rather than refusing or never receiving it. Ends a rate-limit
+    /// backoff.
+    fn endpoint_judged_transaction(&self) -> bool {
+        match self {
+            Self::Success(_)
+            | Self::Underpriced
+            | Self::ReplacementUnderpriced
+            | Self::ConditionNotMet
+            | Self::Rejected
+            | Self::InsufficientFunds
+            | Self::NonceTooLow => true,
+            Self::RateLimited
+            | Self::NoOperationsInitially
+            | Self::NoOperationsAfterFeeFilter
+            | Self::NoOperationsAfterSimulation => false,
+        }
+    }
+}
+
+/// Per-builder backoff against a submission endpoint that is rate limiting us.
+///
+/// A rate limit is the endpoint asking for fewer requests. Retrying at the normal
+/// trigger cadence answers that by asking for exactly as many, which is enough to
+/// keep a whole fleet of builders pinned against the limit for as long as they
+/// have work: nothing lands, so nothing leaves the pool, so every builder has
+/// work on every trigger. Consecutive rate-limited attempts double the wait;
+/// any attempt that is not rate limited clears it.
+#[derive(Debug, Default)]
+struct RateLimitBackoff {
+    /// Consecutive rate-limited submission attempts, which sets the delay.
+    consecutive: u32,
+    /// When the next submission attempt may be made, if a wait is outstanding.
+    retry_after: Option<Instant>,
+}
+
+impl RateLimitBackoff {
+    /// Records a rate-limited attempt and schedules the next one. Returns the
+    /// delay, for logging.
+    fn record(&mut self, initial: Duration, max: Duration) -> Duration {
+        let delay = initial
+            .saturating_mul(2u32.saturating_pow(self.consecutive))
+            .min(max)
+            // Builders on a route hit the limit together, so an unjittered
+            // schedule would have them all retry in the same instant.
+            .mul_f64(rand::thread_rng().gen_range(0.8..=1.2))
+            .min(max);
+        self.consecutive = self.consecutive.saturating_add(1);
+        self.retry_after = Some(Instant::now() + delay);
+        delay
+    }
+
+    /// Clears the backoff after an attempt that was not rate limited.
+    fn clear(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Waits out an outstanding backoff, if any. Called with the signer released
+    /// so a backing-off builder does not hold a signing key other work could use.
+    async fn wait(&mut self) {
+        if let Some(retry_after) = self.retry_after.take() {
+            tokio::time::sleep_until(retry_after).await;
+        }
+    }
 }
 
 #[async_trait]
@@ -167,6 +243,13 @@ where
             if state.is_signer_releasable() {
                 state.transaction_tracker.end_cycle();
             }
+
+            // Wait out any backoff owed to the submission endpoint. Held here,
+            // outside the state machine, so it applies on top of the trigger
+            // cadence no matter which state the last attempt left behind -
+            // including the states that skip the trigger wait entirely - and so
+            // the signer stays released for the duration.
+            self.rate_limit_backoff.wait().await;
 
             // Block until the next trigger or block event arrives.
             // The signer may be free (released above) during this entire wait.
@@ -250,6 +333,7 @@ where
             settings,
             event_sender,
             provider_event_signal,
+            rate_limit_backoff: RateLimitBackoff::default(),
         }
     }
 
@@ -345,6 +429,18 @@ where
         let block_number = state.block_number();
         debug!("Building bundle on block {block_number}");
         let result = self.send_bundle(state, inner.fee_increase_count).await;
+
+        // The escalating wait starts over once the endpoint takes a request from
+        // us again. Triggers that never reached the endpoint - no operations to
+        // bundle, a proposal error - are not that evidence and leave the backoff
+        // alone, so an idle pool between rate-limited attempts cannot silently
+        // hold the wait at its initial value.
+        if result
+            .as_ref()
+            .is_ok_and(SendBundleAttemptResult::endpoint_judged_transaction)
+        {
+            self.rate_limit_backoff.clear();
+        }
 
         // Snapshot pinned proposer after send_bundle (pin is set during assignment)
         let pinned = self.assigner.pinned_proposer(self.sender_eoa);
@@ -453,6 +549,25 @@ where
                 // Set flag to pass to proposer on next make_bundle call
                 state.condition_not_met = true;
                 state.update(InnerState::Building(inner.retry()));
+            }
+            Ok(SendBundleAttemptResult::RateLimited) => {
+                // Release locks only when nothing is pending (continuing)
+                if state.transaction_tracker.num_pending_transactions() == 0 {
+                    self.assigner.release_all(self.sender_eoa);
+                }
+                let delay = self.rate_limit_backoff.record(
+                    self.settings.rate_limit_backoff_initial,
+                    self.settings.rate_limit_backoff_max,
+                );
+                // Warn rather than error: a rate limit is the endpoint pacing us,
+                // not a fault in the bundle, and at fleet scale erroring on every
+                // attempt buries the logs that matter.
+                warn!(
+                    "Submission endpoint rate limited, backing off {}ms before the next attempt",
+                    delay.as_millis()
+                );
+                self.increment_counter("builder_bundle_txns_rate_limited", &pinned, 1);
+                state.update(InnerState::Building(inner.retry_on_next_trigger()));
             }
             Ok(SendBundleAttemptResult::InsufficientFunds) => {
                 // Release all locks — cycle ending
@@ -1064,6 +1179,16 @@ where
                         warn!("Bundle attempt condition not met");
                         Ok(SendBundleAttemptResult::ConditionNotMet)
                     }
+                    // Not an error result: erroring here would reset the
+                    // transaction tracker and log twice per attempt per builder,
+                    // when the bundle is fine and the only thing to do is send
+                    // less often. The caller warns once, with the backoff it
+                    // picked; the endpoint's own wording is only needed when
+                    // diagnosing which limit was hit.
+                    TxSenderError::RateLimited(error) => {
+                        debug!("Bundle attempt rate limited by submission endpoint: {error}");
+                        Ok(SendBundleAttemptResult::RateLimited)
+                    }
                     TxSenderError::Rejected => {
                         self.increment_counter_ep("builder_bundle_txn_rejected", entry_point, 1);
                         warn!("Bundle attempt rejected");
@@ -1434,6 +1559,15 @@ impl BuildingState {
     // Retry the build
     fn retry(mut self) -> Self {
         self.wait_for_trigger = false;
+        self
+    }
+
+    // Retry the build on the next trigger, leaving fee state untouched.
+    //
+    // Unlike `retry`, the next attempt waits: this is for retries that must not
+    // re-submit immediately, such as backing off a rate-limited endpoint.
+    fn retry_on_next_trigger(mut self) -> Self {
+        self.wait_for_trigger = true;
         self
     }
 
@@ -2941,6 +3075,165 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_rate_limit_is_not_poison_evidence() {
+        let Mocks {
+            mut mock_proposer_t,
+            mut mock_tracker,
+            mut mock_trigger,
+            mut mock_pool,
+        } = new_mocks();
+
+        let mut seq = Sequence::new();
+        add_trigger_no_update_last_block(&mut mock_trigger, &mut seq, 1);
+
+        setup_tracker_default(&mut mock_tracker);
+        mock_tracker.expect_reset().returning(|| Box::pin(async {}));
+
+        mock_pool
+            .expect_get_ops_summaries()
+            .times(1)
+            .returning(|_, _, _, _| {
+                Ok(vec![pool_op_summary(
+                    ENTRY_POINT_ADDRESS_V0_6,
+                    Address::ZERO,
+                )])
+            });
+        mock_pool
+            .expect_get_ops_by_hashes()
+            .times(1)
+            .returning(|_, _| Ok(vec![demo_pool_op()]));
+        // The bundle was never judged, so nothing about it is reported to the
+        // pool: no failure counted, no suspect created, no isolation.
+        mock_pool.expect_report_bundle_outcome().never();
+
+        mock_make_bundle(&mut mock_proposer_t, 1, vec![(Address::ZERO, B256::ZERO)]);
+
+        mock_tracker
+            .expect_send_transaction()
+            .returning(move |_, _, _| {
+                Box::pin(async move {
+                    Err(TransactionTrackerError::Sender(TxSenderError::RateLimited(
+                        anyhow::anyhow!("HTTP error 429 with body: Too Many Requests"),
+                    )))
+                })
+            });
+
+        let mut state = new_state_with(
+            mock_trigger,
+            mock_tracker,
+            InnerState::Building(BuildingState {
+                wait_for_trigger: true,
+                fee_increase_count: 0,
+                underpriced_info: None,
+            }),
+        );
+
+        let mut sender = new_sender(mock_proposer_t, mock_pool);
+
+        let update = state.wait_for_trigger().await.unwrap();
+        sender.step_after_trigger(&mut state, update).await.unwrap();
+
+        // Nor is it evidence about the provider's health.
+        assert_eq!(sender.provider_event_signal.observations(), 0);
+        assert!(!sender.provider_event_signal.is_active());
+
+        // The next attempt waits for a trigger and owes a backoff on top of it.
+        assert!(matches!(
+            state.inner,
+            InnerState::Building(BuildingState {
+                wait_for_trigger: true,
+                fee_increase_count: 0,
+                underpriced_info: None,
+            })
+        ));
+        assert_eq!(sender.rate_limit_backoff.consecutive, 1);
+        assert!(sender.rate_limit_backoff.retry_after.is_some());
+    }
+
+    #[test]
+    fn test_rate_limit_backoff_escalates_and_caps() {
+        let initial = Duration::from_secs(1);
+        let max = Duration::from_secs(30);
+        let mut backoff = RateLimitBackoff::default();
+
+        // Doubling from `initial`, with +/-20% jitter so that builders sharing a
+        // route do not retry in lockstep.
+        for expected_base in [1, 2, 4, 8, 16] {
+            let delay = backoff.record(initial, max);
+            let base = Duration::from_secs(expected_base);
+            assert!(
+                delay >= base.mul_f64(0.8) && delay <= base.mul_f64(1.2),
+                "delay {delay:?} outside jitter range of {base:?}"
+            );
+        }
+
+        // 32s would exceed the cap, and jitter must not push it back over.
+        for _ in 0..4 {
+            let delay = backoff.record(initial, max);
+            assert!(delay >= max.mul_f64(0.8) && delay <= max, "delay {delay:?}");
+        }
+    }
+
+    #[test]
+    fn test_only_judged_attempts_end_the_backoff() {
+        // Outcomes the node produced: the endpoint is taking our requests.
+        for result in [
+            SendBundleAttemptResult::Success(Arc::new(vec![])),
+            SendBundleAttemptResult::Underpriced,
+            SendBundleAttemptResult::ConditionNotMet,
+            SendBundleAttemptResult::NonceTooLow,
+        ] {
+            assert!(result.endpoint_judged_transaction());
+        }
+
+        // Nothing was submitted, so nothing was learned about the endpoint.
+        for result in [
+            SendBundleAttemptResult::RateLimited,
+            SendBundleAttemptResult::NoOperationsInitially,
+            SendBundleAttemptResult::NoOperationsAfterFeeFilter,
+            SendBundleAttemptResult::NoOperationsAfterSimulation,
+        ] {
+            assert!(!result.endpoint_judged_transaction());
+        }
+    }
+
+    #[test]
+    fn test_rate_limit_backoff_cleared_after_accepted_attempt() {
+        let initial = Duration::from_secs(1);
+        let max = Duration::from_secs(30);
+        let mut backoff = RateLimitBackoff::default();
+
+        backoff.record(initial, max);
+        backoff.record(initial, max);
+        assert_eq!(backoff.consecutive, 2);
+
+        backoff.clear();
+
+        assert_eq!(backoff.consecutive, 0);
+        assert!(backoff.retry_after.is_none());
+        // Escalation restarts from `initial` rather than resuming mid-ladder.
+        let delay = backoff.record(initial, max);
+        assert!(delay <= initial.mul_f64(1.2), "delay {delay:?}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_rate_limit_backoff_waits_before_next_attempt() {
+        let mut backoff = RateLimitBackoff::default();
+        let delay = backoff.record(Duration::from_secs(5), Duration::from_secs(30));
+
+        let start = Instant::now();
+        backoff.wait().await;
+
+        assert!(start.elapsed() >= delay);
+        // The wait is consumed: a builder does not re-serve the same delay on
+        // every loop iteration, only after another rate-limited attempt.
+        assert!(backoff.retry_after.is_none());
+        let start = Instant::now();
+        backoff.wait().await;
+        assert!(start.elapsed() < Duration::from_millis(1));
+    }
+
+    #[tokio::test]
     async fn test_revert_reports_suspects_and_removes() {
         let Mocks {
             mut mock_proposer_t,
@@ -3098,6 +3391,8 @@ mod tests {
                 max_cancellation_fee_increases: 3,
                 max_blocks_to_wait_for_mine: 3,
                 max_replacement_underpriced_blocks: 3,
+                rate_limit_backoff_initial: Duration::from_secs(1),
+                rate_limit_backoff_max: Duration::from_secs(30),
             },
             broadcast::channel(1000).0,
             Arc::new(ProviderEventSignal::default()),
@@ -3132,6 +3427,8 @@ mod tests {
                 max_cancellation_fee_increases: 3,
                 max_blocks_to_wait_for_mine: 3,
                 max_replacement_underpriced_blocks: 3,
+                rate_limit_backoff_initial: Duration::from_secs(1),
+                rate_limit_backoff_max: Duration::from_secs(30),
             },
             broadcast::channel(1000).0,
             Arc::new(ProviderEventSignal::default()),

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -167,12 +167,8 @@ impl SendBundleAttemptResult {
 
 /// Per-builder backoff against a submission endpoint that is rate limiting us.
 ///
-/// A rate limit is the endpoint asking for fewer requests. Retrying at the normal
-/// trigger cadence answers that by asking for exactly as many, which is enough to
-/// keep a whole fleet of builders pinned against the limit for as long as they
-/// have work: nothing lands, so nothing leaves the pool, so every builder has
-/// work on every trigger. Consecutive rate-limited attempts double the wait;
-/// any attempt that is not rate limited clears it.
+/// Consecutive rate-limited attempts double the wait; any attempt that is not
+/// rate limited clears it.
 #[derive(Debug, Default)]
 struct RateLimitBackoff {
     /// Consecutive rate-limited submission attempts, which sets the delay.
@@ -200,6 +196,11 @@ impl RateLimitBackoff {
     /// Clears the backoff after an attempt that was not rate limited.
     fn clear(&mut self) {
         *self = Self::default();
+    }
+
+    /// True while a wait is outstanding.
+    fn is_waiting(&self) -> bool {
+        self.retry_after.is_some()
     }
 
     /// Waits out an outstanding backoff, if any. Called with the signer released
@@ -240,15 +241,16 @@ where
             // and waiting for the next block trigger. The signing key is not needed
             // during the wait, so it is returned to the pool where it can be borrowed
             // for other work such as sponsored undelegation.
-            if state.is_signer_releasable() {
+            // A rate-limited builder waits out its backoff instead of the trigger,
+            // so an outstanding backoff is idle time too. `end_cycle` is a no-op
+            // while transactions are pending.
+            if state.is_signer_releasable() || self.rate_limit_backoff.is_waiting() {
                 state.transaction_tracker.end_cycle();
             }
 
             // Wait out any backoff owed to the submission endpoint. Held here,
-            // outside the state machine, so it applies on top of the trigger
-            // cadence no matter which state the last attempt left behind -
-            // including the states that skip the trigger wait entirely - and so
-            // the signer stays released for the duration.
+            // outside the state machine, so it survives state resets and applies
+            // whichever state the last attempt left behind.
             self.rate_limit_backoff.wait().await;
 
             // Block until the next trigger or block event arrives.
@@ -559,15 +561,13 @@ where
                     self.settings.rate_limit_backoff_initial,
                     self.settings.rate_limit_backoff_max,
                 );
-                // Warn rather than error: a rate limit is the endpoint pacing us,
-                // not a fault in the bundle, and at fleet scale erroring on every
-                // attempt buries the logs that matter.
                 warn!(
                     "Submission endpoint rate limited, backing off {}ms before the next attempt",
                     delay.as_millis()
                 );
                 self.increment_counter("builder_bundle_txns_rate_limited", &pinned, 1);
-                state.update(InnerState::Building(inner.retry_on_next_trigger()));
+                // The backoff is the wait, so don't also wait for the next trigger.
+                state.update(InnerState::Building(inner.retry()));
             }
             Ok(SendBundleAttemptResult::InsufficientFunds) => {
                 // Release all locks — cycle ending
@@ -1179,12 +1179,6 @@ where
                         warn!("Bundle attempt condition not met");
                         Ok(SendBundleAttemptResult::ConditionNotMet)
                     }
-                    // Not an error result: erroring here would reset the
-                    // transaction tracker and log twice per attempt per builder,
-                    // when the bundle is fine and the only thing to do is send
-                    // less often. The caller warns once, with the backoff it
-                    // picked; the endpoint's own wording is only needed when
-                    // diagnosing which limit was hit.
                     TxSenderError::RateLimited(error) => {
                         debug!("Bundle attempt rate limited by submission endpoint: {error}");
                         Ok(SendBundleAttemptResult::RateLimited)
@@ -1559,15 +1553,6 @@ impl BuildingState {
     // Retry the build
     fn retry(mut self) -> Self {
         self.wait_for_trigger = false;
-        self
-    }
-
-    // Retry the build on the next trigger, leaving fee state untouched.
-    //
-    // Unlike `retry`, the next attempt waits: this is for retries that must not
-    // re-submit immediately, such as backing off a rate-limited endpoint.
-    fn retry_on_next_trigger(mut self) -> Self {
-        self.wait_for_trigger = true;
         self
     }
 
@@ -3137,37 +3122,39 @@ mod tests {
         assert_eq!(sender.provider_event_signal.observations(), 0);
         assert!(!sender.provider_event_signal.is_active());
 
-        // The next attempt waits for a trigger and owes a backoff on top of it.
+        // The backoff is the only thing the next attempt waits on: fee state is
+        // untouched and the trigger wait is not re-armed.
         assert!(matches!(
             state.inner,
             InnerState::Building(BuildingState {
-                wait_for_trigger: true,
+                wait_for_trigger: false,
                 fee_increase_count: 0,
                 underpriced_info: None,
             })
         ));
         assert_eq!(sender.rate_limit_backoff.consecutive, 1);
-        assert!(sender.rate_limit_backoff.retry_after.is_some());
+        assert!(sender.rate_limit_backoff.is_waiting());
     }
 
     #[test]
     fn test_rate_limit_backoff_escalates_and_caps() {
-        let initial = Duration::from_secs(1);
-        let max = Duration::from_secs(30);
+        // The shipped defaults.
+        let initial = Duration::from_millis(100);
+        let max = Duration::from_millis(2000);
         let mut backoff = RateLimitBackoff::default();
 
         // Doubling from `initial`, with +/-20% jitter so that builders sharing a
         // route do not retry in lockstep.
-        for expected_base in [1, 2, 4, 8, 16] {
+        for expected_base in [100, 200, 400, 800, 1600] {
             let delay = backoff.record(initial, max);
-            let base = Duration::from_secs(expected_base);
+            let base = Duration::from_millis(expected_base);
             assert!(
                 delay >= base.mul_f64(0.8) && delay <= base.mul_f64(1.2),
                 "delay {delay:?} outside jitter range of {base:?}"
             );
         }
 
-        // 32s would exceed the cap, and jitter must not push it back over.
+        // 3200ms would exceed the cap, and jitter must not push it back over.
         for _ in 0..4 {
             let delay = backoff.record(initial, max);
             assert!(delay >= max.mul_f64(0.8) && delay <= max, "delay {delay:?}");
@@ -3199,8 +3186,8 @@ mod tests {
 
     #[test]
     fn test_rate_limit_backoff_cleared_after_accepted_attempt() {
-        let initial = Duration::from_secs(1);
-        let max = Duration::from_secs(30);
+        let initial = Duration::from_millis(100);
+        let max = Duration::from_millis(2000);
         let mut backoff = RateLimitBackoff::default();
 
         backoff.record(initial, max);
@@ -3210,7 +3197,7 @@ mod tests {
         backoff.clear();
 
         assert_eq!(backoff.consecutive, 0);
-        assert!(backoff.retry_after.is_none());
+        assert!(!backoff.is_waiting());
         // Escalation restarts from `initial` rather than resuming mid-ladder.
         let delay = backoff.record(initial, max);
         assert!(delay <= initial.mul_f64(1.2), "delay {delay:?}");
@@ -3227,7 +3214,7 @@ mod tests {
         assert!(start.elapsed() >= delay);
         // The wait is consumed: a builder does not re-serve the same delay on
         // every loop iteration, only after another rate-limited attempt.
-        assert!(backoff.retry_after.is_none());
+        assert!(!backoff.is_waiting());
         let start = Instant::now();
         backoff.wait().await;
         assert!(start.elapsed() < Duration::from_millis(1));

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -198,13 +198,7 @@ impl RateLimitBackoff {
         *self = Self::default();
     }
 
-    /// True while a wait is outstanding.
-    fn is_waiting(&self) -> bool {
-        self.retry_after.is_some()
-    }
-
-    /// Waits out an outstanding backoff, if any. Called with the signer released
-    /// so a backing-off builder does not hold a signing key other work could use.
+    /// Waits out an outstanding backoff, if any.
     async fn wait(&mut self) {
         if let Some(retry_after) = self.retry_after.take() {
             tokio::time::sleep_until(retry_after).await;
@@ -241,19 +235,12 @@ where
             // and waiting for the next block trigger. The signing key is not needed
             // during the wait, so it is returned to the pool where it can be borrowed
             // for other work such as sponsored undelegation.
-            // A rate-limited builder waits out its backoff instead of the trigger,
-            // so an outstanding backoff is idle time too. `end_cycle` hands the key
-            // back only when no transactions are tracked at all - stricter than the
-            // `num_pending_transactions() == 0` guard the `RateLimited` arm already
-            // released the assigner locks under - so the key is never returned while
-            // operations are still assigned to it.
-            if state.is_signer_releasable() || self.rate_limit_backoff.is_waiting() {
+            if state.is_signer_releasable() {
                 state.transaction_tracker.end_cycle();
             }
 
-            // Wait out any backoff owed to the submission endpoint. Held here,
-            // outside the state machine, so it survives state resets and applies
-            // whichever state the last attempt left behind.
+            // Wait out any backoff owed to the submission endpoint. Held outside the
+            // state machine so it survives state resets.
             self.rate_limit_backoff.wait().await;
 
             // Block until the next trigger or block event arrives.
@@ -3136,7 +3123,7 @@ mod tests {
             })
         ));
         assert_eq!(sender.rate_limit_backoff.consecutive, 1);
-        assert!(sender.rate_limit_backoff.is_waiting());
+        assert!(sender.rate_limit_backoff.retry_after.is_some());
     }
 
     #[test]
@@ -3200,7 +3187,7 @@ mod tests {
         backoff.clear();
 
         assert_eq!(backoff.consecutive, 0);
-        assert!(!backoff.is_waiting());
+        assert!(backoff.retry_after.is_none());
         // Escalation restarts from `initial` rather than resuming mid-ladder.
         let delay = backoff.record(initial, max);
         assert!(delay <= initial.mul_f64(1.2), "delay {delay:?}");
@@ -3217,7 +3204,7 @@ mod tests {
         assert!(start.elapsed() >= delay);
         // The wait is consumed: a builder does not re-serve the same delay on
         // every loop iteration, only after another rate-limited attempt.
-        assert!(!backoff.is_waiting());
+        assert!(backoff.retry_after.is_none());
         let start = Instant::now();
         backoff.wait().await;
         assert!(start.elapsed() < Duration::from_millis(1));

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -242,8 +242,11 @@ where
             // during the wait, so it is returned to the pool where it can be borrowed
             // for other work such as sponsored undelegation.
             // A rate-limited builder waits out its backoff instead of the trigger,
-            // so an outstanding backoff is idle time too. `end_cycle` is a no-op
-            // while transactions are pending.
+            // so an outstanding backoff is idle time too. `end_cycle` hands the key
+            // back only when no transactions are tracked at all - stricter than the
+            // `num_pending_transactions() == 0` guard the `RateLimited` arm already
+            // released the assigner locks under - so the key is never returned while
+            // operations are still assigned to it.
             if state.is_signer_releasable() || self.rate_limit_backoff.is_waiting() {
                 state.transaction_tracker.end_cycle();
             }

--- a/crates/builder/src/bundle_sender.rs
+++ b/crates/builder/src/bundle_sender.rs
@@ -3126,6 +3126,88 @@ mod tests {
         assert!(sender.rate_limit_backoff.retry_after.is_some());
     }
 
+    #[tokio::test]
+    async fn test_rate_limit_keeps_locks_while_txn_pending() {
+        let Mocks {
+            mut mock_proposer_t,
+            mut mock_tracker,
+            mut mock_trigger,
+            mut mock_pool,
+        } = new_mocks();
+
+        let mut seq = Sequence::new();
+        add_trigger_no_update_last_block(&mut mock_trigger, &mut seq, 1);
+
+        mock_tracker.expect_get_state().returning(|| {
+            Ok(TrackerState {
+                nonce: 0,
+                balance: U256::ZERO,
+                required_fees: None,
+            })
+        });
+        mock_tracker.expect_address().return_const(Address::ZERO);
+        // A replacement attempt: an earlier bundle is still in flight.
+        mock_tracker
+            .expect_num_pending_transactions()
+            .return_const(1_usize);
+        mock_tracker.expect_reset().returning(|| Box::pin(async {}));
+
+        mock_pool
+            .expect_get_ops_summaries()
+            .returning(|_, _, _, _| {
+                Ok(vec![pool_op_summary(
+                    ENTRY_POINT_ADDRESS_V0_6,
+                    Address::ZERO,
+                )])
+            });
+        mock_pool
+            .expect_get_ops_by_hashes()
+            .returning(|_, _| Ok(vec![demo_pool_op()]));
+
+        mock_make_bundle(&mut mock_proposer_t, 1, vec![(Address::ZERO, B256::ZERO)]);
+
+        mock_tracker
+            .expect_send_transaction()
+            .returning(move |_, _, _| {
+                Box::pin(async move {
+                    Err(TransactionTrackerError::Sender(TxSenderError::RateLimited(
+                        anyhow::anyhow!("HTTP error 429 with body: Too Many Requests"),
+                    )))
+                })
+            });
+
+        let mut sender = new_sender(mock_proposer_t, mock_pool);
+
+        // Simulate the prior successful send that put the in-flight transaction
+        // on chain: its sender is confirmed to this builder.
+        sender.assigner.test_establish_pin(
+            Address::ZERO,
+            &[Address::ZERO],
+            (ENTRY_POINT_ADDRESS_V0_6, None),
+        );
+
+        let mut state = new_state_with(
+            mock_trigger,
+            mock_tracker,
+            InnerState::Building(BuildingState {
+                wait_for_trigger: true,
+                fee_increase_count: 1,
+                underpriced_info: None,
+            }),
+        );
+
+        let update = state.wait_for_trigger().await.unwrap();
+        sender.step_after_trigger(&mut state, update).await.unwrap();
+
+        // Survives both drop paths: `confirm_senders_drop_unused` skips confirmed
+        // locks, and `release_all` is gated on no pending transaction.
+        assert!(
+            sender
+                .assigner
+                .test_holds_confirmed_lock(Address::ZERO, Address::ZERO)
+        );
+    }
+
     #[test]
     fn test_rate_limit_backoff_escalates_and_caps() {
         // The shipped defaults.

--- a/crates/builder/src/sender/fallback.rs
+++ b/crates/builder/src/sender/fallback.rs
@@ -51,8 +51,8 @@ enum ActiveSender {
 }
 
 /// A transaction sender that transparently fails over to a fallback sender when
-/// the primary returns [`TxSenderError::SenderUnavailable`] or
-/// [`TxSenderError::UnrecognizedRpc`].
+/// the primary returns [`TxSenderError::SenderUnavailable`],
+/// [`TxSenderError::UnrecognizedRpc`], or [`TxSenderError::RateLimited`].
 ///
 /// Recovery is passive: after `recovery_interval` has elapsed the next send
 /// attempt re-tries the primary. On success the primary is reinstated; on
@@ -170,7 +170,13 @@ impl TransactionSender for FallbackTransactionSender {
                 Ok(hash)
             }
             Err(
-                e @ (TxSenderError::SenderUnavailable(_) | TxSenderError::UnrecognizedRpc { .. }),
+                e @ (TxSenderError::SenderUnavailable(_)
+                | TxSenderError::UnrecognizedRpc { .. }
+                // A rate limit is capacity we cannot use on this route, so the
+                // fallback is exactly the right place to send the bundle. The
+                // caller still backs off the primary if the fallback is not
+                // configured or is itself rate limited.
+                | TxSenderError::RateLimited(_)),
             ) => {
                 self.metrics.primary_unavailable.increment(1);
                 let failures = self.consecutive_failures.fetch_add(1, Ordering::AcqRel) + 1;

--- a/crates/builder/src/sender/fallback.rs
+++ b/crates/builder/src/sender/fallback.rs
@@ -51,8 +51,8 @@ enum ActiveSender {
 }
 
 /// A transaction sender that transparently fails over to a fallback sender when
-/// the primary returns [`TxSenderError::SenderUnavailable`],
-/// [`TxSenderError::UnrecognizedRpc`], or [`TxSenderError::RateLimited`].
+/// the primary returns [`TxSenderError::SenderUnavailable`] or
+/// [`TxSenderError::UnrecognizedRpc`].
 ///
 /// Recovery is passive: after `recovery_interval` has elapsed the next send
 /// attempt re-tries the primary. On success the primary is reinstated; on
@@ -170,13 +170,7 @@ impl TransactionSender for FallbackTransactionSender {
                 Ok(hash)
             }
             Err(
-                e @ (TxSenderError::SenderUnavailable(_)
-                | TxSenderError::UnrecognizedRpc { .. }
-                // A rate limit is capacity we cannot use on this route, so the
-                // fallback is exactly the right place to send the bundle. The
-                // caller still backs off the primary if the fallback is not
-                // configured or is itself rate limited.
-                | TxSenderError::RateLimited(_)),
+                e @ (TxSenderError::SenderUnavailable(_) | TxSenderError::UnrecognizedRpc { .. }),
             ) => {
                 self.metrics.primary_unavailable.increment(1);
                 let failures = self.consecutive_failures.fetch_add(1, Ordering::AcqRel) + 1;

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -93,6 +93,15 @@ pub(crate) enum TxSenderError {
         /// RPC error message.
         message: String,
     },
+    /// The submission endpoint is rate limiting us.
+    ///
+    /// The transaction was never judged, so this says nothing about the bundle's
+    /// contents - only that we are asking for more capacity than the endpoint
+    /// will give us. Handled by backing the builder off the endpoint rather than
+    /// by retrying at the normal trigger cadence. When a fallback sender is
+    /// configured this triggers failover.
+    #[error("submission endpoint rate limited: {0}")]
+    RateLimited(anyhow::Error),
     /// Sender is unavailable due to an outage or transport error.
     ///
     /// When a fallback sender is configured this triggers failover.
@@ -147,7 +156,15 @@ impl TxSenderError {
             TxSenderError::SenderUnavailable(_) | TxSenderError::UnrecognizedRpc { .. } => {
                 RpcOutcomeClass::NonTerminal
             }
-            TxSenderError::Underpriced
+            // A rate limit is a statement about our request volume, not about
+            // the bundle: the endpoint never judged the transaction. Counting it
+            // as provider-health evidence would also make suspects of every op
+            // in the bundle, so a rate-limited endpoint would push the whole
+            // pool into isolation - one submission per bundle - while we are
+            // already being told to send fewer requests. Backing off the
+            // endpoint is the dedicated handling instead.
+            TxSenderError::RateLimited(_)
+            | TxSenderError::Underpriced
             | TxSenderError::ReplacementUnderpriced
             | TxSenderError::NonceTooLow
             | TxSenderError::ConditionNotMet
@@ -390,6 +407,13 @@ fn create_hard_cancel_tx(to: Address, nonce: u64, gas_fees: GasFees) -> Transact
 
 impl From<ProviderError> for TxSenderError {
     fn from(value: ProviderError) -> Self {
+        // Checked before the error-response paths below: providers signal a rate
+        // limit both as HTTP 429 and as a JSON-RPC error response, and the latter
+        // would otherwise land in `UnrecognizedRpc` and be treated as an ambiguous
+        // judgement of the transaction.
+        if value.is_rate_limited() {
+            return TxSenderError::RateLimited(anyhow::anyhow!("{value}"));
+        }
         match &value {
             ProviderError::RPC(e) => {
                 if let Some(e) = e.as_error_resp() {
@@ -473,6 +497,12 @@ mod tests {
                 TxSenderError::Other(anyhow::anyhow!("signing failed")),
                 RpcOutcomeClass::Neutral,
             ),
+            // A rate limit must not reach poison user operation handling: it is
+            // evidence about our request volume, not about the bundle.
+            (
+                TxSenderError::RateLimited(anyhow::anyhow!("HTTP error 429")),
+                RpcOutcomeClass::Neutral,
+            ),
         ];
 
         for (error, expected) in cases {
@@ -497,6 +527,44 @@ mod tests {
         )));
 
         assert!(matches!(error, TxSenderError::SenderUnavailable(_)));
+    }
+
+    #[test]
+    fn maps_rate_limits_to_rate_limited() {
+        // HTTP 429, the shape a public sequencer endpoint returns.
+        let http_429 = TxSenderError::from(ProviderError::RPC(TransportErrorKind::http_error(
+            429,
+            "Too Many Requests".to_string(),
+        )));
+        assert!(matches!(http_429, TxSenderError::RateLimited(_)));
+
+        // A JSON-RPC error response, which would otherwise be classified as an
+        // ambiguous `UnrecognizedRpc` judgement of the transaction.
+        let rpc_429 = TxSenderError::from(super::rpc_error_response(429, "rate limit exceeded"));
+        assert!(matches!(rpc_429, TxSenderError::RateLimited(_)));
+
+        let rpc_limit_exceeded =
+            TxSenderError::from(super::rpc_error_response(-32005, "limit exceeded"));
+        assert!(matches!(rpc_limit_exceeded, TxSenderError::RateLimited(_)));
+
+        // A transport that lost the status code and left it in the text.
+        let stringified = TxSenderError::from(ProviderError::RPC(TransportErrorKind::custom_str(
+            "server returned 429 Too Many Requests",
+        )));
+        assert!(matches!(stringified, TxSenderError::RateLimited(_)));
+    }
+
+    #[test]
+    fn does_not_treat_service_unavailable_as_rate_limited() {
+        // 503 is provider-health evidence, and alloy groups it with rate limits
+        // as "retryable", so it must be excluded explicitly.
+        let error = TxSenderError::from(ProviderError::RPC(TransportErrorKind::http_error(
+            503,
+            "Service Unavailable".to_string(),
+        )));
+
+        assert!(matches!(error, TxSenderError::SenderUnavailable(_)));
+        assert_eq!(error.classify(), RpcOutcomeClass::NonTerminal);
     }
 
     #[test]

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -95,6 +95,15 @@ pub(crate) enum TxSenderError {
         /// RPC error message.
         message: String,
     },
+    /// The submission endpoint is rate limiting us.
+    ///
+    /// The transaction was never judged, so this says nothing about the bundle's
+    /// contents - only that we are asking for more capacity than the endpoint
+    /// will give us. Handled by backing the builder off the endpoint rather than
+    /// by retrying at the normal trigger cadence. When a fallback sender is
+    /// configured this triggers failover.
+    #[error("submission endpoint rate limited: {0}")]
+    RateLimited(anyhow::Error),
     /// Sender is unavailable due to an outage or transport error.
     ///
     /// When a fallback sender is configured this triggers failover.
@@ -149,7 +158,15 @@ impl TxSenderError {
             TxSenderError::SenderUnavailable(_) | TxSenderError::UnrecognizedRpc { .. } => {
                 RpcOutcomeClass::NonTerminal
             }
-            TxSenderError::Underpriced
+            // A rate limit is a statement about our request volume, not about
+            // the bundle: the endpoint never judged the transaction. Counting it
+            // as provider-health evidence would also make suspects of every op
+            // in the bundle, so a rate-limited endpoint would push the whole
+            // pool into isolation - one submission per bundle - while we are
+            // already being told to send fewer requests. Backing off the
+            // endpoint is the dedicated handling instead.
+            TxSenderError::RateLimited(_)
+            | TxSenderError::Underpriced
             | TxSenderError::ReplacementUnderpriced
             | TxSenderError::NonceTooLow
             | TxSenderError::ConditionNotMet
@@ -416,6 +433,13 @@ fn create_hard_cancel_tx(to: Address, nonce: u64, gas_fees: GasFees) -> Transact
 
 impl From<ProviderError> for TxSenderError {
     fn from(value: ProviderError) -> Self {
+        // Checked before the error-response paths below: providers signal a rate
+        // limit both as HTTP 429 and as a JSON-RPC error response, and the latter
+        // would otherwise land in `UnrecognizedRpc` and be treated as an ambiguous
+        // judgement of the transaction.
+        if value.is_rate_limited() {
+            return TxSenderError::RateLimited(anyhow::anyhow!("{value}"));
+        }
         match &value {
             ProviderError::RPC(e) => {
                 if let Some(e) = e.as_error_resp() {
@@ -499,6 +523,12 @@ mod tests {
                 TxSenderError::Other(anyhow::anyhow!("signing failed")),
                 RpcOutcomeClass::Neutral,
             ),
+            // A rate limit must not reach poison user operation handling: it is
+            // evidence about our request volume, not about the bundle.
+            (
+                TxSenderError::RateLimited(anyhow::anyhow!("HTTP error 429")),
+                RpcOutcomeClass::Neutral,
+            ),
         ];
 
         for (error, expected) in cases {
@@ -523,6 +553,44 @@ mod tests {
         )));
 
         assert!(matches!(error, TxSenderError::SenderUnavailable(_)));
+    }
+
+    #[test]
+    fn maps_rate_limits_to_rate_limited() {
+        // HTTP 429, the shape a public sequencer endpoint returns.
+        let http_429 = TxSenderError::from(ProviderError::RPC(TransportErrorKind::http_error(
+            429,
+            "Too Many Requests".to_string(),
+        )));
+        assert!(matches!(http_429, TxSenderError::RateLimited(_)));
+
+        // A JSON-RPC error response, which would otherwise be classified as an
+        // ambiguous `UnrecognizedRpc` judgement of the transaction.
+        let rpc_429 = TxSenderError::from(super::rpc_error_response(429, "rate limit exceeded"));
+        assert!(matches!(rpc_429, TxSenderError::RateLimited(_)));
+
+        let rpc_limit_exceeded =
+            TxSenderError::from(super::rpc_error_response(-32005, "limit exceeded"));
+        assert!(matches!(rpc_limit_exceeded, TxSenderError::RateLimited(_)));
+
+        // A transport that lost the status code and left it in the text.
+        let stringified = TxSenderError::from(ProviderError::RPC(TransportErrorKind::custom_str(
+            "server returned 429 Too Many Requests",
+        )));
+        assert!(matches!(stringified, TxSenderError::RateLimited(_)));
+    }
+
+    #[test]
+    fn does_not_treat_service_unavailable_as_rate_limited() {
+        // 503 is provider-health evidence, and alloy groups it with rate limits
+        // as "retryable", so it must be excluded explicitly.
+        let error = TxSenderError::from(ProviderError::RPC(TransportErrorKind::http_error(
+            503,
+            "Service Unavailable".to_string(),
+        )));
+
+        assert!(matches!(error, TxSenderError::SenderUnavailable(_)));
+        assert_eq!(error.classify(), RpcOutcomeClass::NonTerminal);
     }
 
     #[test]

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -97,11 +97,8 @@ pub(crate) enum TxSenderError {
     },
     /// The submission endpoint is rate limiting us.
     ///
-    /// The transaction was never judged, so this says nothing about the bundle's
-    /// contents - only that we are asking for more capacity than the endpoint
-    /// will give us. Handled by backing the builder off the endpoint rather than
-    /// by retrying at the normal trigger cadence. When a fallback sender is
-    /// configured this triggers failover.
+    /// The transaction was never judged, so this says nothing about the bundle.
+    /// Handled by backing the builder off the endpoint.
     #[error("submission endpoint rate limited: {0}")]
     RateLimited(anyhow::Error),
     /// Sender is unavailable due to an outage or transport error.
@@ -158,13 +155,8 @@ impl TxSenderError {
             TxSenderError::SenderUnavailable(_) | TxSenderError::UnrecognizedRpc { .. } => {
                 RpcOutcomeClass::NonTerminal
             }
-            // A rate limit is a statement about our request volume, not about
-            // the bundle: the endpoint never judged the transaction. Counting it
-            // as provider-health evidence would also make suspects of every op
-            // in the bundle, so a rate-limited endpoint would push the whole
-            // pool into isolation - one submission per bundle - while we are
-            // already being told to send fewer requests. Backing off the
-            // endpoint is the dedicated handling instead.
+            // A rate limit is evidence about our request volume, not about the
+            // bundle: the endpoint never judged the transaction.
             TxSenderError::RateLimited(_)
             | TxSenderError::Underpriced
             | TxSenderError::ReplacementUnderpriced
@@ -433,10 +425,6 @@ fn create_hard_cancel_tx(to: Address, nonce: u64, gas_fees: GasFees) -> Transact
 
 impl From<ProviderError> for TxSenderError {
     fn from(value: ProviderError) -> Self {
-        // Checked before the error-response paths below: providers signal a rate
-        // limit both as HTTP 429 and as a JSON-RPC error response, and the latter
-        // would otherwise land in `UnrecognizedRpc` and be treated as an ambiguous
-        // judgement of the transaction.
         if value.is_rate_limited() {
             return TxSenderError::RateLimited(anyhow::anyhow!("{value}"));
         }

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -477,6 +477,7 @@ impl From<TransactionSubmissionError> for TxSenderError {
 
 #[cfg(test)]
 mod tests {
+    use alloy_json_rpc::Id;
     use alloy_transport::TransportErrorKind;
     use rundler_provider::ProviderError;
     use rundler_types::chain::ChainSpec;
@@ -576,6 +577,19 @@ mod tests {
             503,
             "Service Unavailable".to_string(),
         )));
+
+        assert!(matches!(error, TxSenderError::SenderUnavailable(_)));
+        assert_eq!(error.classify(), RpcOutcomeClass::NonTerminal);
+    }
+
+    #[test]
+    fn does_not_treat_missing_batch_response_as_rate_limited() {
+        // The other reason `is_rate_limited` delegates to
+        // `TransportErrorKind::is_retry_err` per variant instead of for the whole
+        // enum: alloy retries this too, but it is not a rate limit.
+        let error = TxSenderError::from(ProviderError::RPC(
+            TransportErrorKind::missing_batch_response(Id::Number(1)),
+        ));
 
         assert!(matches!(error, TxSenderError::SenderUnavailable(_)));
         assert_eq!(error.classify(), RpcOutcomeClass::NonTerminal);

--- a/crates/builder/src/task.rs
+++ b/crates/builder/src/task.rs
@@ -85,6 +85,11 @@ pub struct Args {
     pub max_cancellation_fee_increases: u64,
     /// Maximum amount of blocks to spend in a replacement underpriced state before moving to cancel
     pub max_replacement_underpriced_blocks: u64,
+    /// Initial delay a builder waits after a rate-limited submission, doubling with
+    /// each consecutive rate-limited attempt
+    pub rate_limit_backoff_initial: Duration,
+    /// Maximum delay a builder waits between rate-limited submissions
+    pub rate_limit_backoff_max: Duration,
     /// Address to bind the remote builder server to, if any. If none, no server is starter.
     pub remote_address: Option<SocketAddr>,
     /// Entry points to start builders for
@@ -550,6 +555,8 @@ where
             max_replacement_underpriced_blocks: self.args.max_replacement_underpriced_blocks,
             max_cancellation_fee_increases: self.args.max_cancellation_fee_increases,
             max_blocks_to_wait_for_mine: self.args.max_blocks_to_wait_for_mine,
+            rate_limit_backoff_initial: self.args.rate_limit_backoff_initial,
+            rate_limit_backoff_max: self.args.rate_limit_backoff_max,
         };
 
         let fee_estimator: Box<dyn FeeEstimator> = Box::new(self.providers.fee_estimator().clone());

--- a/crates/provider/src/traits/error.rs
+++ b/crates/provider/src/traits/error.rs
@@ -12,9 +12,10 @@
 // If not, see https://www.gnu.org/licenses/.
 
 use alloy_contract::Error as ContractError;
+use alloy_json_rpc::RpcError;
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolError;
-use alloy_transport::TransportError;
+use alloy_transport::{TransportError, TransportErrorKind};
 
 /// Error enumeration for the Provider trait
 #[derive(Debug, thiserror::Error)]
@@ -62,6 +63,31 @@ impl ProviderError {
                 TransportError::ErrorResp(e),
             )) => e.as_decoded_error(),
             _ => None,
+        }
+    }
+
+    /// Returns true when the endpoint reported that it is rate limiting us.
+    ///
+    /// Rate limits arrive in several shapes - HTTP 429, a `429`/`-32005`-style
+    /// JSON-RPC error response, or a stringified 429 from a transport that lost
+    /// the status code - so detection is delegated to alloy rather than
+    /// re-listing every provider's wording here.
+    ///
+    /// HTTP 503 is deliberately excluded even though alloy groups it with rate
+    /// limits as "retryable": a temporarily unavailable endpoint is evidence
+    /// about the endpoint's health, which callers classify differently from
+    /// being asked to send fewer requests.
+    pub fn is_rate_limited(&self) -> bool {
+        let ProviderError::RPC(error) = self else {
+            return false;
+        };
+        match error {
+            RpcError::Transport(TransportErrorKind::HttpError(http)) => http.is_rate_limit_err(),
+            RpcError::Transport(TransportErrorKind::Custom(err)) => {
+                err.to_string().contains("429 Too Many Requests")
+            }
+            RpcError::ErrorResp(resp) => resp.is_retry_err(),
+            _ => false,
         }
     }
 }

--- a/crates/provider/src/traits/error.rs
+++ b/crates/provider/src/traits/error.rs
@@ -68,19 +68,10 @@ impl ProviderError {
 
     /// Returns true when the endpoint reported that it is rate limiting us.
     ///
-    /// Every check is alloy's, so the provider-specific codes and wordings live in
-    /// one place: `HttpError::is_rate_limit_err` (HTTP 429),
-    /// `ErrorPayload::is_retry_err` (JSON-RPC responses - `429`, Infura's
-    /// `-32005`, QuickNode's credit limits, and similar), and
-    /// `TransportErrorKind::is_retry_err` for the `Custom` variant, where it is
-    /// exactly a 429 string match, covering transports that stringify the status
-    /// instead of surfacing it.
-    ///
-    /// That last helper is delegated to per variant rather than for the enum as a
-    /// whole because elsewhere it is broader than a rate limit: it also retries
-    /// `MissingBatchResponse` and HTTP 503. 503 in particular is provider-health
-    /// evidence, which callers classify differently from being asked to send fewer
-    /// requests.
+    /// Every check is alloy's, so the provider-specific codes stay in one place.
+    /// Delegated per variant rather than via `TransportErrorKind::is_retry_err`
+    /// for the whole enum, which is broader than a rate limit: it also retries
+    /// `MissingBatchResponse` and HTTP 503, and 503 is provider-health evidence.
     pub fn is_rate_limited(&self) -> bool {
         let ProviderError::RPC(error) = self else {
             return false;

--- a/crates/provider/src/traits/error.rs
+++ b/crates/provider/src/traits/error.rs
@@ -68,25 +68,26 @@ impl ProviderError {
 
     /// Returns true when the endpoint reported that it is rate limiting us.
     ///
-    /// Every arm delegates to alloy so the provider-specific codes and wordings
-    /// live in one place: `HttpError::is_rate_limit_err` (HTTP 429),
+    /// Every check is alloy's, so the provider-specific codes and wordings live in
+    /// one place: `HttpError::is_rate_limit_err` (HTTP 429),
     /// `ErrorPayload::is_retry_err` (JSON-RPC responses - `429`, Infura's
-    /// `-32005`, QuickNode's credit limits, and similar), and the `Custom` check
-    /// from `TransportErrorKind::is_retry_err` for transports that stringify the
-    /// status instead of surfacing it.
+    /// `-32005`, QuickNode's credit limits, and similar), and
+    /// `TransportErrorKind::is_retry_err` for the `Custom` variant, where it is
+    /// exactly a 429 string match, covering transports that stringify the status
+    /// instead of surfacing it.
     ///
-    /// HTTP 503 is excluded: alloy groups it with rate limits as retryable, but a
-    /// temporarily unavailable endpoint is provider-health evidence, which callers
-    /// classify differently from being asked to send fewer requests.
+    /// That last helper is delegated to per variant rather than for the enum as a
+    /// whole because elsewhere it is broader than a rate limit: it also retries
+    /// `MissingBatchResponse` and HTTP 503. 503 in particular is provider-health
+    /// evidence, which callers classify differently from being asked to send fewer
+    /// requests.
     pub fn is_rate_limited(&self) -> bool {
         let ProviderError::RPC(error) = self else {
             return false;
         };
         match error {
             RpcError::Transport(TransportErrorKind::HttpError(http)) => http.is_rate_limit_err(),
-            RpcError::Transport(TransportErrorKind::Custom(err)) => {
-                err.to_string().contains("429 Too Many Requests")
-            }
+            RpcError::Transport(kind @ TransportErrorKind::Custom(_)) => kind.is_retry_err(),
             RpcError::ErrorResp(resp) => resp.is_retry_err(),
             _ => false,
         }

--- a/crates/provider/src/traits/error.rs
+++ b/crates/provider/src/traits/error.rs
@@ -68,15 +68,16 @@ impl ProviderError {
 
     /// Returns true when the endpoint reported that it is rate limiting us.
     ///
-    /// Rate limits arrive in several shapes - HTTP 429, a `429`/`-32005`-style
-    /// JSON-RPC error response, or a stringified 429 from a transport that lost
-    /// the status code - so detection is delegated to alloy rather than
-    /// re-listing every provider's wording here.
+    /// Every arm delegates to alloy so the provider-specific codes and wordings
+    /// live in one place: `HttpError::is_rate_limit_err` (HTTP 429),
+    /// `ErrorPayload::is_retry_err` (JSON-RPC responses - `429`, Infura's
+    /// `-32005`, QuickNode's credit limits, and similar), and the `Custom` check
+    /// from `TransportErrorKind::is_retry_err` for transports that stringify the
+    /// status instead of surfacing it.
     ///
-    /// HTTP 503 is deliberately excluded even though alloy groups it with rate
-    /// limits as "retryable": a temporarily unavailable endpoint is evidence
-    /// about the endpoint's health, which callers classify differently from
-    /// being asked to send fewer requests.
+    /// HTTP 503 is excluded: alloy groups it with rate limits as retryable, but a
+    /// temporarily unavailable endpoint is provider-health evidence, which callers
+    /// classify differently from being asked to send fewer requests.
     pub fn is_rate_limited(&self) -> bool {
         let ProviderError::RPC(error) = self else {
             return false;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -262,6 +262,10 @@ List of command line options for configuring the Builder.
   - env: _BUILDER_ASSIGNER_MAX_OPS_PER_REQUEST_
 - `--builder.assigner_starvation_ratio`: Starvation ratio for the assigner. This value acts as a multiplier on signer count (`num_signers * starvation_ratio`) before force-selecting a starved entrypoint. For example, with 4 signers and the default ratio of 0.50, an entrypoint is force-selected after 2 idle cycles. (default: `0.50`)
   - env: _BUILDER_ASSIGNER_STARVATION_RATIO_
+- `--builder.rate_limit_backoff_initial_millis`: Initial delay a builder waits before its next submission after the submission endpoint rate limited it. Doubles (with jitter) on each consecutive rate-limited attempt and is applied on top of the chain's bundle send interval. Any attempt that is not rate limited resets it. (default: `1000`)
+  - env: _BUILDER_RATE_LIMIT_BACKOFF_INITIAL_MILLIS_
+- `--builder.rate_limit_backoff_max_millis`: Maximum delay a builder waits between submissions while the submission endpoint is rate limiting it. (default: `30000`)
+  - env: _BUILDER_RATE_LIMIT_BACKOFF_MAX_MILLIS_
 
 ## Signer Options
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -266,9 +266,9 @@ List of command line options for configuring the Builder.
   - env: _BUILDER_ASSIGNER_MAX_OPS_PER_REQUEST_
 - `--builder.assigner_starvation_ratio`: Starvation ratio for the assigner. This value acts as a multiplier on signer count (`num_signers * starvation_ratio`) before force-selecting a starved entrypoint. For example, with 4 signers and the default ratio of 0.50, an entrypoint is force-selected after 2 idle cycles. (default: `0.50`)
   - env: _BUILDER_ASSIGNER_STARVATION_RATIO_
-- `--builder.rate_limit_backoff_initial_millis`: Initial delay a builder waits before its next submission after the submission endpoint rate limited it. Doubles (with jitter) on each consecutive rate-limited attempt and is applied on top of the chain's bundle send interval. Any attempt that is not rate limited resets it. (default: `1000`)
+- `--builder.rate_limit_backoff_initial_millis`: Initial delay a builder waits before its next submission after the submission endpoint rate limited it. Doubles (with jitter) on each consecutive rate-limited attempt. Any attempt that is not rate limited resets it. (default: `100`)
   - env: _BUILDER_RATE_LIMIT_BACKOFF_INITIAL_MILLIS_
-- `--builder.rate_limit_backoff_max_millis`: Maximum delay a builder waits between submissions while the submission endpoint is rate limiting it. (default: `30000`)
+- `--builder.rate_limit_backoff_max_millis`: Maximum delay a builder waits between submissions while the submission endpoint is rate limiting it. (default: `2000`)
   - env: _BUILDER_RATE_LIMIT_BACKOFF_MAX_MILLIS_
 
 ## Signer Options

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -266,6 +266,10 @@ List of command line options for configuring the Builder.
   - env: _BUILDER_ASSIGNER_MAX_OPS_PER_REQUEST_
 - `--builder.assigner_starvation_ratio`: Starvation ratio for the assigner. This value acts as a multiplier on signer count (`num_signers * starvation_ratio`) before force-selecting a starved entrypoint. For example, with 4 signers and the default ratio of 0.50, an entrypoint is force-selected after 2 idle cycles. (default: `0.50`)
   - env: _BUILDER_ASSIGNER_STARVATION_RATIO_
+- `--builder.rate_limit_backoff_initial_millis`: Initial delay a builder waits before its next submission after the submission endpoint rate limited it. Doubles (with jitter) on each consecutive rate-limited attempt and is applied on top of the chain's bundle send interval. Any attempt that is not rate limited resets it. (default: `1000`)
+  - env: _BUILDER_RATE_LIMIT_BACKOFF_INITIAL_MILLIS_
+- `--builder.rate_limit_backoff_max_millis`: Maximum delay a builder waits between submissions while the submission endpoint is rate limiting it. (default: `30000`)
+  - env: _BUILDER_RATE_LIMIT_BACKOFF_MAX_MILLIS_
 
 ## Signer Options
 

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -101,12 +101,21 @@ Each configured submission route, including its primary and fallbacks, maintains
 rolling window shared by its builders. Only final submission outcomes are recorded:
 
 - `Success`: the transaction was accepted.
-- `ProviderFailure`: non-terminal transport failure, timeout, sender unavailable, or
-  exhausted rate limit.
-- `Neutral`: known operational errors such as underpriced or nonce-too-low. Neutral
-  outcomes are excluded from the window.
+- `ProviderFailure`: non-terminal transport failure, timeout, or sender unavailable.
+- `Neutral`: known operational errors such as underpriced, nonce-too-low, or a rate
+  limit. Neutral outcomes are excluded from the window.
 
 Terminal RPC errors are handled before this signal and are excluded from its window.
+
+Rate limits are deliberately Neutral rather than `ProviderFailure`. A rate limit is a
+statement about our request volume, not about the endpoint's health or the bundle's
+contents — the transaction is never judged. Counting one as evidence would make
+suspects of every operation in the bundle, so a rate-limited endpoint would push the
+whole pool into isolation, one operation per bundle, while it is asking us to send
+fewer requests. The dedicated handling is
+`--builder.rate_limit_backoff_initial_millis`: the builder backs off the endpoint with
+an escalating, jittered delay on top of the chain's bundle send interval, and resets on
+the first attempt that is not rate limited.
 
 Initial parameters:
 
@@ -115,7 +124,10 @@ Initial parameters:
 - Exit the event when fewer than 10% are failures.
 
 Different enter and exit thresholds prevent flapping. The signal does not change bundle
-construction or submission rate; existing provider rate limiting handles request pacing.
+construction or submission rate. Pacing requests against a submission endpoint is a
+separate concern, handled by the rate-limit backoff above: it is driven by the
+endpoint's own rate-limit responses, not by this signal, and it is the only mechanism
+here that changes how often a builder submits.
 
 The signal has exactly one effect: while a provider event is active, suspects make no
 progress toward removal. Suspect creation and isolation backoff are unaffected. No
@@ -297,9 +309,9 @@ sees it.
 
 - Add a classification to `TxSenderError` (`crates/builder/src/sender/mod.rs`):
   terminal (final rejection, don't retry unchanged), non-terminal (transport failure,
-  timeout, `SenderUnavailable`, rate-limit exhaustion), neutral (underpriced,
-  nonce-too-low, other known operational errors). A small `enum RpcOutcomeClass` plus a
-  `classify()` method is enough.
+  timeout, `SenderUnavailable`), neutral (underpriced, nonce-too-low, rate limited,
+  other known operational errors). A small `enum RpcOutcomeClass` plus a `classify()`
+  method is enough.
 - Fix the collapse in `From<TxSenderError> for TransactionTrackerError`
   (`crates/builder/src/transaction_tracker.rs`), where `SenderUnavailable` and `Other`
   both become `TransactionTrackerError::Other`. The tracker error must carry the class

--- a/docs/designs/poison-user-operations.md
+++ b/docs/designs/poison-user-operations.md
@@ -113,9 +113,9 @@ contents — the transaction is never judged. Counting one as evidence would mak
 suspects of every operation in the bundle, so a rate-limited endpoint would push the
 whole pool into isolation, one operation per bundle, while it is asking us to send
 fewer requests. The dedicated handling is
-`--builder.rate_limit_backoff_initial_millis`: the builder backs off the endpoint with
-an escalating, jittered delay on top of the chain's bundle send interval, and resets on
-the first attempt that is not rate limited.
+`--builder.rate_limit_backoff_initial_millis`: the builder waits out an escalating,
+jittered delay before its next submission instead of waiting for the next bundle
+trigger, and resets on the first attempt that is not rate limited.
 
 Initial parameters:
 


### PR DESCRIPTION
Follow-up to #1316. Prompted by the arb-sepolia bundle-send 429 storm on 07-29 (07:24-08:35 UTC, zero customer impact, 8 high-urgency pages).

`https://sepolia-rollup.arbitrum.io/rpc` began rate limiting our conditional submissions. A 429 collapses into `SenderUnavailable`, which classifies `NonTerminal`, so it entered the provider-health window and incremented the failure counter of every op in the bundle. At the default `--pool.rpc_failures_before_suspect` of 3, a few seconds of that made the whole pool suspect and every builder switched to one-op isolation bundles — against the endpoint that had just asked us for fewer requests. ~98% of submissions during the storm were isolation bundles.

Nothing paced the retries either: `--provider_rate_limit_retry_enabled` defaults to `false`, so alloy's `RetryBackoffLayer` is not installed on the submit provider, and the bundle sender had no 429 handling of its own. Each builder was free to re-submit on every trigger for as long as it had work — and because nothing landed, nothing left the pool, so every builder had work on every trigger.

Two independent problems, fixed separately here: a 429 is not evidence about a user operation, and a 429 needs backoff.

Worth noting what was *not* wrong: submission rate is capped at one attempt per builder per `bundle_max_send_interval_millis` regardless of isolation, and de-batching changes ops-per-submission rather than submissions-per-second. Isolation made the storm less efficient, not faster.

## Proposed Changes

  - Add `ProviderError::is_rate_limited` (`crates/provider/src/traits/error.rs`), recognising HTTP 429, `429`/`-32005`-style JSON-RPC error responses, and transports that leave the status in the error text. Every arm delegates to alloy so the provider-specific codes stay in one place: `HttpError::is_rate_limit_err`, `ErrorPayload::is_retry_err` (which carries `429`, Infura's `-32005`, QuickNode's credit limits and the rest), and the `Custom` check from `TransportErrorKind::is_retry_err`. HTTP 503 stays excluded — alloy groups it with rate limits as "retryable", but a temporarily unavailable endpoint is genuine provider-health evidence and must stay `NonTerminal`.
  - Add `TxSenderError::RateLimited`, classified `RpcOutcomeClass::Neutral`: no bundle outcome is reported to the pool and the provider-event signal never sees it. No failure counter, no suspect, no isolation, and no provider event freezing suspects' counters. Detection runs *before* the error-response paths, since a JSON-RPC-shaped rate limit would otherwise land in `UnrecognizedRpc` and reach `NonTerminal` by a different route.
  - Add `RateLimitBackoff` to the bundle sender: consecutive rate-limited attempts double the wait from `--builder.rate_limit_backoff_initial_millis` (100ms) to `--builder.rate_limit_backoff_max_millis` (2s), with ±20% jitter so builders sharing a route do not retry in the same instant. The backoff *replaces* the trigger wait rather than stacking on top of it — a rate-limited attempt retries as soon as the backoff elapses. Held on `BundleSenderImpl` rather than in the state machine, so it survives state resets and applies whichever state the last attempt left behind. The signer is held for the duration: `retry()` leaves `wait_for_trigger: false`, so the idle-release check does not fire. That is at most 2s, and releasing the key while the builder still holds assignments risks `begin_cycle` leasing a different address and orphaning them.
  - Clear the backoff only on outcomes the node actually judged (`endpoint_judged_transaction`). Clearing on any non-429 result would let an idle pool between rate-limited attempts silently hold the wait at its initial value, reproducing a pinned backoff in a new place.
  - Return `Ok(RateLimited)` instead of `Err`. The error path reset the transaction tracker, which a request refused before processing never warranted (unlike `SenderUnavailable`, acceptance is not ambiguous), and logged two `error!` lines per attempt per builder — ~64 error logs/s across a 32-signer fleet, which is what flapped `RundlerHighLogErrorCount` six times.
  - Leave `RateLimited` out of the fallback sender's failover arm. Failover stays for errors; pacing the primary is the backoff's job. This is a deliberate behaviour change from today, where a 429 counted toward failover as `SenderUnavailable`.
  - Correct `docs/designs/poison-user-operations.md`: its outcome table listed "exhausted rate limit" under `ProviderFailure`, and the claim that "existing provider rate limiting handles request pacing" was not true of any deployment, since that layer is off by default.

## Testing

`make test-unit` (514 passed), `make lint`, `cargo +nightly fmt --all --check`.

New coverage: rate-limit detection across all four shapes plus the 503 exclusion; `RateLimited` classifies `Neutral`; a rate-limited attempt reports no bundle outcome, records no provider-event observation, and leaves the backoff as the only thing the next attempt waits on; backoff escalation over the shipped 100ms→2s ladder, capping under jitter, clearing, and that the wait is consumed once rather than re-served every loop.

## Not in scope

  - The backoff is per-builder, not shared per submission route. `ProviderEventSignal` is already shared per route if we want one fleet-wide gate later.
  - `--pool.rpc_failures_before_suspect` is unchanged. Genuine `SenderUnavailable` outages still make the whole pool suspect within ~3s at the default of 3.
  - arb-sepolia's unkeyed submit endpoint is addressed separately in OMGWINNING/ws-tools#811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

