### PR TITLE
fix(provider): retry consistency errors delivered as JSON-RPC failure payloads

### DIFF
--- a/crates/provider/src/alloy/consistency_retry.rs
+++ b/crates/provider/src/alloy/consistency_retry.rs
@@ -26,7 +26,8 @@ static BLOCK_NOT_FOUND_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// This typically happens when we receive a block number via `eth_getBlockByNumber(latest)`
 /// but subsequent queries for the same block number return block not found (or similar).
 ///
-/// This is detected by checking the JSON-RPC error message.
+/// This is detected by checking the JSON-RPC error message, see [`consistency_error_message`]
+/// for the response shapes that are inspected.
 #[derive(Debug, Clone)]
 pub(crate) struct ConsistencyRetryLayer {
     /// The maximum number of retries for consistency issues
@@ -114,23 +115,11 @@ where
             loop {
                 let resp = inner.call(request.clone()).await;
 
-                let err = match &resp {
-                    Ok(_) => return resp,
-                    Err(e) => e,
+                let Some(err_message) = consistency_error_message(&resp) else {
+                    return resp;
                 };
 
-                // Extract the error message from the error
-                let err_payload = match &err {
-                    RpcError::ErrorResp(err_payload) => err_payload.message.to_string(),
-                    RpcError::Transport(TransportErrorKind::HttpError(HttpError {
-                        status: _,
-                        body,
-                    })) => body.to_string(),
-                    _ => return resp,
-                };
-
-                let should_retry = should_retry_error(&err_payload);
-                if should_retry && retry_number < max_retries {
+                if retry_number < max_retries {
                     retry_number += 1;
                     metrics.retries.increment(1);
                     let next_backoff = initial_backoff
@@ -139,22 +128,55 @@ where
 
                     trace!(
                         next_backoff_millis = next_backoff.as_millis(),
-                        "(all in ms) backing off due to provider server error"
+                        "(all in ms) backing off due to provider consistency error"
                     );
 
                     sleep(next_backoff).await;
                 } else {
-                    if should_retry {
-                        // We should retry but have exceeded max retries
-                        metrics.max_retries_exceeded.increment(1);
-                        warn!("Max retries exceeded for consistency error: {err_payload}");
-                    }
+                    // We should retry but have exceeded max retries
+                    metrics.max_retries_exceeded.increment(1);
+                    warn!("Max retries exceeded for consistency error: {err_message}");
                     return resp;
                 }
             }
         }
         .boxed()
     }
+}
+
+/// Returns the error message that identifies `resp` as a consistency error, if there is one.
+///
+/// A node can report a consistency error in three different shapes, all of which are inspected
+/// here:
+///
+/// * A JSON-RPC error payload returned with HTTP 200. Alloy converts a `Failure` payload into
+///   [`RpcError::ErrorResp`] in `transform_response`, which runs *above* the transport stack, so a
+///   transport layer receives it as `Ok(ResponsePacket)` with a `Failure` payload. This is the
+///   common shape: nodes answering `-32000 header not found` do so with HTTP 200.
+/// * An [`RpcError::ErrorResp`], in case a layer above this one has already performed that
+///   conversion.
+/// * A non-2xx HTTP response carrying the message in its body.
+///
+/// For batch responses, any sub-response reporting a consistency error retries the whole packet.
+/// Rundler only issues single requests today, and retrying the successful sub-requests of a batch
+/// is harmless for the read methods this layer protects.
+fn consistency_error_message(resp: &Result<ResponsePacket, TransportError>) -> Option<String> {
+    let message = match resp {
+        Ok(packet) => {
+            return packet
+                .iter_errors()
+                .map(|err_payload| err_payload.message.as_ref())
+                .find(|message| should_retry_error(message))
+                .map(ToString::to_string);
+        }
+        Err(RpcError::ErrorResp(err_payload)) => err_payload.message.as_ref(),
+        Err(RpcError::Transport(TransportErrorKind::HttpError(HttpError { status: _, body }))) => {
+            body.as_str()
+        }
+        Err(_) => return None,
+    };
+
+    should_retry_error(message).then(|| message.to_string())
 }
 
 // Determine if we should retry based on the error message.
@@ -169,4 +191,196 @@ struct ConsistencyRetryMetrics {
     retries: Counter,
     #[metric(describe = "the count of failures due to max retries exceeded.")]
     max_retries_exceeded: Counter,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use alloy_json_rpc::{ErrorPayload, Id, Request, Response, ResponsePayload};
+    use alloy_primitives::B256;
+    use serde_json::value::RawValue;
+    use tower::{ServiceExt, util::service_fn};
+
+    use super::*;
+
+    const MAX_RETRIES: u32 = 3;
+
+    #[tokio::test(start_paused = true)]
+    async fn retries_error_payload_delivered_as_ok() {
+        // A node answering "-32000 header not found" over HTTP 200 reaches a transport layer as
+        // `Ok(ResponsePacket)` with a `Failure` payload, not as `Err(RpcError::ErrorResp)`.
+        let calls = call_service(|_| async { Ok(error_packet("header not found")) }).await;
+
+        assert_eq!(calls, MAX_RETRIES + 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retries_error_resp() {
+        let calls =
+            call_service(|_| async { Err(RpcError::ErrorResp(error_payload("header not found"))) })
+                .await;
+
+        assert_eq!(calls, MAX_RETRIES + 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retries_http_error_body() {
+        let calls = call_service(|_| async {
+            Err(TransportErrorKind::http_error(
+                503,
+                "header not found".to_string(),
+            ))
+        })
+        .await;
+
+        assert_eq!(calls, MAX_RETRIES + 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retries_batch_with_consistency_error() {
+        let calls = call_service(|_| async {
+            Ok(ResponsePacket::Batch(vec![
+                success_response(Id::Number(1)),
+                Response {
+                    id: Id::Number(2),
+                    payload: ResponsePayload::Failure(error_payload("header not found")),
+                },
+            ]))
+        })
+        .await;
+
+        assert_eq!(calls, MAX_RETRIES + 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn returns_response_once_consistent() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let response = call_counting_service(calls.clone(), |call_number| async move {
+            if call_number == 0 {
+                Ok(error_packet("header not found"))
+            } else {
+                Ok(ResponsePacket::Single(success_response(Id::Number(1))))
+            }
+        })
+        .await
+        .expect("should return the successful response");
+
+        assert!(response.is_success());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn does_not_retry_success() {
+        let calls =
+            call_service(|_| async { Ok(ResponsePacket::Single(success_response(Id::Number(1)))) })
+                .await;
+
+        assert_eq!(calls, 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn does_not_retry_unrelated_error_payload() {
+        let calls = call_service(|_| async { Ok(error_packet("execution reverted")) }).await;
+
+        assert_eq!(calls, 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn does_not_retry_unrelated_transport_error() {
+        let calls = call_service(|_| async { Err(TransportErrorKind::backend_gone()) }).await;
+
+        assert_eq!(calls, 1);
+    }
+
+    #[test]
+    fn matches_known_consistency_errors() {
+        let messages = [
+            "header not found",
+            "Header not found",
+            "block not found",
+            "unknown block",
+            "header for hash not found",
+            "requested epoch was a null round, or is not currently canonical",
+            &format!("block {:#x} not found", B256::repeat_byte(1)),
+        ];
+
+        for message in messages {
+            assert!(should_retry_error(message), "message: {message}");
+        }
+    }
+
+    #[test]
+    fn ignores_unrelated_errors() {
+        for message in ["execution reverted", "insufficient funds", "nonce too low"] {
+            assert!(!should_retry_error(message), "message: {message}");
+        }
+    }
+
+    // Calls the layer with a service built from `respond`, returning how many times the inner
+    // service was called.
+    async fn call_service<F, Fut>(respond: F) -> u32
+    where
+        F: FnMut(usize) -> Fut + Clone + Send + Sync + 'static,
+        Fut: Future<Output = Result<ResponsePacket, TransportError>> + Send,
+    {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let _ = call_counting_service(calls.clone(), respond).await;
+        calls.load(Ordering::SeqCst) as u32
+    }
+
+    // Drives one request through the layer, passing the current call count to `respond` and
+    // incrementing it on every call.
+    async fn call_counting_service<F, Fut>(
+        calls: Arc<AtomicUsize>,
+        mut respond: F,
+    ) -> Result<ResponsePacket, TransportError>
+    where
+        F: FnMut(usize) -> Fut + Clone + Send + Sync + 'static,
+        Fut: Future<Output = Result<ResponsePacket, TransportError>> + Send,
+    {
+        let inner = service_fn(move |_: RequestPacket| {
+            let call_number = calls.fetch_add(1, Ordering::SeqCst);
+            respond(call_number)
+        });
+        // Backoffs are irrelevant under a paused clock, but keep them small anyway.
+        let mut service = ConsistencyRetryLayer::new(MAX_RETRIES, 1, 10).layer(inner);
+
+        service.ready().await.unwrap().call(request()).await
+    }
+
+    fn request() -> RequestPacket {
+        RequestPacket::Single(
+            Request::new("eth_getBlockByNumber", Id::Number(1), ())
+                .serialize()
+                .unwrap(),
+        )
+    }
+
+    fn error_packet(message: &str) -> ResponsePacket {
+        ResponsePacket::Single(Response {
+            id: Id::Number(1),
+            payload: ResponsePayload::Failure(error_payload(message)),
+        })
+    }
+
+    fn error_payload(message: &str) -> ErrorPayload {
+        ErrorPayload {
+            code: -32000,
+            message: message.to_string().into(),
+            data: None,
+        }
+    }
+
+    fn success_response(id: Id) -> Response {
+        Response {
+            id,
+            payload: ResponsePayload::Success(
+                RawValue::from_string("\"0x1\"".to_string()).unwrap(),
+            ),
+        }
+    }
 }


### PR DESCRIPTION
## Proposed Changes

The consistency retry layer has been enabled in prod/stg for ~9 months but effectively never retried, because it only inspected `Err` outcomes:

```rust
let err = match &resp {
    Ok(_) => return resp,   // <- short-circuit
    Err(e) => e,
};
```

A node answering `-32000 header not found` responds with **HTTP 200** and a JSON-RPC error body. Alloy converts a `Failure` payload into `RpcError::ErrorResp` in `transform_response` (`alloy-json-rpc/src/result.rs`), which runs in `RpcCall` — *above* the transport stack. A tower transport layer therefore receives that error as `Ok(ResponsePacket)` with a `Failure` payload, so it hit the `Ok(_)` arm and returned before the regex ever ran.

At this position in the stack the `ErrorResp` arm is unreachable: the reqwest transport only yields `Ok(ResponsePacket)` on 2xx, `http_error` on non-2xx, or `deser_err` on an unparseable body. Only the rarer non-2xx `HttpError` responses ever took the retry path, which matches the handful of retries visible in `provider_consistency_retry_retries`. The metrics layer, which sits inside this one, has been logging the same errors from its `Ok(resp)` branch all along — that's the tell.

  - Inspect the response packet's failure payloads via `iter_errors()` in addition to the existing `ErrorResp` and `HttpError` cases. `iter_errors()` covers both `Single` and `Batch`, so any sub-response reporting a consistency error retries the packet.
  - Collapse the retry decision into `consistency_error_message()`, which returns the matching message (dropping the separate `should_retry` bool).
  - Add unit tests to a module that had none.

The regex, both metrics counters, the exponential backoff, and returning the original response after max retries are all unchanged. This only changes *where* the layer looks for a consistency error, not which messages qualify.

## Backwards compatibility

Strictly additive. Every input that retried before still retries — the `ErrorResp` and `HttpError` arms are preserved and pinned by tests. After exhaustion the original response is returned untouched, so caller-visible error values and shapes are identical. No public API, config, CLI, or dependency change, and no change at all when `consistency_retry_enabled` is false (the default).

For deployments with the flag on, this does mean the feature starts doing what it says: matching requests now cost up to `max_retries` extra round trips before returning the same error. Two things to watch:

  - `fetch_block_with_retries` (`crates/pool/src/chain.rs`) already loops `POOL_CHAIN_SYNC_MAX_RETRIES` (default 5), so an erroring block fetch can now issue up to 30 requests instead of 5. Note that a node reporting a missing block as `null` yields `Ok(None)` and is unaffected — only error responses amplify.
  - Because the metrics layer sits inside this one, each attempt is counted separately, so provider RPC error counters will climb on chains where this fires even as caller-visible errors drop.

Rollback is config-level: `PROVIDER_CONSISTENCY_RETRY_ENABLED=false` restores the exact prior behavior.

Follow-up: `consistency_retry_max_retries`/`initial_backoff_ms`/`max_backoff_ms` are still hardcoded via `..Default::default()` in `TryFrom<&CommonArgs> for AlloyNetworkConfig`, so there is currently no way to dial the retry count back short of disabling the layer. Worth wiring to CLI/env next.

## Testing

`make test-unit` (503 passed). To confirm the tests actually catch the bug, reverting the `Ok(packet)` arm to `return None` fails exactly three of them — `retries_error_payload_delivered_as_ok`, `retries_batch_with_consistency_error`, and `returns_response_once_consistent` — each with 1 call and 0 retries. The `ErrorResp` and `HttpError` tests pass either way, as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)