### PR TITLE
fix(builder): fall back to node_http, not submit_url

### DIFF
--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -96,9 +96,8 @@ pub struct BuilderArgs {
     /// If present, the url of the ETH provider that will be used to send
     /// transactions. Defaults to the value of `node_http`.
     ///
-    /// Only used when BUILDER_SENDER is "raw" or "polygonprivate". Never used
-    /// for the raw sender that BUILDER_SENDER_RECOVERY_INTERVAL_SECS falls back
-    /// to, which always submits to `node_http`.
+    /// Only used when BUILDER_SENDER is "raw" or "polygonprivate". Never used by
+    /// the fallback sender, which always submits to `node_http`.
     #[arg(
         long = "builder.submit_url",
         name = "builder.submit_url",
@@ -332,12 +331,10 @@ impl BuilderArgs {
         chain_spec: &ChainSpec,
         rpc_url: &str,
     ) -> anyhow::Result<TransactionSenderArgs> {
-        // The raw sender used to stand in for an unavailable primary. It always
-        // submits to `rpc_url` (`NODE_HTTP`) and never to `submit_url`:
-        // `submit_url` is the primary's own endpoint for the senders that read it
-        // (e.g. Polygon's private gateway for `polygonprivate`), so honoring it
-        // here would point the fallback straight back at the outage it exists to
-        // route around.
+        // The raw sender that stands in for an unavailable primary. It submits
+        // to `rpc_url` rather than `submit_url` because `submit_url` is the
+        // primary's own endpoint (`polygonprivate` submits there), and a
+        // fallback is only useful on an endpoint independent of the primary.
         let fallback_args = || RawSenderArgs {
             submit_url: rpc_url.into(),
             use_conditional_rpc: false,
@@ -614,8 +611,7 @@ mod tests {
             }
             other => panic!("expected a polygon private primary, got {other:?}"),
         }
-        // ...while the fallback goes to the public mempool. Reusing submit_url
-        // here would send the fallback back into the primary's outage.
+        // ...while the fallback reaches the public mempool through node_http.
         assert_eq!(unwrap_raw(*fallback.fallback).submit_url, RPC_URL);
     }
 

--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -96,7 +96,9 @@ pub struct BuilderArgs {
     /// If present, the url of the ETH provider that will be used to send
     /// transactions. Defaults to the value of `node_http`.
     ///
-    /// Only used when BUILDER_SENDER is "raw"
+    /// Only used when BUILDER_SENDER is "raw" or "polygonprivate". Never used
+    /// for the raw sender that BUILDER_SENDER_RECOVERY_INTERVAL_SECS falls back
+    /// to, which always submits to `node_http`.
     #[arg(
         long = "builder.submit_url",
         name = "builder.submit_url",
@@ -330,8 +332,14 @@ impl BuilderArgs {
         chain_spec: &ChainSpec,
         rpc_url: &str,
     ) -> anyhow::Result<TransactionSenderArgs> {
-        let raw_args = || RawSenderArgs {
-            submit_url: self.submit_url.clone().unwrap_or_else(|| rpc_url.into()),
+        // The raw sender used to stand in for an unavailable primary. It always
+        // submits to `rpc_url` (`NODE_HTTP`) and never to `submit_url`:
+        // `submit_url` is the primary's own endpoint for the senders that read it
+        // (e.g. Polygon's private gateway for `polygonprivate`), so honoring it
+        // here would point the fallback straight back at the outage it exists to
+        // route around.
+        let fallback_args = || RawSenderArgs {
+            submit_url: rpc_url.into(),
             use_conditional_rpc: false,
             chain_spec: chain_spec.clone(),
         };
@@ -341,7 +349,7 @@ impl BuilderArgs {
             if let Some(secs) = self.sender_recovery_interval_secs {
                 TransactionSenderArgs::Fallback(FallbackSenderArgs {
                     primary: Box::new(primary),
-                    fallback: Box::new(TransactionSenderArgs::Raw(raw_args())),
+                    fallback: Box::new(TransactionSenderArgs::Raw(fallback_args())),
                     recovery_interval: std::time::Duration::from_secs(secs),
                     failure_threshold: self.sender_failure_threshold,
                 })
@@ -551,4 +559,106 @@ pub fn is_nonspammy_event(event: &WithEntryPoint<BuilderEvent>) -> bool {
         return false;
     }
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    const RPC_URL: &str = "https://node.example.com/v2/key";
+    const SUBMIT_URL: &str = "https://priv-rpc-gateway.example.com/?key=key";
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        builder: BuilderArgs,
+    }
+
+    fn builder_args(args: &[&str]) -> BuilderArgs {
+        TestCli::parse_from(std::iter::once("test").chain(args.iter().copied())).builder
+    }
+
+    fn unwrap_fallback(sender: TransactionSenderArgs) -> FallbackSenderArgs {
+        match sender {
+            TransactionSenderArgs::Fallback(fallback) => fallback,
+            other => panic!("expected a fallback sender, got {other:?}"),
+        }
+    }
+
+    fn unwrap_raw(sender: TransactionSenderArgs) -> RawSenderArgs {
+        match sender {
+            TransactionSenderArgs::Raw(raw) => raw,
+            other => panic!("expected a raw sender, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn polygon_private_fallback_submits_to_node_http() {
+        let args = builder_args(&[
+            "--builder.sender",
+            "polygonprivate",
+            "--builder.submit_url",
+            SUBMIT_URL,
+            "--builder.sender_recovery_interval_secs",
+            "60",
+        ]);
+
+        let fallback = unwrap_fallback(args.sender_args(&ChainSpec::default(), RPC_URL).unwrap());
+
+        // The primary keeps submitting to the private gateway...
+        match *fallback.primary {
+            TransactionSenderArgs::PolygonPrivate(primary) => {
+                assert_eq!(primary.submit_url, SUBMIT_URL)
+            }
+            other => panic!("expected a polygon private primary, got {other:?}"),
+        }
+        // ...while the fallback goes to the public mempool. Reusing submit_url
+        // here would send the fallback back into the primary's outage.
+        assert_eq!(unwrap_raw(*fallback.fallback).submit_url, RPC_URL);
+    }
+
+    #[test]
+    fn flashbots_fallback_submits_to_node_http() {
+        let args = builder_args(&[
+            "--builder.sender",
+            "flashbots",
+            "--builder.submit_url",
+            SUBMIT_URL,
+            "--builder.sender_recovery_interval_secs",
+            "60",
+            "--builder.flashbots_relay_auth_key",
+            "0x01",
+        ]);
+        let chain_spec = ChainSpec {
+            flashbots_enabled: true,
+            flashbots_relay_url: Some("https://relay.flashbots.net".to_owned()),
+            ..Default::default()
+        };
+
+        let fallback = unwrap_fallback(args.sender_args(&chain_spec, RPC_URL).unwrap());
+
+        assert_eq!(unwrap_raw(*fallback.fallback).submit_url, RPC_URL);
+    }
+
+    #[test]
+    fn raw_sender_submits_to_submit_url() {
+        let args = builder_args(&["--builder.submit_url", SUBMIT_URL]);
+
+        let raw = unwrap_raw(args.sender_args(&ChainSpec::default(), RPC_URL).unwrap());
+
+        assert_eq!(raw.submit_url, SUBMIT_URL);
+    }
+
+    #[test]
+    fn raw_sender_defaults_to_node_http() {
+        let raw = unwrap_raw(
+            builder_args(&[])
+                .sender_args(&ChainSpec::default(), RPC_URL)
+                .unwrap(),
+        );
+
+        assert_eq!(raw.submit_url, RPC_URL);
+    }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -245,7 +245,7 @@ List of command line options for configuring the Builder.
   - env: _BUILDER_MAX_REPLACEMENT_UNDERPRICED_BLOCKS_
 - `--builder.sender`: Choice of what sender type to use for transaction submission. (default: `raw`, options: `raw`, `flashbots`, `bloxroute`, `polygonprivate`)
   - env: _BUILDER_SENDER_
-- `--builder.submit_url`: Only used if builder.sender == "raw" or "polygonprivate." If present, the URL of the ETH provider that will be used to send transactions. Defaults to the value of `node_http`. Not used by the fallback sender configured with `builder.sender_recovery_interval_secs`, which always submits to `node_http`.
+- `--builder.submit_url`: Only used if builder.sender == "raw" or "polygonprivate." If present, the URL of the ETH provider that will be used to send transactions. Defaults to the value of `node_http`. Not used by the fallback sender, which always submits to `node_http`.
   - env: _BUILDER_SUBMIT_URL_
 - `--builder.use_conditional_rpc`: Only used if builder.sender == "raw." Use `eth_sendRawTransactionConditional` when submitting. (default: `false`)
   - env: _BUILDER_USE_CONDITIONAL_RPC_

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -243,9 +243,9 @@ List of command line options for configuring the Builder.
   - env: _BUILDER_MAX_CANCELLATION_FEE_INCREASES_
 - `--builder.max_replacement_underpriced_blocks`: The maximum number of blocks to wait in a replacement underpriced state before issuing a cancellation transaction (default: `20`)
   - env: _BUILDER_MAX_REPLACEMENT_UNDERPRICED_BLOCKS_
-- `--builder.sender`: Choice of what sender type to use for transaction submission. (default: `raw`, options: `raw`, `flashbots`, `polygon_bloxroute`)
+- `--builder.sender`: Choice of what sender type to use for transaction submission. (default: `raw`, options: `raw`, `flashbots`, `bloxroute`, `polygonprivate`)
   - env: _BUILDER_SENDER_
-- `--builder.submit_url`: Only used if builder.sender == "raw." If present, the URL of the ETH provider that will be used to send transactions. Defaults to the value of `node_http`.
+- `--builder.submit_url`: Only used if builder.sender == "raw" or "polygonprivate." If present, the URL of the ETH provider that will be used to send transactions. Defaults to the value of `node_http`. Not used by the fallback sender configured with `builder.sender_recovery_interval_secs`, which always submits to `node_http`.
   - env: _BUILDER_SUBMIT_URL_
 - `--builder.use_conditional_rpc`: Only used if builder.sender == "raw." Use `eth_sendRawTransactionConditional` when submitting. (default: `false`)
   - env: _BUILDER_USE_CONDITIONAL_RPC_
@@ -253,8 +253,12 @@ List of command line options for configuring the Builder.
   - env: _BUILDER_FLASHBOTS_RELAY_BUILDERS_
 - `--builder.flashbots_relay_auth_key`: Only used/required if builder.sender == "flashbots." Authorization key to use with the flashbots relay. See [here](https://docs.flashbots.net/flashbots-auction/advanced/rpc-endpoint#authentication) for more info. (default: None)
   - env: _BUILDER_FLASHBOTS_RELAY_AUTH_KEY_
-- `--builder.bloxroute_auth_header`: Only used/required if builder.sender == "polygon_bloxroute." If using the bloxroute transaction sender on Polygon, this is the auth header to supply with the requests. (default: None)
+- `--builder.bloxroute_auth_header`: Only used/required if builder.sender == "bloxroute." If using the bloxroute transaction sender on Polygon, this is the auth header to supply with the requests. (default: None)
   - env: _BUILDER_BLOXROUTE_AUTH_HEADER_
+- `--builder.sender_recovery_interval_secs`: Enable automatic failover to a raw sender when a non-raw `builder.sender` is unavailable, set to the number of seconds to remain on the fallback before re-attempting the primary. The fallback always submits to `node_http`, never to `builder.submit_url`. Has no effect when builder.sender == "raw." (default: None, no fallback configured)
+  - env: _BUILDER_SENDER_RECOVERY_INTERVAL_SECS_
+- `--builder.sender_failure_threshold`: Number of consecutive unavailable responses from the primary sender before activating the fallback. Only applies when `builder.sender_recovery_interval_secs` is set. (default: `3`)
+  - env: _BUILDER_SENDER_FAILURE_THRESHOLD_
 - `--builder.pool_url`: If running in distributed mode, the URL of the pool server to use. (default: `http://localhost:50051`)
   - env: _BUILDER_POOL_URL_
   - _Only required when running in distributed mode_


### PR DESCRIPTION
Fixes the failover bug behind today's `RundlerRPCProviderHTTPSuccessRateBelowThreshold` page on polygon-mainnet prod ([PagerDuty Q1IF1NQHEN89EB](https://down-to-lunch.pagerduty.com/incidents/Q1IF1NQHEN89EB)).

## What broke

The raw sender injected as the failover target resolved its submit URL the same way the primary does, so it inherited `BUILDER_SUBMIT_URL`:

```rust
submit_url: self.submit_url.clone().unwrap_or_else(|| rpc_url.into()),
```

For the senders that actually read that variable it is the *primary's own* endpoint. On polygon-mainnet prod it is Polygon's private gateway (`helm/prod/use1/rundler-polygon-mainnet/values.yaml`), so when the gateway began rejecting our access key, failover built a raw sender pointed back at the same dead gateway — this time calling plain `eth_sendRawTransaction` instead of the private variant, producing exactly the observed error:

```
-32601: jsonrpc method 'eth_sendRawTransaction' is unavailable for this access key
```

The public mempool was never reached and 100% of bundle sends failed for the duration of the incident.

The rest of the failover chain was already correct: the gateway's `-32601` maps to `TxSenderError::UnrecognizedRpc`, which `crates/builder/src/sender/fallback.rs` counts toward the failure threshold and does activate the fallback on. The fallback's URL was the only defect.

## Proposed Changes

  - The fallback raw sender always submits to `rpc_url` (`NODE_HTTP`) and never reads `submit_url`, since `submit_url` belongs to the primary
  - Four tests covering the fallback URL for `polygonprivate` and `flashbots` primaries, plus the raw-primary cases that must keep honoring `submit_url`. The two fallback tests fail against the old logic (verified by reverting the fix) and pass with it
  - Corrects the stale `submit_url` doc comment that invited the mistake — it claimed the flag is only read when the sender is `raw`, but `polygonprivate` reads it too — and documents `sender_recovery_interval_secs` / `sender_failure_threshold` in `docs/cli.md`, which were previously undocumented

## Not addressed here

`BUILDER_SENDER_RECOVERY_INTERVAL_SECS` is silently a no-op when `BUILDER_SENDER` is `raw`, because `maybe_with_fallback` is only applied to the non-raw match arms. `helm/stg/use1/rundler-base-sepolia/values.yaml` sets the interval to `60` with no `BUILDER_SENDER` and a dedicated Base sequencer `submit_url`, so that deployment has no failover despite being configured as though it does. The flag's own docs say "for non-raw sender types", so this is current documented behavior rather than the reported bug — left out to avoid changing failover behavior for the Base/OP fleets in an incident fix. Happy to wire it up in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
