### PR TITLE
fix(builder): stop per-op sponsorship rejection log spam, add budget-blocked gauge

### DIFF
--- a/bin/rundler/src/cli/backend.rs
+++ b/bin/rundler/src/cli/backend.rs
@@ -16,7 +16,7 @@
 //! This is useful for running a single-chain backend that the gateway can connect to.
 
 use clap::Args;
-use rundler_builder::{BuilderEvent, BuilderEventKind, BuilderTask, LocalBuilderBuilder};
+use rundler_builder::{BuilderEvent, BuilderTask, LocalBuilderBuilder};
 use rundler_pool::{LocalPoolBuilder, PoolEvent, PoolTask};
 use rundler_provider::Providers;
 use rundler_sim::MempoolConfigs;
@@ -25,7 +25,11 @@ use rundler_types::chain::ChainSpec;
 use rundler_utils::emit::{self, EVENT_CHANNEL_CAPACITY, WithEntryPoint};
 use tokio::sync::broadcast;
 
-use super::{CommonArgs, EntryPointBuilderConfigs, builder::BuilderArgs, pool::PoolArgs};
+use super::{
+    CommonArgs, EntryPointBuilderConfigs,
+    builder::{BuilderArgs, is_nonspammy_event},
+    pool::PoolArgs,
+};
 
 const REQUEST_CHANNEL_CAPACITY: usize = 1024;
 const BLOCK_CHANNEL_CAPACITY: usize = 1024;
@@ -164,18 +168,4 @@ pub async fn spawn_tasks<T: TaskSpawnerExt + 'static>(
     tracing::info!("Backend started with pool and builder gRPC endpoints exposed");
 
     Ok(())
-}
-
-fn is_nonspammy_event(event: &WithEntryPoint<BuilderEvent>) -> bool {
-    if let BuilderEventKind::FormedBundle {
-        tx_details,
-        fee_increase_count,
-        ..
-    } = &event.event.kind
-        && tx_details.is_none()
-        && *fee_increase_count == 0
-    {
-        return false;
-    }
-    true
 }

--- a/bin/rundler/src/cli/builder.rs
+++ b/bin/rundler/src/cli/builder.rs
@@ -19,7 +19,7 @@ use clap::Args;
 use rundler_builder::{
     self, BloxrouteSenderArgs, BuilderEvent, BuilderEventKind, BuilderSettings, BuilderTask,
     BuilderTaskArgs, EntryPointBuilderSettings, FallbackSenderArgs, FlashbotsSenderArgs,
-    LocalBuilderBuilder, PolygonPrivateArgs, RawSenderArgs, TransactionSenderArgs,
+    LocalBuilderBuilder, PolygonPrivateArgs, RawSenderArgs, SkipReason, TransactionSenderArgs,
     TransactionSenderKind,
 };
 use rundler_pbh::PbhSubmissionProxy;
@@ -569,7 +569,11 @@ pub async fn spawn_tasks<T: TaskSpawnerExt + 'static>(
     Ok(())
 }
 
+/// Filters builder events that report a steady-state condition on every
+/// bundle attempt out of the log stream. Such conditions are tracked as
+/// gauges instead.
 pub fn is_nonspammy_event(event: &WithEntryPoint<BuilderEvent>) -> bool {
+    // An idle builder forms an empty bundle every cycle.
     if let BuilderEventKind::FormedBundle {
         tx_details,
         fee_increase_count,
@@ -580,12 +584,24 @@ pub fn is_nonspammy_event(event: &WithEntryPoint<BuilderEvent>) -> bool {
     {
         return false;
     }
+    // A bundler-sponsored op whose budget no longer covers the gas price is
+    // skipped on every bundle attempt until fees drop or it expires. The
+    // assigner's `ep_sponsorship_budget_blocked_ops` gauge tracks the count.
+    if let BuilderEventKind::SkippedOp {
+        reason: SkipReason::OverSponsorshipMaxCost { .. },
+        ..
+    } = &event.event.kind
+    {
+        return false;
+    }
     true
 }
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::{B256, U256};
     use clap::Parser;
+    use rundler_types::GasFees;
 
     use super::*;
 
@@ -681,5 +697,74 @@ mod tests {
         );
 
         assert_eq!(raw.submit_url, RPC_URL);
+    }
+
+    fn builder_event(kind: BuilderEventKind) -> WithEntryPoint<BuilderEvent> {
+        WithEntryPoint {
+            entry_point: Address::ZERO,
+            event: BuilderEvent {
+                tag: "test".to_string(),
+                kind,
+            },
+        }
+    }
+
+    fn skipped_op(reason: SkipReason) -> WithEntryPoint<BuilderEvent> {
+        builder_event(BuilderEventKind::SkippedOp {
+            op_hash: B256::ZERO,
+            reason,
+        })
+    }
+
+    #[test]
+    fn nonspammy_filters_over_sponsorship_max_cost_skips() {
+        let event = skipped_op(SkipReason::OverSponsorshipMaxCost {
+            max_cost: U256::from(1),
+            actual_cost: U256::from(2),
+        });
+        assert!(!is_nonspammy_event(&event));
+    }
+
+    #[test]
+    fn nonspammy_keeps_other_skip_reasons() {
+        let reasons = [
+            SkipReason::TargetGasLimit,
+            SkipReason::MaxGasLimit,
+            SkipReason::InsufficientFees {
+                required_fees: GasFees {
+                    max_fee_per_gas: 2,
+                    max_priority_fee_per_gas: 1,
+                },
+                actual_fees: GasFees::default(),
+            },
+            SkipReason::AccessedOtherSender {
+                other_sender: Address::ZERO,
+            },
+        ];
+        for reason in reasons {
+            assert!(
+                is_nonspammy_event(&skipped_op(reason.clone())),
+                "{reason:?} should be logged"
+            );
+        }
+    }
+
+    #[test]
+    fn nonspammy_filters_empty_formed_bundle_but_keeps_fee_bumps() {
+        let empty = builder_event(BuilderEventKind::FormedBundle {
+            tx_details: None,
+            nonce: 0,
+            fee_increase_count: 0,
+            required_fees: None,
+        });
+        assert!(!is_nonspammy_event(&empty));
+
+        let fee_bump = builder_event(BuilderEventKind::FormedBundle {
+            tx_details: None,
+            nonce: 0,
+            fee_increase_count: 1,
+            required_fees: None,
+        });
+        assert!(is_nonspammy_event(&fee_bump));
     }
 }

--- a/crates/builder/src/assigner.rs
+++ b/crates/builder/src/assigner.rs
@@ -711,7 +711,9 @@ impl Assigner {
                 continue;
             }
             assignable += 1;
-            if self.op_meets_fee_requirements(op, required_fees, true) {
+            // Counting path: never log per-op rejections here. The assignment
+            // path (`assign_ops_internal`) logs them.
+            if self.op_meets_fee_requirements(op, required_fees, false) {
                 eligible += 1;
             }
         }
@@ -1092,15 +1094,19 @@ fn ep_metrics_for_key(key: &ProposerKey) -> PerEntrypointMetrics {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
 
     use alloy_primitives::B256;
     use rundler_types::{
-        EntityInfos, UserOperation, UserOperationPermissions, ValidTimeRange,
+        BundlerSponsorship, EntityInfos, UserOperation, UserOperationPermissions, ValidTimeRange,
         chain::ChainSpec,
         pool::MockPool,
         v0_6::{UserOperationBuilder, UserOperationRequiredFields},
     };
+    use tracing::{Event, Metadata, Subscriber, span};
 
     use super::*;
 
@@ -1689,6 +1695,91 @@ mod tests {
         entry_point: Address,
     ) -> Vec<PoolOperation> {
         create_test_ops_inner(senders, entry_point, 0, 0)
+    }
+
+    /// Counts every tracing event emitted while installed as the default subscriber.
+    struct EventCounter(Arc<AtomicUsize>);
+
+    impl Subscriber for EventCounter {
+        fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+            true
+        }
+
+        fn new_span(&self, _span: &span::Attributes<'_>) -> span::Id {
+            span::Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
+
+        fn event(&self, _event: &Event<'_>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn enter(&self, _span: &span::Id) {}
+
+        fn exit(&self, _span: &span::Id) {}
+    }
+
+    #[test]
+    fn test_count_ops_does_not_log_rejections() {
+        // A bundler-sponsored op whose budget cannot cover the required fee
+        // (gas_limit * required.max_fee_per_gas > max_cost), and a non-sponsored
+        // op whose own fees are below the required fees. Both are rejected by
+        // the fee check, and `count_ops` must count them silently: it runs on
+        // every assignment pass for every entrypoint, so a per-op log line here
+        // is emitted thousands of times per second for stranded ops.
+        let mut sponsored = create_test_ops_inner(&[address(1)], TEST_ENTRY_POINT, 0, 0);
+        sponsored[0].uo = UserOperationBuilder::new(
+            &ChainSpec::default(),
+            UserOperationRequiredFields {
+                sender: address(1),
+                call_gas_limit: 100_000,
+                ..Default::default()
+            },
+        )
+        .build()
+        .into();
+        sponsored[0].perms.bundler_sponsorship = Some(BundlerSponsorship {
+            max_cost: U256::from(1),
+            valid_until: u64::MAX,
+        });
+        let underpriced = create_test_ops_with_fees(&[address(2)], 1, 1);
+
+        let summaries: Vec<PoolOperationSummary> = sponsored
+            .iter()
+            .chain(underpriced.iter())
+            .map(|op| op.into())
+            .collect();
+        assert!(summaries[0].bundler_sponsorship_max_cost.is_some());
+        assert!(summaries[1].bundler_sponsorship_max_cost.is_none());
+
+        let assigner = Assigner::new(
+            Box::new(MockPool::new()),
+            test_entrypoints(),
+            4,
+            10,
+            10,
+            0.50,
+        );
+        let required_fees = GasFees {
+            max_fee_per_gas: 100,
+            max_priority_fee_per_gas: 10,
+        };
+
+        let events = Arc::new(AtomicUsize::new(0));
+        let (assignable, eligible) =
+            tracing::subscriber::with_default(EventCounter(events.clone()), || {
+                assigner.count_ops(&summaries, address(0), u64::MAX, &required_fees)
+            });
+
+        assert_eq!((assignable, eligible), (2, 0));
+        assert_eq!(
+            events.load(Ordering::SeqCst),
+            0,
+            "count_ops must not log per-op fee rejections"
+        );
     }
 
     #[tokio::test]

--- a/crates/builder/src/assigner.rs
+++ b/crates/builder/src/assigner.rs
@@ -266,10 +266,16 @@ impl Assigner {
             if !suspects.is_empty() {
                 suspect_candidates.push((ep.clone(), suspects));
             }
-            let (assignable_count, eligible_count) =
-                self.count_ops(&ops, builder_address, max_sim_block_number, &required_fees);
+            let OpCounts {
+                assignable: assignable_count,
+                eligible: eligible_count,
+                sponsorship_budget_blocked,
+            } = self.count_ops(&ops, builder_address, max_sim_block_number, &required_fees);
             let ep_metrics = ep_metrics_for(ep);
             ep_metrics.ep_eligible_ops.set(eligible_count as f64);
+            ep_metrics
+                .ep_sponsorship_budget_blocked_ops
+                .set(sponsorship_budget_blocked as f64);
             if eligible_count > 0 {
                 candidates.push(Candidate {
                     config_index: entrypoint_idx,
@@ -581,8 +587,11 @@ impl Assigner {
             )
             .await?;
 
-        let (assignable_count, eligible_count) =
-            self.count_ops(&ops, builder_address, max_sim_block_number, &required_fees);
+        let OpCounts {
+            assignable: assignable_count,
+            eligible: eligible_count,
+            sponsorship_budget_blocked,
+        } = self.count_ops(&ops, builder_address, max_sim_block_number, &required_fees);
 
         let ep_info = EntrypointInfo {
             address: entry_point,
@@ -590,6 +599,9 @@ impl Assigner {
         };
         let ep_metrics = ep_metrics_for(&ep_info);
         ep_metrics.ep_eligible_ops.set(eligible_count as f64);
+        ep_metrics
+            .ep_sponsorship_budget_blocked_ops
+            .set(sponsorship_budget_blocked as f64);
 
         // Always update starvation tracking, even with no eligible ops.
         // This intentionally inflates the starvation counter for this entrypoint during
@@ -686,19 +698,15 @@ impl Assigner {
     }
 
     /// Count ops in a single pass under one lock acquisition.
-    /// Returns (assignable_count, eligible_count) where:
-    /// - assignable: not assigned to another builder, simulated before max_sim_block_number
-    /// - eligible: assignable AND meets fee requirements
     fn count_ops(
         &self,
         ops: &[PoolOperationSummary],
         builder_address: Address,
         max_sim_block_number: u64,
         required_fees: &GasFees,
-    ) -> (usize, usize) {
+    ) -> OpCounts {
         let state = self.state.lock().unwrap();
-        let mut assignable = 0;
-        let mut eligible = 0;
+        let mut counts = OpCounts::default();
         for op in ops.iter() {
             if op.sim_block_number > max_sim_block_number {
                 continue;
@@ -710,14 +718,19 @@ impl Assigner {
             if !is_assignable {
                 continue;
             }
-            assignable += 1;
+            counts.assignable += 1;
             // Counting path: never log per-op rejections here. The assignment
             // path (`assign_ops_internal`) logs them.
             if self.op_meets_fee_requirements(op, required_fees, false) {
-                eligible += 1;
+                counts.eligible += 1;
+            } else if op.bundler_sponsorship_max_cost.is_some() {
+                // The sponsorship budget is the only fee check applied to a
+                // bundler-sponsored op, so failing it means the op is
+                // budget-blocked.
+                counts.sponsorship_budget_blocked += 1;
             }
         }
-        (assignable, eligible)
+        counts
     }
 
     /// Check if an operation meets the fee requirements for bundling.
@@ -727,8 +740,12 @@ impl Assigner {
     /// later by the proposer. Some sponsored ops may pass this check but be rejected
     /// during bundle proposal when exact gas costs are known.
     ///
-    /// When `log` is true, logs the reason for rejection (used during assignment).
-    /// Set `log` to false for counting paths to avoid duplicate log noise.
+    /// When `log` is true, logs the reason for rejection at debug level (used
+    /// during assignment). Set `log` to false for counting paths to avoid
+    /// duplicate log noise. Rejections are steady-state conditions that
+    /// recur on every assignment pass, so they are reported as levels via
+    /// the `ep_eligible_ops` and `ep_sponsorship_budget_blocked_ops` gauges
+    /// rather than at info.
     fn op_meets_fee_requirements(
         &self,
         op: &PoolOperationSummary,
@@ -741,7 +758,7 @@ impl Assigner {
             if total_cost > max_cost {
                 if log {
                     let hash = op.hash;
-                    tracing::info!(
+                    tracing::debug!(
                         "Builder Assigner: op {hash:?} doesn't meet bundler sponsorship requirements: total_cost: {total_cost:?}, max_cost: {max_cost:?}"
                     );
                 }
@@ -757,7 +774,7 @@ impl Assigner {
                 let hash = op.hash;
                 let max_priority = op.max_priority_fee_per_gas;
                 let max_fee = op.max_fee_per_gas;
-                tracing::info!(
+                tracing::debug!(
                     "Builder Assigner: op {hash:?} doesn't meet fee requirements: max_priority_fee_per_gas: {max_priority:?}, max_fee_per_gas: {max_fee:?}, required_fees: {required_fees:?}"
                 );
             }
@@ -1049,6 +1066,19 @@ struct GlobalMetrics {
     isolating_builders: Gauge,
 }
 
+/// Result of `Assigner::count_ops` for one entrypoint's ops.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct OpCounts {
+    /// Not assigned to another builder and simulated at or before the max block.
+    assignable: usize,
+    /// Assignable and meets the fee requirements.
+    eligible: usize,
+    /// Assignable but bundler-sponsored with a budget that does not cover the
+    /// required fee. A level, not an event: these ops are re-checked on every
+    /// assignment pass and stay blocked until fees drop or the op expires.
+    sponsorship_budget_blocked: usize,
+}
+
 #[derive(Metrics)]
 #[metrics(scope = "builder_assigner")]
 struct PerBuilderMetrics {
@@ -1073,6 +1103,10 @@ struct PerEntrypointMetrics {
     ep_starvation_wakeups: Counter,
     #[metric(describe = "the last-seen eligible op count for this entrypoint.")]
     ep_eligible_ops: Gauge,
+    #[metric(
+        describe = "the last-seen count of bundler-sponsored ops for this entrypoint whose sponsorship budget does not cover the required fee."
+    )]
+    ep_sponsorship_budget_blocked_ops: Gauge,
     #[metric(describe = "the total number of suspect isolation assignments from this entrypoint.")]
     ep_isolation_assignments: Counter,
 }
@@ -1722,6 +1756,51 @@ mod tests {
         fn exit(&self, _span: &span::Id) {}
     }
 
+    /// A bundler-sponsored op with zero fees of its own, `call_gas_limit` gas,
+    /// and a sponsorship budget of `max_cost` wei.
+    fn create_sponsored_test_op(
+        sender: Address,
+        call_gas_limit: u128,
+        max_cost: U256,
+    ) -> PoolOperation {
+        let mut op = create_test_ops_inner(&[sender], TEST_ENTRY_POINT, 0, 0).remove(0);
+        op.uo = UserOperationBuilder::new(
+            &ChainSpec::default(),
+            UserOperationRequiredFields {
+                sender,
+                call_gas_limit,
+                ..Default::default()
+            },
+        )
+        .build()
+        .into();
+        op.perms.bundler_sponsorship = Some(BundlerSponsorship {
+            max_cost,
+            valid_until: u64::MAX,
+        });
+        op
+    }
+
+    fn summaries_of(ops: &[PoolOperation]) -> Vec<PoolOperationSummary> {
+        ops.iter().map(|op| op.into()).collect()
+    }
+
+    fn test_assigner_with_empty_pool() -> Assigner {
+        Assigner::new(
+            Box::new(MockPool::new()),
+            test_entrypoints(),
+            4,
+            10,
+            10,
+            0.50,
+        )
+    }
+
+    const TEST_REQUIRED_FEES: GasFees = GasFees {
+        max_fee_per_gas: 100,
+        max_priority_fee_per_gas: 10,
+    };
+
     #[test]
     fn test_count_ops_does_not_log_rejections() {
         // A bundler-sponsored op whose budget cannot cover the required fee
@@ -1730,55 +1809,99 @@ mod tests {
         // the fee check, and `count_ops` must count them silently: it runs on
         // every assignment pass for every entrypoint, so a per-op log line here
         // is emitted thousands of times per second for stranded ops.
-        let mut sponsored = create_test_ops_inner(&[address(1)], TEST_ENTRY_POINT, 0, 0);
-        sponsored[0].uo = UserOperationBuilder::new(
-            &ChainSpec::default(),
-            UserOperationRequiredFields {
-                sender: address(1),
-                call_gas_limit: 100_000,
-                ..Default::default()
-            },
-        )
-        .build()
-        .into();
-        sponsored[0].perms.bundler_sponsorship = Some(BundlerSponsorship {
-            max_cost: U256::from(1),
-            valid_until: u64::MAX,
-        });
-        let underpriced = create_test_ops_with_fees(&[address(2)], 1, 1);
-
-        let summaries: Vec<PoolOperationSummary> = sponsored
-            .iter()
-            .chain(underpriced.iter())
-            .map(|op| op.into())
-            .collect();
+        let ops = vec![
+            create_sponsored_test_op(address(1), 100_000, U256::from(1)),
+            create_test_ops_with_fees(&[address(2)], 1, 1).remove(0),
+        ];
+        let summaries = summaries_of(&ops);
         assert!(summaries[0].bundler_sponsorship_max_cost.is_some());
         assert!(summaries[1].bundler_sponsorship_max_cost.is_none());
 
-        let assigner = Assigner::new(
-            Box::new(MockPool::new()),
-            test_entrypoints(),
-            4,
-            10,
-            10,
-            0.50,
-        );
-        let required_fees = GasFees {
-            max_fee_per_gas: 100,
-            max_priority_fee_per_gas: 10,
-        };
+        let assigner = test_assigner_with_empty_pool();
 
         let events = Arc::new(AtomicUsize::new(0));
-        let (assignable, eligible) =
-            tracing::subscriber::with_default(EventCounter(events.clone()), || {
-                assigner.count_ops(&summaries, address(0), u64::MAX, &required_fees)
-            });
+        let counts = tracing::subscriber::with_default(EventCounter(events.clone()), || {
+            assigner.count_ops(&summaries, address(0), u64::MAX, &TEST_REQUIRED_FEES)
+        });
 
-        assert_eq!((assignable, eligible), (2, 0));
+        assert_eq!(
+            counts,
+            OpCounts {
+                assignable: 2,
+                eligible: 0,
+                sponsorship_budget_blocked: 1,
+            }
+        );
         assert_eq!(
             events.load(Ordering::SeqCst),
             0,
             "count_ops must not log per-op fee rejections"
+        );
+    }
+
+    #[test]
+    fn test_count_ops_reports_sponsorship_budget_blocked() {
+        // gas_limit * required.max_fee_per_gas = 100_000 * 100 = 10_000_000 wei.
+        let over_budget = U256::from(9_999_999);
+        let exactly_budget = U256::from(10_000_000);
+        let ops = vec![
+            // Non-sponsored, meets the required fees: eligible.
+            create_test_ops_with_fees(&[address(1)], 100, 10).remove(0),
+            create_test_ops_with_fees(&[address(2)], 200, 20).remove(0),
+            // Sponsored, budget covers the required fee exactly: eligible even
+            // though the op's own fees are zero.
+            create_sponsored_test_op(address(3), 100_000, exactly_budget),
+            // Sponsored, budget one wei short: blocked.
+            create_sponsored_test_op(address(4), 100_000, over_budget),
+            create_sponsored_test_op(address(5), 100_000, over_budget),
+            // Non-sponsored, underpriced: neither eligible nor budget-blocked.
+            create_test_ops_with_fees(&[address(6)], 1, 1).remove(0),
+        ];
+        let assigner = test_assigner_with_empty_pool();
+
+        let counts = assigner.count_ops(
+            &summaries_of(&ops),
+            address(0),
+            u64::MAX,
+            &TEST_REQUIRED_FEES,
+        );
+
+        assert_eq!(
+            counts,
+            OpCounts {
+                assignable: 6,
+                eligible: 3,
+                sponsorship_budget_blocked: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn test_count_ops_budget_blocked_recovers_when_fees_drop() {
+        // The budget check is re-evaluated against the current required fees
+        // on every pass: a blocked op becomes eligible again once fees fall.
+        let ops = vec![create_sponsored_test_op(
+            address(1),
+            100_000,
+            U256::from(5_000_000),
+        )];
+        let summaries = summaries_of(&ops);
+        let assigner = test_assigner_with_empty_pool();
+
+        let blocked = assigner.count_ops(&summaries, address(0), u64::MAX, &TEST_REQUIRED_FEES);
+        assert_eq!(
+            (blocked.eligible, blocked.sponsorship_budget_blocked),
+            (0, 1)
+        );
+
+        let lower_fees = GasFees {
+            max_fee_per_gas: 50,
+            max_priority_fee_per_gas: 5,
+        };
+        let recovered = assigner.count_ops(&summaries, address(0), u64::MAX, &lower_fees);
+        assert_eq!(
+            (recovered.eligible, recovered.sponsorship_budget_blocked),
+            (1, 0)
         );
     }
 

--- a/crates/builder/src/emit.rs
+++ b/crates/builder/src/emit.rs
@@ -154,21 +154,35 @@ pub struct BundleTxDetails {
 #[derive(Clone, Debug)]
 pub enum SkipReason {
     /// Operation accessed another sender account included earlier in the bundle
-    AccessedOtherSender { other_sender: Address },
+    AccessedOtherSender {
+        /// The other sender whose account was accessed
+        other_sender: Address,
+    },
     /// Operation did not bid high enough gas fees for inclusion in the bundle
     InsufficientFees {
+        /// Fees required for inclusion in the bundle
         required_fees: GasFees,
+        /// Fees the operation bid
         actual_fees: GasFees,
     },
     /// Insufficient pre-verification gas for the operation at the given base fee
     InsufficientPreVerificationGas {
+        /// Base fee used for the pre-verification gas calculation
         base_fee: u128,
+        /// Fees the operation bid
         op_fees: GasFees,
+        /// Pre-verification gas required at this base fee
         required_pvg: u128,
+        /// Pre-verification gas the operation provided
         actual_pvg: u128,
     },
     /// Cost of this operation is greater than the max cost of the bundler sponsorship
-    OverSponsorshipMaxCost { max_cost: U256, actual_cost: U256 },
+    OverSponsorshipMaxCost {
+        /// Maximum cost the bundler sponsorship covers
+        max_cost: U256,
+        /// Cost of the operation at the current gas price
+        actual_cost: U256,
+    },
     /// Bundle ran out of space by simulation gas limit to include the operation
     SimulationGasLimit,
     /// Bundle ran out of space by target gas limit to include the operation
@@ -186,7 +200,10 @@ pub enum SkipReason {
     /// UO uses an unsupported aggregator
     UnsupportedAggregator(Address),
     /// Other reason, typically internal errors
-    Other { reason: Arc<String> },
+    Other {
+        /// Description of the reason
+        reason: Arc<String>,
+    },
 }
 
 /// Reason for rejecting an operation from a bundle

--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -30,7 +30,7 @@ mod delegation_sender;
 pub(crate) type ProposerKey = (Address, Option<String>);
 
 mod emit;
-pub use emit::{BuilderEvent, BuilderEventKind};
+pub use emit::{BuilderEvent, BuilderEventKind, SkipReason};
 
 mod sender;
 pub use sender::{


### PR DESCRIPTION
Task 3 of the [Rundler Production Task](https://app.notion.com/p/alchemotion/Rundler-Production-Task-3d1069f2006680c490a3fd109082afe3) handoff doc. Observability only: no change to bundling behaviour, what the assigner hands to builders, or op lifecycle.

## Motivation

On `rundler-robinhood-mainnet` a single assigner log line, `doesn't meet bundler sponsorship requirements`, was emitting ~18,300 lines/sec (~500 GB/day), roughly half the pod's log output. Every line reported the same steady-state condition: ~300 bundler-sponsored ops whose budget no longer covers the current gas price, re-checked on every assignment pass. The proposer's `SkippedOp { OverSponsorshipMaxCost }` event added a smaller stream (~37 lines/sec) for the same condition.

## Proposed Changes

  - **3a.** `count_ops` passes `log: false` to `op_meets_fee_requirements`. It runs over every op of every entrypoint on every assignment attempt purely to produce the `ep_eligible_ops` gauge, and the flag's own contract says counting paths must not log. This removes the bulk of the volume. A test runs `count_ops` under a counting `tracing` subscriber and asserts zero events.
  - **3b.** The two fee-rejection logs in `op_meets_fee_requirements` are demoted from `info` to `debug`. The condition is a level, so it is now reported by a new per-entrypoint gauge, `rundler_builder_assigner_ep_sponsorship_budget_blocked_ops`, set from the count `count_ops` already computes. `count_ops` returns an `OpCounts` struct instead of a tuple.
  - **3c.** `is_nonspammy_event` filters `SkippedOp { OverSponsorshipMaxCost }` out of the event log stream. The private duplicate of that predicate in `cli/backend.rs` is removed in favour of the public one in `cli/builder.rs`. `SkipReason` is re-exported from `rundler-builder` so the CLI can match on it, with doc comments added to its fields for `missing_docs`.

## Expected effect

  - `doesn't meet bundler sponsorship requirements` no longer appears at INFO.
  - Log volume from the robinhood namespace drops by roughly half.
  - `ep_sponsorship_budget_blocked_ops` for EP v0.7 on robinhood reads ~300 while `ep_eligible_ops` reads 0, describing the situation with no log line needed.

Tasks 1 and 2 from the same doc (pool `num_candidates` and `num_suspect_ops` accuracy) are independent and will follow in separate PRs.
