### PR TITLE
fix(builder): treat unsupported transaction type as a terminal RPC error

### DIFF
--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -188,8 +188,10 @@ fn is_terminal_rejection(message: &str, code: i64, chain_spec: &ChainSpec) -> bo
 
     // The node cannot decode the transaction envelope, so it never evaluated
     // the transaction and never will until it is upgraded. Substring-matched
-    // under any code: clients wrap it (op-geth reports "failed to unmarshal
-    // tx: transaction type not supported") and number it differently.
+    // because op-geth wraps it ("failed to unmarshal tx: ..."); un-gated by
+    // code because the phrase names its own condition, unlike the generic
+    // messages below. Matching distinctive messages alone is the convention in
+    // `classify_submission_error`.
     if trimmed
         .to_ascii_lowercase()
         .contains("transaction type not supported")

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -161,44 +161,56 @@ impl TxSenderError {
     }
 
     /// Promotes an ambiguous `UnrecognizedRpc` response to `TerminalRpcError`
-    /// when its message is known to be a terminal, per-transaction rejection
-    /// rather than a transient or provider-health condition.
+    /// when its message is a known terminal, per-transaction rejection rather
+    /// than a transient or provider-health condition.
     ///
-    /// Three message shapes are recognized. The first two require code
-    /// `-32000`:
-    /// - `"internal error"` — only promoted on chains with
-    ///   `ChainSpec::internal_rpc_error_is_terminal`, since some providers also use
-    ///   this generic wording for transient outages.
-    /// - `"Transaction rejected by chain policy"` — Robinhood's unambiguous wording
-    ///   for the same rejection; promoted unconditionally, since no chain
-    ///   legitimately emits this phrase for a transient condition.
-    /// - `"transaction type not supported"` — the node cannot decode the
-    ///   transaction envelope, so it never evaluated the transaction and never
-    ///   will until it is upgraded. Matched as a substring under any error code,
-    ///   because clients wrap it differently (op-geth reports
-    ///   `"failed to unmarshal tx: transaction type not supported"`) and report
-    ///   it under codes that vary by client. Retrying is futile and the
-    ///   rejection is unambiguous, so no chain gate applies.
+    /// The recognized messages and their conditions are in
+    /// [`is_terminal_rejection`].
     pub(crate) fn promote_terminal_error(self, chain_spec: &ChainSpec) -> Self {
         match self {
-            TxSenderError::UnrecognizedRpc { code, message } => {
-                let trimmed = message.trim();
-                let is_terminal = trimmed
-                    .to_ascii_lowercase()
-                    .contains("transaction type not supported")
-                    || (code == -32000
-                        && (trimmed.eq_ignore_ascii_case("Transaction rejected by chain policy")
-                            || (chain_spec.internal_rpc_error_is_terminal
-                                && trimmed.eq_ignore_ascii_case("internal error"))));
-                if is_terminal {
-                    TxSenderError::TerminalRpcError { code, message }
-                } else {
-                    TxSenderError::UnrecognizedRpc { code, message }
-                }
+            TxSenderError::UnrecognizedRpc { code, message }
+                if is_terminal_rejection(&message, code, chain_spec) =>
+            {
+                TxSenderError::TerminalRpcError { code, message }
             }
             other => other,
         }
     }
+}
+
+/// Whether an RPC error response is a known terminal rejection: the
+/// transaction was refused and retrying it unchanged cannot succeed.
+///
+/// DEVELOPER NOTE: each rule states its own matching strategy and why it is
+/// safe. Prefer adding a rule here over widening an existing one.
+fn is_terminal_rejection(message: &str, code: i64, chain_spec: &ChainSpec) -> bool {
+    let trimmed = message.trim();
+
+    // The node cannot decode the transaction envelope, so it never evaluated
+    // the transaction and never will until it is upgraded. Substring-matched
+    // under any code: clients wrap it (op-geth reports "failed to unmarshal
+    // tx: transaction type not supported") and number it differently.
+    if trimmed
+        .to_ascii_lowercase()
+        .contains("transaction type not supported")
+    {
+        return true;
+    }
+
+    // The remaining rules are specific to this code.
+    if code != -32000 {
+        return false;
+    }
+
+    // Robinhood's unambiguous wording for a policy rejection. No chain
+    // legitimately emits this phrase for a transient condition.
+    if trimmed.eq_ignore_ascii_case("Transaction rejected by chain policy") {
+        return true;
+    }
+
+    // Some providers reuse this generic wording for transient outages, so it is
+    // terminal only where the chain spec says so.
+    chain_spec.internal_rpc_error_is_terminal && trimmed.eq_ignore_ascii_case("internal error")
 }
 
 pub(crate) type Result<T> = std::result::Result<T, TxSenderError>;

--- a/crates/builder/src/sender/mod.rs
+++ b/crates/builder/src/sender/mod.rs
@@ -82,10 +82,12 @@ pub(crate) enum TxSenderError {
     /// terminal for this chain: retrying the identical transaction cannot succeed.
     ///
     /// Produced by [`TxSenderError::promote_terminal_error`] for `-32000: internal
-    /// error` on chains with `ChainSpec::internal_rpc_error_is_terminal`, and
+    /// error` on chains with `ChainSpec::internal_rpc_error_is_terminal`,
     /// unconditionally for `-32000: Transaction rejected by chain policy`
     /// (Robinhood's unambiguous wording for the same rejection, unlike the
-    /// generic "internal error").
+    /// generic "internal error"), and unconditionally for any message containing
+    /// `transaction type not supported` (the node cannot decode the transaction
+    /// envelope at all).
     #[error("terminal RPC error {code}: {message}")]
     TerminalRpcError {
         /// RPC error code.
@@ -158,26 +160,36 @@ impl TxSenderError {
         }
     }
 
-    /// Promotes an ambiguous `-32000: UnrecognizedRpc` response to
-    /// `TerminalRpcError` when its message is known to be a terminal,
-    /// per-transaction rejection rather than a transient or provider-health
-    /// condition.
+    /// Promotes an ambiguous `UnrecognizedRpc` response to `TerminalRpcError`
+    /// when its message is known to be a terminal, per-transaction rejection
+    /// rather than a transient or provider-health condition.
     ///
-    /// Two message shapes are recognized:
+    /// Three message shapes are recognized. The first two require code
+    /// `-32000`:
     /// - `"internal error"` — only promoted on chains with
     ///   `ChainSpec::internal_rpc_error_is_terminal`, since some providers also use
     ///   this generic wording for transient outages.
     /// - `"Transaction rejected by chain policy"` — Robinhood's unambiguous wording
     ///   for the same rejection; promoted unconditionally, since no chain
     ///   legitimately emits this phrase for a transient condition.
+    /// - `"transaction type not supported"` — the node cannot decode the
+    ///   transaction envelope, so it never evaluated the transaction and never
+    ///   will until it is upgraded. Matched as a substring under any error code,
+    ///   because clients wrap it differently (op-geth reports
+    ///   `"failed to unmarshal tx: transaction type not supported"`) and report
+    ///   it under codes that vary by client. Retrying is futile and the
+    ///   rejection is unambiguous, so no chain gate applies.
     pub(crate) fn promote_terminal_error(self, chain_spec: &ChainSpec) -> Self {
         match self {
-            TxSenderError::UnrecognizedRpc { code, message } if code == -32000 => {
+            TxSenderError::UnrecognizedRpc { code, message } => {
                 let trimmed = message.trim();
                 let is_terminal = trimmed
-                    .eq_ignore_ascii_case("Transaction rejected by chain policy")
-                    || (chain_spec.internal_rpc_error_is_terminal
-                        && trimmed.eq_ignore_ascii_case("internal error"));
+                    .to_ascii_lowercase()
+                    .contains("transaction type not supported")
+                    || (code == -32000
+                        && (trimmed.eq_ignore_ascii_case("Transaction rejected by chain policy")
+                            || (chain_spec.internal_rpc_error_is_terminal
+                                && trimmed.eq_ignore_ascii_case("internal error"))));
                 if is_terminal {
                     TxSenderError::TerminalRpcError { code, message }
                 } else {
@@ -567,6 +579,59 @@ mod tests {
             error,
             TxSenderError::TerminalRpcError { code: -32000, .. }
         ));
+    }
+
+    #[test]
+    fn promotes_unsupported_transaction_type_to_terminal() {
+        // Matched as a substring under any code: clients wrap and number this
+        // rejection differently. op-geth's wording is the first case.
+        let cases = [
+            (
+                -32000,
+                "failed to unmarshal tx: transaction type not supported",
+            ),
+            (-32000, "transaction type not supported"),
+            (-32603, "Transaction Type Not Supported"),
+            (
+                -32000,
+                " failed to unmarshal tx: transaction type not supported ",
+            ),
+        ];
+
+        for (code, message) in cases {
+            let error = TxSenderError::UnrecognizedRpc {
+                code,
+                message: message.to_string(),
+            }
+            .promote_terminal_error(&ChainSpec::default());
+
+            assert!(
+                matches!(error, TxSenderError::TerminalRpcError { .. }),
+                "message: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn does_not_promote_unrelated_unsupported_messages() {
+        let cases = [
+            (-32000, "transaction type not supporte"),
+            (-32000, "access list not supported"),
+            (-32000, "eth_sendRawTransaction not supported"),
+        ];
+
+        for (code, message) in cases {
+            let error = TxSenderError::UnrecognizedRpc {
+                code,
+                message: message.to_string(),
+            }
+            .promote_terminal_error(&ChainSpec::default());
+
+            assert!(
+                matches!(error, TxSenderError::UnrecognizedRpc { .. }),
+                "message: {message}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Soneium's RPC rejects type `0x04` transactions with `-32000: failed to unmarshal tx: transaction type not supported`. Rundler makes a bundle type `0x04` if *any* op carries an `eip7702Auth`, so such an op fails every bundle it joins until it gets quarantined.

That rejection was classified non-terminal, which is wrong: the node cannot decode the transaction envelope, so it never evaluated the transaction and never will until it is upgraded. Retrying it unchanged cannot succeed.

## What went wrong

Quarantine worked. On soneium-mainnet 2026-08-05 the ops crossed the suspect threshold, were excluded from normal bundles, and were isolated — all as designed. Removal never fired:

| Signal (09:00–15:00 UTC) | Value |
|---|---|
| `transaction type not supported` (log lines / 30 min) | 48 before 10:30 → 14,928 → 27,880 |
| `num_suspect_ops` | steady at 8 |
| `ep_isolation_assignments` | 68.7k → 227k |
| `provider_event_active` | 1 continuously from 10:20 UTC |
| `num_suspects_removed` | **0** |

Because the error was non-terminal, every rejection fed the provider-event window — and an active event pauses suspect removal progress. The ops' own rejections therefore froze their removal counters. With removal paused and the success that would clear them impossible by construction, they had no exit and re-isolated until they aged out of the pool.

The frozen counter also pinned the retry at the 1s floor: `reschedule_retry` derives its backoff exponent from `failures - suspect_threshold`, and `failures` was stuck at exactly the threshold, so the exponent stayed 0 and the backoff curve never engaged.

Blast radius was bounded. The ops stayed quarantined the whole time, so bundling was not blocked and other ops were unaffected — this is not the entrypoint-blocking case the poison-op design was built to prevent. The cost was wasted submissions plus a handful of ops that never resolved.

## Proposed Changes

  - `promote_terminal_error` recognizes `transaction type not supported` as terminal. A terminal error removes a singleton immediately and bypasses provider-health gating, so the op dies on its first isolation attempt.
  - Matched as a substring with no code gate: op-geth wraps it (`failed to unmarshal tx: ...`), and the phrase names its own condition, so unlike `internal error` it needs no code to disambiguate. Only `-32000` has been observed for it; matching distinctive messages alone rather than codes is the existing convention in `classify_submission_error`.
  - Extracts the rules into `is_terminal_rejection`, one early-return each. The previous nested boolean mixed three message rules with two different guards (error code and chain spec) and was no longer readable. No behavior change.

## Testing

`make test-unit` (495 passed), `make lint`, `cargo +nightly fmt --all --check` all clean. New tests:

  - `promotes_unsupported_transaction_type_to_terminal` — op-geth's wrapped wording, bare wording, mixed case, surrounding whitespace, and both `-32000` and `-32603`
  - `does_not_promote_unrelated_unsupported_messages` — near-misses stay non-terminal

## Not in scope

**The general case.** Error responses feed the provider-event window, so any deterministically rejected transaction can still manufacture the event that freezes its own removal. This PR fixes one error string, so we remain a message behind on the general case.

An earlier revision closed that by excluding all error responses from the window. It was dropped as unsafe: the same chain returns `Transaction verification service temporarily unavailable` in bursts of 2–3k per 30 min, an error *response* that genuinely does mean the provider cannot serve, and excluding all responses would lose outage detection exactly where it is warranted. A workable version needs to separate provider-unavailability responses from judgments about the transaction — likely by classifying recognized unavailability wording as `SenderUnavailable` (non-terminal, health evidence, triggers fallback) and excluding only responses that stay unrecognized. Worth its own PR.

**The concurrent bundling outage**, which this does not explain. Successful bundle transactions went 436 per 10 min → ~0 at 10:30 UTC and stayed there. Two tempting explanations are both ruled out:

  - Not a pool full of 7702 ops: `num_7702_ops_added` totals 36 for the life of the pod, five of them between 07:20 and 08:50 UTC and none during the outage, against ~1200 ops per 10 min of inflow.
  - Not isolation starving normal work: `Selected bundle for` ran 35k–53k per 30 min after 10:20 with `Sending isolation bundle` at 10k–27k of it, leaving ~20k–36k normal bundles per 30 min — higher than the ~27k before the incident.

Bundles kept being formed and sent and essentially none mined. `replacement transaction underpriced` dominates the logs at 52k–95k per 30 min, but it was *already* 52k–60k from 09:00–10:00 while bundling was healthy, so it does not discriminate. Separate investigation.

**Soneium's node upgrade.** The superchain registry shows Isthmus active since 2025-05-09, so type `0x04` should work at the protocol level; the sequencer is behind. `eip7702_enabled = false` in the soneium chain spec remains the faster mitigation and needs someone with deploy access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
